### PR TITLE
feat: add /health route + route53 uptime monitor

### DIFF
--- a/backend/src/handlers/api/handler.ts
+++ b/backend/src/handlers/api/handler.ts
@@ -7,6 +7,7 @@
  * changes go behind `/api/v2`. Backwards-compatible additions land in v1.
  */
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { GetCommand } from '@aws-sdk/lib-dynamodb';
 import createHttpError from 'http-errors';
 import { createHandler } from '../../middleware/handler.js';
 import { createRouter } from '../../middleware/router.js';
@@ -15,6 +16,7 @@ import { rateLimit, userRateLimit } from '../../middleware/rateLimit.js';
 import type { AuthenticatedEvent } from '../../middleware/auth.js';
 import * as plantService from '../../services/plantService.js';
 import * as taskService from '../../services/taskService.js';
+import { dynamodb, TABLE_NAME } from '../../utils/dynamodb.js';
 import { successResponse } from '../../utils/response.js';
 
 // Two-layer rate limit on the public API:
@@ -102,8 +104,48 @@ export const listActivity = createHandler(
   .use(perKeyRateLimit())
   .use(requireApiScope('read:activity'));
 
+// GET /health
+// Unauthenticated liveness probe: proves the Lambda boots, the router
+// dispatches end-to-end, and the data plane is reachable. Returns the build
+// SHA so a synthetic monitor can also catch a stuck/old deploy, not just a
+// hard outage. No auth and no rate limit — it must stay cheap and always
+// reachable for uptime checks (the prod smoke test previously had to use
+// /billing/plans because no health route existed).
+//
+// Shape matches the local-server mock + the /status page contract:
+//   { status, version, checkedAt, components: { database, auth, mail } }
+// `database` is a real reachability probe (a cheap GetItem on a sentinel
+// key). `auth`/`mail` are reported passively for now — they're not actively
+// probed, so they stay 'ok' until a dedicated check is added.
+export const health = createHandler(async (): Promise<APIGatewayProxyResult> => {
+  let database: 'ok' | 'error' = 'ok';
+  try {
+    await dynamodb.send(
+      new GetCommand({
+        TableName: TABLE_NAME,
+        Key: { PK: 'HEALTHCHECK', SK: 'PROBE' },
+      })
+    );
+  } catch {
+    database = 'error';
+  }
+
+  const overall = database === 'ok' ? 'ok' : 'degraded';
+  return successResponse({
+    status: overall,
+    version: process.env.GIT_SHA ?? 'unknown',
+    checkedAt: new Date().toISOString(),
+    components: {
+      database: { status: database },
+      auth: { status: 'ok' },
+      mail: { status: 'ok' },
+    },
+  });
+});
+
 // Lambda entrypoint: dispatch this group's routes (see middleware/router.ts).
 export const handler = createRouter({
+  'GET /health': health,
   'GET /api/v1/me': me,
   'GET /api/v1/plants': listPlants,
   'GET /api/v1/plants/{id}': getPlant,

--- a/backend/tests/unit/handlers/health.test.ts
+++ b/backend/tests/unit/handlers/health.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from 'aws-lambda';
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+  GetCommand: vi.fn((input) => ({ input, kind: 'Get' })),
+}));
+
+vi.mock('../../../src/utils/dynamodb.js', () => ({
+  dynamodb: { send: vi.fn() },
+  TABLE_NAME: 'test-table',
+}));
+
+function buildEvent(): APIGatewayProxyEvent {
+  return {
+    body: null,
+    headers: {},
+    httpMethod: 'GET',
+    isBase64Encoded: false,
+    multiValueHeaders: {},
+    multiValueQueryStringParameters: null,
+    path: '/health',
+    pathParameters: null,
+    queryStringParameters: null,
+    requestContext: {
+      identity: { sourceIp: '127.0.0.1' },
+    } as APIGatewayProxyEvent['requestContext'],
+    resource: '/health',
+    stageVariables: null,
+  };
+}
+
+const ctx = {} as Context;
+
+describe('GET /health', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('returns ok with all components healthy when DDB is reachable', async () => {
+    const { dynamodb } = await import('../../../src/utils/dynamodb.js');
+    vi.mocked(dynamodb.send).mockResolvedValueOnce({ Item: undefined } as never);
+    const { health } = await import('../../../src/handlers/api/handler.js');
+    const res = (await health(buildEvent(), ctx)) as APIGatewayProxyResult;
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.status).toBe('ok');
+    expect(body.components.database.status).toBe('ok');
+    expect(body.checkedAt).toBeTypeOf('string');
+  });
+
+  it('reports degraded when the DDB probe fails', async () => {
+    const { dynamodb } = await import('../../../src/utils/dynamodb.js');
+    vi.mocked(dynamodb.send).mockRejectedValueOnce(new Error('ddb down'));
+    const { health } = await import('../../../src/handlers/api/handler.js');
+    const res = (await health(buildEvent(), ctx)) as APIGatewayProxyResult;
+    // The endpoint itself still answers 200 (it's reachable); the payload
+    // carries the degraded signal a monitor parses.
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.status).toBe('degraded');
+    expect(body.components.database.status).toBe('error');
+  });
+});

--- a/docs/api-spec.yaml
+++ b/docs/api-spec.yaml
@@ -16,6 +16,13 @@ security:
   - bearerAuth: []
 
 paths:
+  /health:
+    get:
+      summary: Unauthenticated liveness probe (status + build SHA)
+      tags: [System]
+      security: []
+      responses:
+        '200': { $ref: '#/components/responses/Ok' }
   /auth/signup:
     post:
       summary: Register a new user

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -119,6 +119,7 @@ module "monitoring" {
   lambda_function_names = module.api.lambda_function_names
   alert_email           = var.alert_email
   dynamodb_table_name   = module.database.table_name
+  api_endpoint          = module.api.api_gateway_endpoint
 }
 
 # Security module (WAF, IAM)

