### PR TITLE
chore(infra): env-var drift, WAF association, cost budget

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -93,6 +93,10 @@ module "api" {
   # Perenual uses the Secrets-Manager-ID indirection so the API key never
   # touches Terraform state (see modules/api/main.tf IAM block).
   perenual_api_key_secret_id = var.perenual_api_key_secret_id
+  perenual_daily_budget      = var.perenual_daily_budget
+  openweather_api_key        = var.openweather_api_key
+  openweather_daily_budget   = var.openweather_daily_budget
+  bedrock_embed_model_id     = var.bedrock_embed_model_id
 }
 
 # Frontend module (S3 + CloudFront)

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -129,10 +129,11 @@ module "monitoring" {
 module "security" {
   source = "./modules/security"
 
-  environment     = var.environment
-  project_name    = var.project_name
-  api_gateway_arn = module.api.api_gateway_arn
-  cloudfront_arn  = module.frontend.cloudfront_arn
+  environment           = var.environment
+  project_name          = var.project_name
+  api_gateway_arn       = module.api.api_gateway_arn
+  api_gateway_stage_arn = module.api.api_gateway_stage_arn
+  cloudfront_arn        = module.frontend.cloudfront_arn
 }
 
 # GitHub OIDC + deploy role for CI/CD. Skipped (count=0) until github_org +

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -123,6 +123,7 @@ module "monitoring" {
   lambda_function_names = module.api.lambda_function_names
   alert_email           = var.alert_email
   dynamodb_table_name   = module.database.table_name
+  monthly_budget_usd    = var.monthly_budget_usd
 }
 
 # Security module (WAF, IAM)

--- a/infrastructure/modules/api/main.tf
+++ b/infrastructure/modules/api/main.tf
@@ -271,14 +271,23 @@ resource "aws_lambda_function" "handlers" {
       WEB_PUSH_VAPID_SUBJECT     = var.web_push_vapid_subject
       SMS_NOTIFICATIONS_ENABLED  = var.sms_notifications_enabled
       PLANT_ID_API_KEY           = var.plant_id_api_key
+      # OpenWeather powers the climate/weather features. Without the key the
+      # weather service short-circuits to null and those features silently
+      # disable in prod — so it must be wired here, not left to drift.
+      OPENWEATHER_API_KEY      = var.openweather_api_key
+      OPENWEATHER_DAILY_BUDGET = var.openweather_daily_budget
       # Perenual key is held in Secrets Manager (runtime fetch). Pass the
       # SECRET NAME, not the value — the value never reaches Terraform state.
       PERENUAL_API_KEY_SECRET_ID = var.perenual_api_key_secret_id
-      SENTRY_DSN                 = var.sentry_dsn
-      SENTRY_TRACES_SAMPLE_RATE  = var.sentry_traces_sample_rate
-      GIT_SHA                    = var.git_sha
-      CHAT_BUDGET_INPUT_TOKENS   = var.chat_budget_input_tokens
-      CHAT_BUDGET_OUTPUT_TOKENS  = var.chat_budget_output_tokens
+      PERENUAL_DAILY_BUDGET      = var.perenual_daily_budget
+      # Bedrock embedding model for the chat RAG corpus. Empty lets the code
+      # default to amazon.titan-embed-text-v2:0.
+      BEDROCK_EMBED_MODEL_ID    = var.bedrock_embed_model_id
+      SENTRY_DSN                = var.sentry_dsn
+      SENTRY_TRACES_SAMPLE_RATE = var.sentry_traces_sample_rate
+      GIT_SHA                   = var.git_sha
+      CHAT_BUDGET_INPUT_TOKENS  = var.chat_budget_input_tokens
+      CHAT_BUDGET_OUTPUT_TOKENS = var.chat_budget_output_tokens
     }
   }
 

--- a/infrastructure/modules/api/outputs.tf
+++ b/infrastructure/modules/api/outputs.tf
@@ -13,6 +13,11 @@ output "api_gateway_arn" {
   value       = aws_apigatewayv2_api.main.arn
 }
 
