### PR TITLE
fix(frontend): harden route errors, auth sync, locale opt-in, query scope

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { Layout } from '@/components/Layout';
 import { ProtectedRoute } from '@/components/ProtectedRoute';
 import { LoadingSpinner } from '@/components/LoadingSpinner';
 import { NotFoundPage } from '@/components/NotFoundPage';
+import { RouteErrorBoundary } from '@/components/RouteErrorBoundary';
 
 // Route-level code splitting. Each feature module compiles into its own
 // chunk; the initial bundle drops by ~150 KB because the marketing landing
@@ -110,65 +111,67 @@ function App() {
       <a href="#main-content" className="skip-link">
         Skip to main content
       </a>
-      <Suspense fallback={<RouteFallback />}>
-        <div id="main-content" tabIndex={-1}>
-          <Routes>
-            {/* Public routes */}
-            <Route
-              path="/"
-              element={isAuthenticated ? <Navigate to="/dashboard" replace /> : <LandingPage />}
-            />
-            <Route
-              path="/login"
-              element={isAuthenticated ? <Navigate to="/dashboard" replace /> : <LoginPage />}
-            />
-            <Route
-              path="/register"
-              element={isAuthenticated ? <Navigate to="/dashboard" replace /> : <RegisterPage />}
-            />
-            <Route path="/confirm-email" element={<ConfirmEmailPage />} />
-            <Route path="/forgot-password" element={<ForgotPasswordPage />} />
-            <Route path="/reset-password" element={<ResetPasswordPage />} />
-            <Route path="/join/:inviteCode" element={<JoinHouseholdPage />} />
-            <Route path="/blog" element={<BlogIndex />} />
-            <Route path="/blog/:slug" element={<BlogPost />} />
-            <Route path="/changelog" element={<ChangelogPage />} />
-            <Route path="/legal/privacy" element={<PrivacyPage />} />
-            <Route path="/legal/terms" element={<TermsPage />} />
-            <Route path="/status" element={<StatusPage />} />
-            <Route path="/pricing" element={<PricingPage />} />
-
-            {/* Protected routes */}
-            <Route element={<ProtectedRoute />}>
+      <RouteErrorBoundary>
+        <Suspense fallback={<RouteFallback />}>
+          <div id="main-content" tabIndex={-1}>
+            <Routes>
+              {/* Public routes */}
               <Route
-                path="/onboarding"
-                element={
-                  // `?mode=add` lets users create an additional household
-                  // from the switcher without bouncing them off this route.
-                  <OnboardingGate hasHousehold={hasHousehold} />
-                }
+                path="/"
+                element={isAuthenticated ? <Navigate to="/dashboard" replace /> : <LandingPage />}
               />
-              <Route path="/welcome" element={<WelcomeFlow />} />
+              <Route
+                path="/login"
+                element={isAuthenticated ? <Navigate to="/dashboard" replace /> : <LoginPage />}
+              />
+              <Route
+                path="/register"
+                element={isAuthenticated ? <Navigate to="/dashboard" replace /> : <RegisterPage />}
+              />
+              <Route path="/confirm-email" element={<ConfirmEmailPage />} />
+              <Route path="/forgot-password" element={<ForgotPasswordPage />} />
+              <Route path="/reset-password" element={<ResetPasswordPage />} />
+              <Route path="/join/:inviteCode" element={<JoinHouseholdPage />} />
+              <Route path="/blog" element={<BlogIndex />} />
+              <Route path="/blog/:slug" element={<BlogPost />} />
+              <Route path="/changelog" element={<ChangelogPage />} />
+              <Route path="/legal/privacy" element={<PrivacyPage />} />
+              <Route path="/legal/terms" element={<TermsPage />} />
+              <Route path="/status" element={<StatusPage />} />
+              <Route path="/pricing" element={<PricingPage />} />
 
-              <Route element={hasHousehold ? <Layout /> : <Navigate to="/onboarding" replace />}>
-                <Route path="/dashboard" element={<DashboardPage />} />
-                <Route path="/plants" element={<PlantsPage />} />
-                <Route path="/plants/new" element={<AddPlantPage />} />
-                <Route path="/plants/:plantId" element={<PlantDetailPage />} />
-                <Route path="/tasks" element={<TasksPage />} />
-                <Route path="/chat" element={<ChatPage />} />
-                <Route path="/household" element={<HouseholdPage />} />
-                <Route path="/settings" element={<SettingsPage />} />
-                <Route path="/settings/billing" element={<SettingsPage />} />
-                <Route path="/help" element={<HelpPage />} />
-                <Route path="/analytics" element={<AnalyticsPage />} />
+              {/* Protected routes */}
+              <Route element={<ProtectedRoute />}>
+                <Route
+                  path="/onboarding"
+                  element={
+                    // `?mode=add` lets users create an additional household
+                    // from the switcher without bouncing them off this route.
+                    <OnboardingGate hasHousehold={hasHousehold} />
+                  }
+                />
+                <Route path="/welcome" element={<WelcomeFlow />} />
+
+                <Route element={hasHousehold ? <Layout /> : <Navigate to="/onboarding" replace />}>
+                  <Route path="/dashboard" element={<DashboardPage />} />
+                  <Route path="/plants" element={<PlantsPage />} />
+                  <Route path="/plants/new" element={<AddPlantPage />} />
+                  <Route path="/plants/:plantId" element={<PlantDetailPage />} />
+                  <Route path="/tasks" element={<TasksPage />} />
+                  <Route path="/chat" element={<ChatPage />} />
+                  <Route path="/household" element={<HouseholdPage />} />
+                  <Route path="/settings" element={<SettingsPage />} />
+                  <Route path="/settings/billing" element={<SettingsPage />} />
+                  <Route path="/help" element={<HelpPage />} />
+                  <Route path="/analytics" element={<AnalyticsPage />} />
+                </Route>
               </Route>
-            </Route>
 
-            <Route path="*" element={<NotFoundPage />} />
-          </Routes>
-        </div>
-      </Suspense>
+              <Route path="*" element={<NotFoundPage />} />
+            </Routes>
+          </div>
+        </Suspense>
+      </RouteErrorBoundary>
     </>
   );
 }