--- a/infrastructure/modules/api/main.tf
+++ b/infrastructure/modules/api/main.tf
@@ -420,6 +420,9 @@ locals {
     "POST /api-keys"        = { group = "apiKeys", auth = "jwt" }
     "DELETE /api-keys/{id}" = { group = "apiKeys", auth = "jwt" }
 
+    # --- health (unauthenticated liveness probe for synthetic monitoring) ---
+    "GET /health" = { group = "api", auth = "none" }
+
     # --- public API v1 (authenticated by API key inside the handler) ---
     "GET /api/v1/me"          = { group = "api", auth = "none" }
     "GET /api/v1/plants"      = { group = "api", auth = "none" }

--- a/infrastructure/modules/api/outputs.tf
+++ b/infrastructure/modules/api/outputs.tf
@@ -13,6 +13,11 @@ output "api_gateway_arn" {
   value       = aws_apigatewayv2_api.main.arn
 }
 
+output "api_gateway_endpoint" {
+  description = "API Gateway base endpoint (https://<id>.execute-api.<region>.amazonaws.com), no stage path"
+  value       = aws_apigatewayv2_api.main.api_endpoint
+}
+
 output "lambda_function_names" {
   description = "Lambda function names"
   value       = [for k, v in aws_lambda_function.handlers : v.function_name]

--- a/infrastructure/modules/monitoring/main.tf
+++ b/infrastructure/modules/monitoring/main.tf
@@ -242,3 +242,53 @@ resource "aws_cloudwatch_metric_alarm" "api_5xx" {
     Name = "${var.project_name}-api-5xx-alarm-${var.environment}"
   }
 }
+
+# --- Synthetic uptime monitor ---
+# A Route53 health check continuously probes the public GET /health endpoint
+# from AWS's global checker fleet — catching a hard outage (the API down) or a
+# degraded state (the body no longer contains "status":"ok", e.g. DDB
+# unreachable) even when no real user is hitting the app. Its metric
+# (AWS/Route53 HealthCheckStatus) only publishes in us-east-1, which is also
+# our primary region, so the alarm lives here too. Created only when an API
+# endpoint is supplied.
+resource "aws_route53_health_check" "api" {
+  count = var.api_endpoint == "" ? 0 : 1
+
+  # fqdn wants the bare host; api_endpoint is https://<host> with no path.
+  fqdn              = replace(replace(var.api_endpoint, "https://", ""), "http://", "")
+  port              = 443
+  type              = "HTTPS_STR_MATCH"
+  resource_path     = "/${var.environment}/health"
+  search_string     = "\"status\":\"ok\""
+  request_interval  = 30
+  failure_threshold = 3
+
+  tags = {
+    Name = "${var.project_name}-api-health-${var.environment}"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "api_health" {
+  count = var.api_endpoint == "" ? 0 : 1
+
+  alarm_name          = "${var.project_name}-api-health-${var.environment}"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "HealthCheckStatus"
+  namespace           = "AWS/Route53"
+  period              = 60
+  statistic           = "Minimum"
+  threshold           = 1
+  alarm_description   = "Public /health endpoint is failing (unreachable, non-2xx, or status != ok)"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+  ok_actions          = [aws_sns_topic.alerts.arn]
+  treat_missing_data  = "breaching"
+
+  dimensions = {
+    HealthCheckId = aws_route53_health_check.api[0].id
+  }
+
+  tags = {
+    Name = "${var.project_name}-api-health-alarm-${var.environment}"
+  }
+}

--- a/infrastructure/modules/monitoring/variables.tf
+++ b/infrastructure/modules/monitoring/variables.tf
@@ -29,3 +29,9 @@ variable "dynamodb_table_name" {
   type        = string
   default     = ""
 }
+
+variable "api_endpoint" {
+  description = "API Gateway base endpoint (https://host, no stage path) for the uptime health check. Empty disables the synthetic monitor."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Problem
The deployed API had **no health route** — the production smoke test had to probe `/billing/plans`, and there was **no continuous uptime monitoring**. The local-server mock and the `/status` page already reference a health endpoint shape that production never implemented.

## Backend
Adds an unauthenticated `GET /health` to the `api` group (no new Lambda) returning the advertised shape:
```json
{ "status": "ok", "version": "<git sha>", "checkedAt": "...",
  "components": { "database": {"status":"ok"}, "auth": {"status":"ok"}, "mail": {"status":"ok"} } }
```
- `database` is a **real** reachability probe (a cheap `GetItem` on a sentinel key); a failure flips overall `status` to `degraded`. The Lambda already holds `dynamodb:GetItem`.
- `auth`/`mail` are passive `ok` for now (not yet actively probed — commented as such).
- Wired into the router, `docs/api-spec.yaml` (drift check passes — 74 routes), and the Terraform route map.

## Infra
A **Route53 `HTTPS_STR_MATCH` health check** probes `/health` from AWS's global fleet and alarms to the existing alerts SNS topic when the endpoint is unreachable, non-2xx, or no longer reports `"status":"ok"` (so a `degraded` DB also pages). The metric is us-east-1-only — same as our primary region. Gated on `api_endpoint`.

## Verification
backend 361 tests ✓ · 2 new health tests ✓ · api-spec drift ✓ · `terraform validate` + `fmt` ✓

> Follow-up (left out to avoid conflicting with #7): once both merge, the prod smoke test in `cd-production.yml` can switch from `/billing/plans` to `/health`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)