### PR TITLE
fix(ci): archive lambda zips so production auto-rollback works

### DIFF
--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -18,6 +18,8 @@ env:
   NODE_VERSION: '20'
   AWS_REGION: us-east-1
   ENVIRONMENT: production
+  # Bucket holding per-version Lambda zips that auto-rollback restores from.
+  ARTIFACT_BUCKET: family-greenhouse-tfstate-014248889144
 
 permissions:
   id-token: write
@@ -236,11 +238,20 @@ jobs:
             [ -f "${SRC}.map" ] && cp "${SRC}.map" "${WORK}/handler.mjs.map" || true
             (cd "$WORK" && zip -q -r "/tmp/${handler}.zip" .)
 
-            aws lambda update-function-code \
+            PUBLISHED_VER=$(aws lambda update-function-code \
               --function-name "$FUNCTION_NAME" \
               --zip-file "fileb:///tmp/${handler}.zip" \
-              --publish > /dev/null
-            echo "  ✓ ${FUNCTION_NAME}"
+              --publish --query 'Version' --output text)
+            echo "  ✓ ${FUNCTION_NAME} (v${PUBLISHED_VER})"
+
+            # Archive this version's zip keyed by the version number we just
+            # published, so a later run's auto-rollback (which restores by
+            # version number from prev-versions.txt) can actually find the
+            # artifact. Without this, the rollback job's S3 source path is
+            # never populated and rollback silently no-ops.
+            aws s3 cp "/tmp/${handler}.zip" \
+              "s3://${ARTIFACT_BUCKET}/lambda-versions/${handler}-v${PUBLISHED_VER}.zip" \
+              --only-show-errors
             rm -rf "$WORK" "/tmp/${handler}.zip"
           done
 
@@ -327,12 +338,14 @@ jobs:
             test -z "$handler" && continue
             FUNCTION_NAME="family-greenhouse-${handler}-production"
             echo "Rolling back ${FUNCTION_NAME} -> v${ver}"
-            # `update-alias` would be the cleanest path once an alias
-            # exists; until then we re-tag the previous published version
-            # by copying its code to $LATEST.
+            # Restore the previous version's code from the per-version zip the
+            # deploy job archived to S3 (keyed by published version number).
+            # `update-alias` would be cleaner once aliases exist; until then we
+            # re-publish the previous version's code to $LATEST. The fallback
+            # only fires for versions deployed before artifact archival existed.
             aws lambda update-function-code \
               --function-name "$FUNCTION_NAME" \
-              --s3-bucket family-greenhouse-tfstate-014248889144 \
+              --s3-bucket "$ARTIFACT_BUCKET" \
               --s3-key "lambda-versions/${handler}-v${ver}.zip" \
               --publish > /dev/null 2>&1 || echo "  ! ${FUNCTION_NAME}: no prior-version artifact found"
           done < prev-versions.txt


### PR DESCRIPTION
## Problem
The production `rollback` job restores prior Lambda code from `s3://<bucket>/lambda-versions/<handler>-v<ver>.zip`, but the `deploy-backend` job **never uploaded** anything to that prefix. So on a smoke-test failure, auto-rollback always hit the `|| echo "no prior-version artifact found"` fallback and silently no-oped — the safety net wasn't connected.

## Fix
The deploy step now captures each function's **published version** (`update-function-code --query Version`) and archives that exact zip to the same `lambda-versions/` prefix, keyed by version number. A later run's rollback (which reads version numbers from `prev-versions.txt`) can now actually find and restore the artifact. The bucket name is lifted to a shared `ARTIFACT_BUCKET` env var used by both jobs.

Notes:
- The deploy role already has `AdministratorAccess`, so no IAM change is required for the `s3:PutObject`/`s3:GetObject`.
- The fallback still covers versions published before this change (their artifacts won't exist yet) — it's forward-correct from the next deploy on.

CI-only change; workflow YAML validated locally with `yq`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)