### PR TITLE
ci: make gitleaks blocking (license-free) + add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,75 @@
+version: 2
+updates:
+  # --- npm workspaces ---
+  # Root holds shared tooling (eslint, prettier, husky); the two workspaces
+  # carry their own runtime deps. Dependabot needs one entry per manifest.
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      # Batch low-risk dev tooling so we get one PR, not a dozen.
+      dev-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+    labels:
+      - dependencies
+
+  - package-ecosystem: npm
+    directory: /backend
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      aws-sdk:
+        patterns:
+          - '@aws-sdk/*'
+      dev-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+    labels:
+      - dependencies
+      - backend
+
+  - package-ecosystem: npm
+    directory: /frontend
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      dev-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+    labels:
+      - dependencies
+      - frontend
+
+  # --- GitHub Actions ---
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    labels:
+      - dependencies
+      - ci
+
+  # --- Terraform providers/modules ---
+  - package-ecosystem: terraform
+    directory: /infrastructure
+    schedule:
+      interval: weekly
+      day: monday
+    labels:
+      - dependencies
+      - infra

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Full history so gitleaks scans every commit, not just the tip —
+          # a secret committed then removed still needs to be caught.
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -149,18 +153,19 @@ jobs:
         # the vite-6 migration). Critical CVEs in runtime deps still block.
         run: npm audit --omit=dev --audit-level=high
 
-      - name: Run Gitleaks
-        # gitleaks-action@v2 requires a paid GITLEAKS_LICENSE for private
-        # repos; without one it errors "Resource not accessible by
-        # integration" and gates every build. Mark advisory until either
-        # the license is provisioned or we move to a license-free scanner
-        # (e.g. trufflehog OSS). The repo is private — leak risk on push
-        # is minimal — but we should still wire some scanner before going
-        # public-history.
-        continue-on-error: true
-        uses: gitleaks/gitleaks-action@v2
+      - name: Run Gitleaks (license-free CLI, blocking)
+        # The gitleaks-action@v2 wrapper needs a paid GITLEAKS_LICENSE for
+        # private repos. The gitleaks BINARY is MIT-licensed and free, so we
+        # run it directly and let a non-zero exit (leaks found) gate the
+        # build. `--redact` keeps any match out of the public log.
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_VERSION: 8.21.2
+        run: |
+          set -euo pipefail
+          curl -sSfL \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xz -C /tmp gitleaks
+          /tmp/gitleaks detect --source . --config .gitleaks.toml --redact --no-banner --verbose
 
   terraform-validate:
     name: Terraform Validate

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,13 @@
+# Gitleaks config for Family Greenhouse.
+# Extends the upstream default ruleset and adds a narrow allowlist for the
+# dev/test bearer-token format, which appears in docs and test fixtures and
+# is NOT a real credential (the local Express mock accepts `mock-token-*`
+# instead of a Cognito JWT — see backend/src/local-server.ts).
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Dev/test mock bearer tokens (local-server.ts auth shim) — not real secrets"
+regexes = [
+  '''mock-token-[0-9a-fA-F-]+''',
+]


### PR DESCRIPTION
## Secret scanning — advisory → blocking
`gitleaks-action@v2` needs a paid `GITLEAKS_LICENSE` for private repos, so the step was `continue-on-error: true` — a real secret could land on `main` undetected.

Now runs the **MIT-licensed gitleaks binary** directly and lets a non-zero exit gate the build, over **full history** (`fetch-depth: 0`) so a committed-then-removed secret is still caught.

A `.gitleaks.toml` extends the default ruleset and allowlists the dev-only `mock-token-*` bearer format (the `local-server.ts` auth shim) that appears in docs/tests. **Verified locally**: scan finds the one false positive (`docs/notifications.md` curl example) without the allowlist, and is clean (exit 0) with it.

## Dependabot
Adds `.github/dependabot.yml` — weekly updates for npm (root + backend + frontend, dev deps grouped, `@aws-sdk/*` grouped), `github-actions`, and `terraform`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)