### PR TITLE
docs: add incident response, runbooks, and support playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ For everything else (running tests, deploying, configuring channels) follow the 
 - [`docs/billing.md`](docs/billing.md) — Stripe integration, plan caps, webhook flow
 - [`docs/public-api.md`](docs/public-api.md) — read-only public API: key auth, scopes, rate limits, endpoints
 - [`docs/production-checklist.md`](docs/production-checklist.md) — gating list for going live
+- [`docs/incidents.md`](docs/incidents.md) — severity levels, the first 15 minutes, post-mortem template
+- [`docs/runbooks.md`](docs/runbooks.md) — step-by-step fixes (rollback, DDB throttle, Stripe webhooks, PITR…)
+- [`docs/support.md`](docs/support.md) — user-issue triage + common resolutions
 
 ## What works today
 

--- a/docs/incidents.md
+++ b/docs/incidents.md
@@ -1,0 +1,60 @@
+# Incident response
+
+What to do when production breaks. Pair this with [`runbooks.md`](runbooks.md) (the step-by-step fixes for specific failures) and [`support.md`](support.md) (how user-reported issues get triaged).
+
+Today the team is small enough that "on-call" is "whoever is awake." This doc exists so that when there are two of us — or when it's 3am — nobody has to invent a process mid-incident.
+
+## Severity levels
+
+| Sev       | Definition                                             | Examples                                                                      | Response                                                 |
+| --------- | ------------------------------------------------------ | ----------------------------------------------------------------------------- | -------------------------------------------------------- |
+| **SEV-1** | App unusable for all/most users; data at risk          | Login broken, API 5xx storm, DynamoDB unavailable, data loss                  | Drop everything. Start a timeline. Fix or roll back now. |
+| **SEV-2** | A major feature is broken for many users; no data risk | Billing checkout failing, reminders not sending, image upload broken          | Same day. Mitigate, then fix.                            |
+| **SEV-3** | Degraded or broken for some users; workaround exists   | One integration down (Perenual/Plant.id), slow p95, cosmetic but user-visible | Next business day. Track as a normal bug.                |
+
+When unsure, **round up** for the first 15 minutes, then downgrade once scope is clear.
+
+## First 15 minutes (any SEV-1/2)
+
+1. **Acknowledge.** Note the start time. If a second person is around, one drives, one scribes.
+2. **Confirm it's real.** Hit `GET /health` (the Route53 monitor alarms on this). Load `https://familygreenhouse.net`. Is it you or everyone? Check the CloudWatch dashboard `family-greenhouse-production` (API 5xx, Lambda errors/p95, DDB throttles).
+3. **Find the blast radius.** One handler group or all? One household or all? Recent deploy? `git log --oneline -5` and check whether a deploy/tag landed in the last hour.
+4. **Stop the bleeding before you fix the cause.** Prefer rollback over a forward-fix under pressure — see [`runbooks.md` → Roll back a bad deploy](runbooks.md#roll-back-a-bad-deploy). A production smoke failure already triggers **auto-rollback** of the Lambda code (see `cd-production.yml`), so check whether that already fired.
+5. **Communicate.** If users are affected, post to the status channel / status page. "We're aware of <X>, investigating" beats silence.
+
+## Escalation
+
+- **Solo:** you are the escalation. Use the runbooks; don't improvise on data-destructive steps (restores, deletes) — read the runbook first.
+- **Two+ engineers:** the person who took the page owns the incident until explicitly handed off ("you have the conn"). The owner decides rollback vs forward-fix and writes the post-mortem.
+- **Vendor-side:** if the root cause is AWS (region event), Stripe, or another provider, link their status page in the timeline and switch to monitoring + comms — there's no code fix to make.
+
+## After it's over (SEV-1/2 → post-mortem)
+
+Write a short blameless post-mortem within 48h. Template:
+
+```
+# Post-mortem: <short title> — <date>
+
+## Summary
+One paragraph: what broke, who was affected, for how long.
+
+## Timeline (UTC)
+- HH:MM  first signal (alarm / user report)
+- HH:MM  acknowledged
+- HH:MM  mitigation applied
+- HH:MM  resolved
+
+## Impact
+Users affected, features down, any data loss.
+
+## Root cause
+The actual cause, not the symptom.
+
+## What went well / what didn't
+Detection, response, tooling gaps.
+
+## Action items
+- [ ] <owner> <concrete fix or guardrail> — so this class of failure can't recur
+```
+
+The point of the action items is to convert each incident into a guardrail (an alarm, a test, a runbook entry). Add new runbook entries here as you learn them.

--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -1,0 +1,104 @@
+# Runbooks
+
+Step-by-step responses to specific production failures. Each entry: **symptom → diagnosis → fix**. When you resolve a new class of incident, add an entry here. See [`incidents.md`](incidents.md) for the overall severity/comms process.
+
+Assumed context: single region **us-east-1**, serverless stack (API Gateway HTTP API → Lambda per handler group → DynamoDB single table), CloudWatch dashboard `family-greenhouse-production`, alerts fan out to the `family-greenhouse-alerts-production` SNS topic (email).
+
+---
+
+## Roll back a bad deploy
+
+**Symptom:** errors/latency spiked right after a deploy or `v*` tag.
+
+**Auto path:** a failing post-deploy smoke test already triggers the `rollback` job in `cd-production.yml`, which restores each Lambda's previous published version from `s3://<artifact-bucket>/lambda-versions/`. Confirm it fired (Actions run → `rollback` job).
+
+**Manual path:** if you need to roll back without a smoke failure:
+
+```bash
+# List recent versions for a function
+aws lambda list-versions-by-function --function-name family-greenhouse-<group>-production \
+  --query 'Versions[-3:].[Version,LastModified]' --output table
+# Restore a known-good version's code (zips are archived per published version)
+aws lambda update-function-code --function-name family-greenhouse-<group>-production \
+  --s3-bucket <artifact-bucket> --s3-key lambda-versions/<group>-v<N>.zip --publish
+```
+
+Then re-run `GET /health` and the smoke check. **Frontend** rollback = re-sync the previous `dist/` to the S3 bucket and invalidate CloudFront.
+
+---
+
+## DynamoDB throttling
+
+**Symptom:** `DDB throttle` panel non-zero on the dashboard; 5xx or slow writes; `ProvisionedThroughputExceeded`/`ThrottlingException` in logs.
+
+**Diagnosis:** the table is on-demand (PAY_PER_REQUEST), so sustained throttling means either a hot partition or a runaway caller. Check: which access pattern? A single household hammering one PK (`HOUSEHOLD#<id>`)? A loop in a handler?
+
+**Fix:**
+
+1. Identify the hot key from logs (every request logs `householdId`).
+2. If it's a runaway client, rate-limiting already exists per-IP and per-user (`middleware/rateLimit.ts`) — confirm it's engaged for that route.
+3. On-demand scales automatically but has a ramp; for a sudden 10x, request a service quota bump or pre-warm. Persistent hot partitions are a data-model issue — file a follow-up, don't hot-patch the schema during the incident.
+
+---
+
+## Stripe webhooks not applying
+
+**Symptom:** a user paid but their plan didn't change; or subscription state looks stale.
+
+**Diagnosis:**
+
+1. Stripe Dashboard → Developers → Webhooks → check delivery attempts + response codes to `POST /billing/webhook`.
+2. **403/400 with signature error** → `STRIPE_WEBHOOK_SECRET` mismatch between Stripe and the Lambda env. The handler uses the **raw** body for signature verification (`createRawBodyHandler`); if someone reintroduced a JSON body parser on that route, every signature fails — check `handlers/billing/handler.ts`.
+3. **200 but no change** → the event may have been deduped. Webhook processing is idempotent: each `event.id` is recorded once (`STRIPE_EVENT#<id>`), and a redelivery logs `stripe_event_duplicate_skipped` and skips. That's correct behavior, not a bug — verify the _first_ delivery actually applied.
+
+**Fix:** correct the webhook secret and **resend** the event from the Stripe Dashboard (idempotency makes resends safe). For a one-off correction, the household's `planId`/subscription fields can be patched directly on its `HOUSEHOLD#<id>` / `METADATA` item.
+
+---
+
+## Reminders not sending
+
+**Symptom:** users report missing watering reminders.
+
+**Diagnosis:** reminders run hourly via an EventBridge rule → `reminders` Lambda → SES (email) / SNS (SMS) / web push.
+
+1. EventBridge → rule `family-greenhouse-reminders-production` → confirm it's enabled and firing.
+2. `reminders` Lambda logs (CloudWatch) → did the scan run? Any errors per channel?
+3. **Email silent** → SES still in sandbox, or `SES_FROM_EMAIL` unset/unverified. **SMS silent** → `SMS_NOTIFICATIONS_ENABLED` not `1`, or SNS spend limit hit. Each channel falls back to a structured log line when unconfigured — grep for it.
+
+---
+
+## Cost spike
+
+**Symptom:** the monthly budget alarm emailed (80% actual or 100% forecast).
+
+**Diagnosis:** Cost Explorer → group by service. Usual suspects: a Lambda in a retry loop (esp. `chat` → Bedrock), DynamoDB throttle-retry storm, or unexpected egress.
+
+**Fix:** trace the runaway to a handler, fix or disable it, then confirm the dashboard normalizes. The budget is a guardrail, not a circuit breaker — it won't stop spend on its own.
+
+---
+
+## Lambda cold-start / latency
+
+**Symptom:** intermittent slow first requests, `p95` panel elevated.
+
+**Diagnosis:** cold starts are expected at low traffic. The `chat` Lambda is 512MB/90s on purpose (Bedrock tool loop); others are 256MB/30s. A _sustained_ p95 climb that isn't cold starts points at a downstream dependency (DDB, Bedrock, an external API) — check X-Ray traces (trace id is on every log line).
+
+---
+
+## Data restore (DynamoDB PITR)
+
+**Symptom:** data corruption or accidental deletion needing point-in-time recovery.
+
+> ⚠️ This is destructive and rarely rehearsed — **read fully before running**, and prefer restoring to a _new_ table over overwriting.
+
+1. PITR is enabled on the production table. Restore to a **new** table name:
+   ```bash
+   aws dynamodb restore-table-to-point-in-time \
+     --source-table-name FamilyGreenhouse-production \
+     --target-table-name FamilyGreenhouse-restore-<date> \
+     --use-latest-restorable-time   # or --restore-date-time <ISO8601>
+   ```
+2. Validate the restored data out-of-band before any cutover.
+3. Cutover (point Lambdas at the new table via `TABLE_NAME`, or copy the needed items back) is a deliberate, reviewed step — not done mid-panic.
+
+A real restore drill is still outstanding (see [`production-checklist.md`](production-checklist.md) / [`deferred-resilience.md`](deferred-resilience.md)); run one in staging before you ever need it for real.

--- a/docs/support.md
+++ b/docs/support.md
@@ -1,0 +1,34 @@
+# Support
+
+How user-reported problems get handled. For production _outages_ (not individual user issues), see [`incidents.md`](incidents.md).
+
+## Channel & response targets
+
+- **Primary channel:** the support email listed in the app footer / privacy policy.
+- **Targets (aspirational until volume justifies an SLA):**
+  - Acknowledge within **1 business day**.
+  - Anything that looks like a security report or data loss → treat as same-day, escalate to [`incidents.md`](incidents.md).
+
+## Triage
+
+For each report, capture: account email, household, what they expected vs saw, rough time, and whether it's reproducible. Then:
+
+1. **Is it widespread?** Cross-check the CloudWatch dashboard and `GET /health`. If others are affected → it's an incident, not a support ticket.
+2. **Is it security/privacy?** (Someone seeing another household's data, an unexpected charge, a leaked link.) → escalate immediately.
+3. **Otherwise** → reproduce, file a normal bug, reply with a workaround + timeline.
+
+## Common issues & resolutions
+
+| Report                                                   | Likely cause                                                                | Resolution                                                                                                                                                                                                                                                                                      |
+| -------------------------------------------------------- | --------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "I didn't get my confirmation / reset email"             | SES sandbox, spam folder, or unverified sender                              | Confirm SES status; ask them to check spam; resend. Auth emails go through Cognito → SES.                                                                                                                                                                                                       |
+| "My SMS reminders aren't arriving"                       | `SMS_NOTIFICATIONS_ENABLED` off, or number not opted-in/verified            | SMS is gated; confirm it's enabled and the number opted in. See [`notifications.md`](notifications.md).                                                                                                                                                                                         |
+| "I paid but I'm still on the free plan"                  | Webhook delivery / signature issue                                          | Follow [`runbooks.md` → Stripe webhooks not applying](runbooks.md#stripe-webhooks-not-applying). Resends are idempotent.                                                                                                                                                                        |
+| "I can see/can't see a household I expected"             | Membership / `X-Household-Id` scoping                                       | Membership is validated server-side; check the user's memberships on their `USER#<id>` items. See [`multi-household.md`](multi-household.md).                                                                                                                                                   |
+| **"I deleted a plant by mistake — can you restore it?"** | Plant delete is currently a **hard delete** (cascades tasks/history/images) | Today: only recoverable via a DynamoDB PITR restore ([`runbooks.md`](runbooks.md#data-restore-dynamodb-pitr)) — heavy, rarely worth it for one plant. **This is exactly why soft-delete/archive is on the roadmap; once shipped, this becomes a one-click restore.** Set expectations honestly. |
+| "Can I get my data out?"                                 | —                                                                           | Self-serve: Settings → export (JSON + per-household CSV for plants/tasks). Backend `GET /me/export` returns the full JSON.                                                                                                                                                                      |
+| "Delete my account"                                      | —                                                                           | Self-serve: `DELETE /me`. Note it removes login + personal data but preserves household activity history under the (pseudonymized) member name — say so explicitly.                                                                                                                             |
+
+## When to escalate to an incident
+
+Two or more independent reports of the same failure in a short window, anything touching billing correctness or cross-household data exposure, or any report of data loss. Don't wait for the dashboard to confirm — round up, then downgrade.


### PR DESCRIPTION
The app is live in production but had no operational docs — no severity definitions, no step-by-step recovery, no user-issue triage. This adds the three that matter before the team grows past one person or the first 3am page.

- **`docs/incidents.md`** — SEV-1/2/3 definitions, the first-15-minutes checklist, escalation, blameless post-mortem template.
- **`docs/runbooks.md`** — symptom → diagnosis → fix for the real failure modes: deploy rollback (incl. the auto-rollback path), DDB throttling, Stripe webhook non-application (signature + idempotency), reminders, cost spikes, cold starts, PITR restore.
- **`docs/support.md`** — response targets, triage flow, common-issues table (incl. the honest "I deleted a plant" answer that motivates soft-delete).

Linked from the README docs index. The runbooks deliberately reference the guardrails added in this same batch of work (auto-rollback artifacts #7, `/health` monitor #10, cost budget #8, webhook idempotency #6) so the docs and the infra stay coherent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)