--- a/frontend/src/components/HouseholdSwitcher.tsx
+++ b/frontend/src/components/HouseholdSwitcher.tsx
@@ -64,9 +64,27 @@ export function HouseholdSwitcher() {
               onClick={(e) => {
                 setActiveHouseholdId(m.householdId === user?.householdId ? null : m.householdId);
                 track('household_switched');
-                // Drop every cached query — they were scoped to the
-                // previous household and would render stale data.
-                queryClient.invalidateQueries();
+                // Drop only household-scoped queries (plants, tasks, household
+                // detail, activity, billing). The unscoped invalidation we
+                // used to do thundered every cached query — even ones that
+                // are user-scoped or genuinely shared (templates, species
+                // catalog) — and produced a visible refetch lag on switch.
+                queryClient.invalidateQueries({
+                  predicate: (q) => {
+                    const k = q.queryKey[0];
+                    return (
+                      k === 'plants' ||
+                      k === 'tasks' ||
+                      k === 'household' ||
+                      k === 'households' ||
+                      k === 'activity' ||
+                      k === 'subscription' ||
+                      k === 'notification-prefs' ||
+                      k === 'chat-budget' ||
+                      k === 'climate'
+                    );
+                  },
+                });
                 (e.currentTarget.closest('details') as HTMLDetailsElement).open = false;
               }}
             >

--- a/frontend/src/components/RouteErrorBoundary.tsx
+++ b/frontend/src/components/RouteErrorBoundary.tsx
@@ -1,0 +1,58 @@
+import { Component, type ReactNode } from 'react';
+
+/**
+ * Catches errors thrown while loading or rendering a lazy route. Suspense
+ * alone only handles the loading state; if a chunk fetch fails (network
+ * error, cache-busted CDN URL after a deploy, parse error) the user sees
+ * an infinite spinner with no recovery.
+ *
+ * This boundary surfaces a small inline panel with a reload button. We
+ * deliberately don't try to fix the failure (rehydrate the chunk, retry,
+ * etc.) because the most common cause is a stale tab pointing at a
+ * vendor chunk that no longer exists — a hard reload pulls the new
+ * index.html with the current chunk hashes.
+ */
+interface State {
+  error: Error | null;
+}
+
+interface Props {
+  children: ReactNode;
+}
+
+export class RouteErrorBoundary extends Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error): void {
+    console.error('[route-boundary]', error);
+  }
+
+  render(): ReactNode {
+    if (!this.state.error) return this.props.children;
+    return (
+      <div
+        role="alert"
+        className="mx-auto my-12 max-w-md rounded-md border border-amber-300 bg-amber-50 p-6"
+      >
+        <h2 className="mb-2 text-lg font-semibold text-amber-900">
+          We couldn&apos;t load this page
+        </h2>
+        <p className="mb-4 text-sm text-amber-900">
+          The page&apos;s code couldn&apos;t be fetched. This usually means the app updated while
+          your tab was open. Refreshing should fix it.
+        </p>
+        <button
+          type="button"
+          onClick={() => window.location.reload()}
+          className="rounded-md bg-amber-900 px-4 py-2 text-sm font-medium text-white hover:bg-amber-800 min-h-touch min-w-touch"
+        >
+          Refresh
+        </button>
+      </div>
+    );
+  }
+}

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -28,12 +28,38 @@ export type LangCode = (typeof ALL_LANGS)[number];
  * exposing them would mislead users into thinking the app speaks Spanish
  * when half the strings still fall through to English.
  *