+output "api_gateway_stage_arn" {
+  description = "API Gateway stage ARN (the resource a WAF web ACL associates with)"
+  value       = aws_apigatewayv2_stage.main.arn
+}
+
 output "lambda_function_names" {
   description = "Lambda function names"
   value       = [for k, v in aws_lambda_function.handlers : v.function_name]

--- a/infrastructure/modules/api/variables.tf
+++ b/infrastructure/modules/api/variables.tf
@@ -137,6 +137,33 @@ variable "perenual_api_key_secret_id" {
   default     = ""
 }
 
+variable "perenual_daily_budget" {
+  description = "Max Perenual API calls per day. Empty lets the code default (80) apply."
+  type        = string
+  default     = ""
+}
+
+# --- OpenWeather (climate / weather) integration ---
+variable "openweather_api_key" {
+  description = "OpenWeather API key. Optional, but without it the weather service short-circuits to null and the climate features silently disable."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "openweather_daily_budget" {
+  description = "Max OpenWeather API calls per day. Empty lets the code default (800) apply."
+  type        = string
+  default     = ""
+}
+
+# --- Bedrock embeddings (chat RAG corpus) ---
+variable "bedrock_embed_model_id" {
+  description = "Bedrock embedding model ID for the chat RAG corpus. Empty lets the code default (amazon.titan-embed-text-v2:0) apply."
+  type        = string
+  default     = ""
+}
+
 # --- Sentry / release tagging ---
 variable "sentry_dsn" {
   description = "Sentry DSN. Empty = Sentry disabled (instrument() falls through to a no-op wrapper)."

--- a/infrastructure/modules/monitoring/main.tf
+++ b/infrastructure/modules/monitoring/main.tf
@@ -15,6 +15,45 @@ resource "aws_sns_topic_subscription" "email" {
   endpoint  = var.alert_email
 }
 
+# Monthly cost guardrail. A serverless household app should cost a few
+# dollars/month; a runaway (e.g. a DDB throttle retry-storm or a Bedrock
+# loop) is the realistic surprise. Budgets only support email/SNS
+# subscribers directly, so notifications go to alert_email — the same
+# address already on the alerts topic — when one is configured. The budget
+# itself is always created for console visibility.
+resource "aws_budgets_budget" "monthly_cost" {
+  name         = "${var.project_name}-monthly-cost-${var.environment}"
+  budget_type  = "COST"
+  limit_amount = var.monthly_budget_usd
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
+
+  # Alert at 80% of actual spend (early warning)...
+  dynamic "notification" {
+    for_each = var.alert_email != "" ? [1] : []
+    content {
+      comparison_operator        = "GREATER_THAN"
+      threshold                  = 80
+      threshold_type             = "PERCENTAGE"
+      notification_type          = "ACTUAL"
+      subscriber_email_addresses = [var.alert_email]
+    }
+  }
+
+  # ...and when the month is *forecast* to exceed 100% (catches a spike
+  # before the bill actually lands).
+  dynamic "notification" {
+    for_each = var.alert_email != "" ? [1] : []
+    content {
+      comparison_operator        = "GREATER_THAN"
+      threshold                  = 100
+      threshold_type             = "PERCENTAGE"
+      notification_type          = "FORECASTED"
+      subscriber_email_addresses = [var.alert_email]
+    }
+  }
+}
+
 # CloudWatch Dashboard
 #
 # Layout (24-col grid):

--- a/infrastructure/modules/monitoring/variables.tf
+++ b/infrastructure/modules/monitoring/variables.tf
@@ -29,3 +29,9 @@ variable "dynamodb_table_name" {
   type        = string
   default     = ""
 }
+
+variable "monthly_budget_usd" {
+  description = "Monthly AWS cost budget in USD; breaching 80% actual / 100% forecast emails alert_email."
+  type        = string
+  default     = "50"
+}

--- a/infrastructure/modules/security/main.tf
+++ b/infrastructure/modules/security/main.tf
@@ -134,7 +134,10 @@ resource "aws_wafv2_web_acl_logging_configuration" "api" {
   resource_arn            = aws_wafv2_web_acl.api.arn
 }
 
-# Note: WAF association with API Gateway is done separately
-# as API Gateway v2 (HTTP API) doesn't support WAF directly.
-# For production, consider using API Gateway REST API or
-# CloudFront in front of the HTTP API.
+# Associate the regional web ACL with the API Gateway stage. HTTP API (v2)
+# stages have supported WAFv2 association since 2021 — the previous note
+# claiming otherwise was stale, so the ACL existed but protected nothing.
+resource "aws_wafv2_web_acl_association" "api" {
+  resource_arn = var.api_gateway_stage_arn
+  web_acl_arn  = aws_wafv2_web_acl.api.arn
+}

--- a/infrastructure/modules/security/variables.tf
+++ b/infrastructure/modules/security/variables.tf
@@ -13,6 +13,11 @@ variable "api_gateway_arn" {
   type        = string
 }
 
+variable "api_gateway_stage_arn" {
+  description = "API Gateway stage ARN — the resource the WAF web ACL associates with"
+  type        = string
+}
+
 variable "cloudfront_arn" {
   description = "CloudFront distribution ARN"
   type        = string

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -32,6 +32,12 @@ variable "alert_email" {
   default     = ""
 }
 
+variable "monthly_budget_usd" {
+  description = "Monthly AWS cost budget in USD; breaching 80% actual / 100% forecast emails alert_email."
+  type        = string
+  default     = "50"
+}
+
 variable "email_from_address" {
   description = "Friendly From header for Cognito mail (signup confirmations, password resets). E.g. 'Family Greenhouse <hello@familygreenhouse.net>'. Required when domain_name is set."
   type        = string

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -74,3 +74,30 @@ variable "perenual_api_key_secret_id" {
   type        = string
   default     = ""
 }
+
+variable "perenual_daily_budget" {
+  description = "Max Perenual API calls per day. Blank lets the code default (80) apply."
+  type        = string
+  default     = ""
+}
+
+# OpenWeather powers the climate/weather features. Without the key the weather
+# service short-circuits to null and those features silently disable in prod.
+variable "openweather_api_key" {
+  description = "OpenWeather API key. Blank disables the climate/weather features."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "openweather_daily_budget" {
+  description = "Max OpenWeather API calls per day. Blank lets the code default (800) apply."
+  type        = string
+  default     = ""
+}
+
+variable "bedrock_embed_model_id" {
+  description = "Bedrock embedding model ID for the chat RAG corpus. Blank lets the code default (amazon.titan-embed-text-v2:0) apply."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
Three independent infra hardening fixes (separate commits for review).

### 1. `fix(infra)` wire OpenWeather/Perenual/Bedrock env vars to Lambda
Four env vars are read by the backend but were never declared in the Lambda `environment{}` block, so they couldn't be set without a code change:
- `OPENWEATHER_API_KEY` — **without it the weather service short-circuits to null and the climate features silently disable in prod**
- `OPENWEATHER_DAILY_BUDGET`, `PERENUAL_DAILY_BUDGET`, `BEDROCK_EMBED_MODEL_ID` — drifted from code defaults
Declared in the api module + plumbed through root so they're tfvar-settable (empty default = current behavior).

### 2. `feat(infra)` associate WAF web ACL with the API Gateway stage
The regional WAFv2 ACL (rate limit + AWS managed rules) existed and logged but was associated with **nothing** — a stale comment claimed HTTP API v2 doesn't support WAF (it has since 2021). Adds `aws_wafv2_web_acl_association` on the stage ARN + the output/variable plumbing.

### 3. `feat(infra)` add monthly AWS cost budget
No cost guardrail existed. Adds `aws_budgets_budget` (default \$50/mo, tfvar-configurable) emailing `alert_email` at 80% actual / 100% forecasted spend.

## Verification
`terraform validate` ✓ · `terraform fmt -recursive -check` ✓

> Note: the broader "wire *all* integration secrets (Stripe/SES/Plant.id) through root" gap is pre-existing and intentionally out of scope here — those are declared in the api module and provisioned when credentials land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)