### PR TITLE
fix(backend): make stripe webhook processing idempotent

### DIFF
--- a/backend/src/services/billing.ts
+++ b/backend/src/services/billing.ts
@@ -1,5 +1,5 @@
 import Stripe from 'stripe';
-import { UpdateCommand, GetCommand } from '@aws-sdk/lib-dynamodb';
+import { UpdateCommand, GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb';
 import { dynamodb, TABLE_NAME } from '../utils/dynamodb.js';
 import { logger } from '../utils/logger.js';
 import { Plan, PlanId, getPlan, PLANS } from '../models/plans.js';
@@ -201,7 +201,46 @@ export function deltaForStripeEvent(event: Stripe.Event): SubscriptionDelta | nu
   }
 }
 
+/**
+ * Record a Stripe event id exactly once, so a redelivered webhook can't
+ * re-apply the same subscription change. Stripe retries webhooks (and may
+ * deliver duplicates) and our handler is otherwise last-write-wins, which
+ * means a re-delivered stale `created` could clobber a later `deleted`.
+ *
+ * Returns `true` when this is the first time we've seen the event (caller
+ * should proceed), `false` when it was already processed (caller should skip).
+ * The ledger row carries a 30-day TTL so the table sweeps it automatically.
+ */
+export async function recordStripeEventOnce(eventId: string): Promise<boolean> {
+  const ttl = Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60;
+  try {
+    await dynamodb.send(
+      new PutCommand({
+        TableName: TABLE_NAME,
+        Item: {
+          PK: `STRIPE_EVENT#${eventId}`,
+          SK: 'METADATA',
+          entityType: 'StripeEvent',
+          ttl,
+        },
+        ConditionExpression: 'attribute_not_exists(PK)',
+      })
+    );
+    return true;
+  } catch (err) {
+    if (err instanceof Error && err.name === 'ConditionalCheckFailedException') {
+      return false;
+    }
+    throw err;
+  }
+}
+
 export async function applyStripeEvent(event: Stripe.Event): Promise<void> {
+  const isNew = await recordStripeEventOnce(event.id);
+  if (!isNew) {
+    logger.info({ stripeEventId: event.id, type: event.type }, 'stripe_event_duplicate_skipped');
+    return;
+  }
   const delta = deltaForStripeEvent(event);
   if (!delta) return;
   await updateHouseholdSubscription(delta.householdId, delta.fields);

--- a/backend/tests/unit/services/billing.test.ts
+++ b/backend/tests/unit/services/billing.test.ts
@@ -77,6 +77,65 @@ describe('deltaForStripeEvent', () => {
   });
 });
 
+describe('recordStripeEventOnce / applyStripeEvent idempotency', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns true the first time an event id is seen', async () => {
+    const { dynamodb } = await import('../../../src/utils/dynamodb.js');
+    vi.mocked(dynamodb.send).mockResolvedValueOnce({});
+    const { recordStripeEventOnce } = await import('../../../src/services/billing.js');
+    expect(await recordStripeEventOnce('evt_1')).toBe(true);
+    const putArg = vi.mocked(dynamodb.send).mock.calls[0][0] as unknown as {
+      input: { ConditionExpression: string; Item: { PK: string; ttl: number } };
+    };
+    expect(putArg.input.ConditionExpression).toBe('attribute_not_exists(PK)');
+    expect(putArg.input.Item.PK).toBe('STRIPE_EVENT#evt_1');
+    expect(putArg.input.Item.ttl).toBeGreaterThan(Math.floor(Date.now() / 1000));
+  });
+
+  it('returns false when the event id was already recorded', async () => {
+    const { dynamodb } = await import('../../../src/utils/dynamodb.js');
+    const conditionErr = Object.assign(new Error('exists'), {
+      name: 'ConditionalCheckFailedException',
+    });
+    vi.mocked(dynamodb.send).mockRejectedValueOnce(conditionErr);
+    const { recordStripeEventOnce } = await import('../../../src/services/billing.js');
+    expect(await recordStripeEventOnce('evt_dup')).toBe(false);
+  });
+
+  it('does not apply a subscription update for a duplicate event', async () => {
+    const { dynamodb } = await import('../../../src/utils/dynamodb.js');
+    const conditionErr = Object.assign(new Error('exists'), {
+      name: 'ConditionalCheckFailedException',
+    });
+    // First send = the ledger PutCommand, which fails the condition (duplicate).
+    vi.mocked(dynamodb.send).mockRejectedValueOnce(conditionErr);
+    const { applyStripeEvent } = await import('../../../src/services/billing.js');
+    await applyStripeEvent({
+      id: 'evt_dup',
+      type: 'checkout.session.completed',
+      data: { object: { metadata: { householdId: 'hh-1', planId: 'garden' } } },
+    } as unknown as Stripe.Event);
+    // Only the ledger write was attempted — no follow-up UpdateCommand.
+    expect(vi.mocked(dynamodb.send)).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies the subscription update for a first-seen event', async () => {
+    const { dynamodb } = await import('../../../src/utils/dynamodb.js');
+    vi.mocked(dynamodb.send).mockResolvedValue({});
+    const { applyStripeEvent } = await import('../../../src/services/billing.js');
+    await applyStripeEvent({
+      id: 'evt_new',
+      type: 'checkout.session.completed',
+      data: { object: { metadata: { householdId: 'hh-1', planId: 'garden' }, customer: 'cus_1' } },
+    } as unknown as Stripe.Event);
+    // Ledger Put + subscription Update.
+    expect(vi.mocked(dynamodb.send)).toHaveBeenCalledTimes(2);
+  });
+});
+
 describe('getHouseholdSubscription', () => {
   beforeEach(() => {
     vi.clearAllMocks();


### PR DESCRIPTION
## Problem
Stripe retries webhooks and can redeliver the same event. `applyStripeEvent` was last-write-wins with no dedup, so a re-delivered **stale** event (e.g. an out-of-order `subscription.created` arriving after a `subscription.deleted`) could clobber the correct subscription state.

## Fix
`recordStripeEventOnce(eventId)` performs a conditional DDB put — `STRIPE_EVENT#<id>` / `attribute_not_exists(PK)` with a 30-day TTL — before the delta is applied. A `ConditionalCheckFailedException` means we've already processed the event, so `applyStripeEvent` logs `stripe_event_duplicate_skipped` and returns without touching subscription state. The ledger rows sweep themselves via the table's existing `ttl` attribute.

## Tests
4 new cases: first-seen returns true (asserts the conditional + TTL), duplicate returns false, duplicate event does **not** issue a subscription update, first-seen event does. Full suite: 363 ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)