- * Flip `VITE_ENABLE_NON_ENGLISH_LOCALES=true` at build time once translator
- * output lands and there's a strings-coverage check we trust. Until then,
- * the picker hides itself and the runtime forces `en` even if a stale
- * localStorage entry says otherwise.
+ * Three layered opt-ins, evaluated in order:
+ *   1. URL query param `?locales=on` — flips the flag for this tab and
+ *      persists into localStorage. Lets internal/QA testers exercise the
+ *      Spanish path without a rebuild.
+ *   2. localStorage key `feature:non_english_locales` (set by #1, or
+ *      pushed via the browser console).
+ *   3. Build-time `VITE_ENABLE_NON_ENGLISH_LOCALES=true` — the global
+ *      switch for "ship Spanish to everyone." Stays off by default.
+ *
+ * Order matters: the build-time flag is the broadest signal, so any of the
+ * narrower opt-ins also enables. Disabling is just "remove the localStorage
+ * key + leave the env var unset" — the safe default wins on a cold reload.
  */
-const nonEnglishEnabled = import.meta.env.VITE_ENABLE_NON_ENGLISH_LOCALES === 'true';
+const LS_KEY_NON_ENGLISH = 'feature:non_english_locales';
+
+function readNonEnglishOptIn(): boolean {
+  if (import.meta.env.VITE_ENABLE_NON_ENGLISH_LOCALES === 'true') return true;
+  if (typeof window === 'undefined') return false;
+  try {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('locales') === 'on') {
+      window.localStorage.setItem(LS_KEY_NON_ENGLISH, 'true');
+      return true;
+    }
+    return window.localStorage.getItem(LS_KEY_NON_ENGLISH) === 'true';
+  } catch {
+    // Private mode etc.; fall through to the safe default.
+    return false;
+  }
+}
+
+const nonEnglishEnabled = readNonEnglishOptIn();
 
 export const SUPPORTED_LANGS = nonEnglishEnabled
   ? ALL_LANGS

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -246,16 +246,34 @@ if (typeof window !== 'undefined') {
     if (e.key !== 'auth-storage') return;
     // If the local-side payload disappears or no longer carries an idToken,
     // mirror logout into this tab so its in-memory zustand state matches.
+    //
+    // The payload is same-origin (the `storage` event only fires for our own
+    // localStorage key) so the trust boundary is the same as any other
+    // localStorage read — but we still validate shape before reading nested
+    // fields. A bare `?? null` would coerce both "missing" and "wrong type"
+    // to logout; that's the right action either way, but typeof-checking
+    // first keeps the read explicit and the failure mode obvious.
+    if (!e.newValue) {
+      useAuthStore.getState().logout();
+      return;
+    }
     try {
-      const parsed = e.newValue
-        ? (JSON.parse(e.newValue) as { state?: { idToken?: string | null } })
-        : null;
-      const idToken = parsed?.state?.idToken ?? null;
+      const parsed = JSON.parse(e.newValue) as unknown;
+      const idToken =
+        parsed &&
+        typeof parsed === 'object' &&
+        'state' in parsed &&
+        parsed.state &&
+        typeof parsed.state === 'object' &&
+        'idToken' in parsed.state &&
+        typeof (parsed.state as { idToken?: unknown }).idToken === 'string'
+          ? (parsed.state as { idToken: string }).idToken
+          : null;
       if (!idToken) {
         useAuthStore.getState().logout();
       }
     } catch {
-      // Malformed payload — safer to log out than to keep stale auth state.
+      // Malformed JSON — safer to log out than to keep stale auth state.
       useAuthStore.getState().logout();
     }
   });


### PR DESCRIPTION
Small frontend robustness fixes (the in-flight `fix/frontend-small-fixes` work, validated against typecheck/lint/unit + full pre-push suite).

## Changes
- **Route error boundary** — `RouteErrorBoundary` now wraps the lazy route tree so a failed chunk fetch (stale tab after a deploy) shows a refresh panel instead of an infinite spinner.
- **Cross-tab auth sync** — the `storage` logout listener validates the payload shape before reading nested fields; malformed/wrong-typed payloads fall through to a safe logout explicitly.
- **Locale opt-in** — non-English locales can be enabled via build flag → `?locales=on` query → localStorage, so QA can exercise the Spanish path without a rebuild.
- **Query invalidation scope** — `HouseholdSwitcher` invalidates only household-scoped query keys on switch instead of dropping every cached query (removes refetch lag on shared/user-scoped data).

## Verification
typecheck ✓ · lint (max-warnings 0) ✓ · unit 162 ✓ · full pre-push suite 359 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)