### PR TITLE
fix(infra): include custom headers in CORS preflight; enforce TLS 1.2

### DIFF
--- a/infrastructure/modules/api/main.tf
+++ b/infrastructure/modules/api/main.tf
@@ -4,9 +4,16 @@ resource "aws_apigatewayv2_api" "main" {
   protocol_type = "HTTP"
 
   cors_configuration {
-    allow_origins     = [var.allowed_origin]
-    allow_methods     = ["GET", "POST", "PUT", "DELETE", "OPTIONS"]
-    allow_headers     = ["Content-Type", "Authorization"]
+    allow_origins = [var.allowed_origin]
+    allow_methods = ["GET", "POST", "PUT", "DELETE", "OPTIONS"]
+    # X-Household-Id pins a non-default household per request (see
+    # docs/multi-household.md). X-Cognito-Access-Token carries the Cognito
+    # access token alongside the ID token for Cognito-direct calls (see
+    # docs/security-review-2026-05-31.md token-split fix). Both must be
+    # declared here or strict browsers (Safari, Firefox) reject the
+    # preflight before the request reaches Lambda — failure mode is a
+    # silent CORS block with no log on our side.
+    allow_headers     = ["Content-Type", "Authorization", "X-Household-Id", "X-Cognito-Access-Token"]
     allow_credentials = true
     max_age           = 300
   }

--- a/infrastructure/modules/frontend/main.tf
+++ b/infrastructure/modules/frontend/main.tf
@@ -165,7 +165,12 @@ resource "aws_cloudfront_distribution" "frontend" {
     cloudfront_default_certificate = var.domain_name == ""
     acm_certificate_arn            = var.domain_name == "" ? null : aws_acm_certificate_validation.frontend[0].certificate_arn
     ssl_support_method             = var.domain_name == "" ? null : "sni-only"
-    minimum_protocol_version       = var.domain_name == "" ? "TLSv1" : "TLSv1.2_2021"
+    # CloudFront's default cert only supports up to TLSv1 when you don't
+    # specify, but we use real auth tokens in every environment (including
+    # the no-domain dev one). Enforce TLSv1.2_2021 unconditionally — the
+    # only browsers that can't negotiate it are EOL'd and shouldn't be
+    # touching production-class credentials anyway.
+    minimum_protocol_version = "TLSv1.2_2021"
   }
 
   tags = {


### PR DESCRIPTION
## Summary
Two infra-only findings from the 2026-06-03 review.

**CORS allow_headers** (high) — the frontend sends `X-Household-Id` (multi-household pin per `docs/multi-household.md`) and `X-Cognito-Access-Token` (token-split per `docs/security-review-2026-05-31.md`), but API Gateway's preflight only allowed `Content-Type, Authorization`. Strict browsers reject the preflight before the request reaches Lambda — failure mode is a silent CORS block with no log on our side. Most visible on the household-switcher flow.

**TLS minimum** (medium) — the CloudFront `viewer_certificate` used `TLSv1` when `var.domain_name == ""` (dev). Dev still handles real auth tokens, so the conditional is more permissive than warranted. Always `TLSv1.2_2021`.

## Deploy plan
After merge: `scripts/deploy.sh production` (runs `terraform apply` first which will reconfigure API GW CORS + CloudFront TLS) → post-deploy smoke test.

## Test plan
- [x] `terraform validate` clean
- [x] `terraform fmt -recursive` clean
- [ ] CI green
- [ ] Post-deploy smoke (`tests/e2e/post-deploy-smoke.spec.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)