### PR TITLE
feat(frontend): toast + skeletons + taskType dedup + zod i18n

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { Layout } from '@/components/Layout';
 import { ProtectedRoute } from '@/components/ProtectedRoute';
 import { LoadingSpinner } from '@/components/LoadingSpinner';
 import { NotFoundPage } from '@/components/NotFoundPage';
+import { Toaster } from '@/components/Toaster';
 
 // Route-level code splitting. Each feature module compiles into its own
 // chunk; the initial bundle drops by ~150 KB because the marketing landing
@@ -110,6 +111,7 @@ function App() {
       <a href="#main-content" className="skip-link">
         Skip to main content
       </a>
+      <Toaster />
       <Suspense fallback={<RouteFallback />}>
         <div id="main-content" tabIndex={-1}>
           <Routes>

--- a/frontend/src/components/Skeleton.tsx
+++ b/frontend/src/components/Skeleton.tsx
@@ -1,0 +1,68 @@
+import clsx from 'clsx';
+
+/**
+ * Base shimmer block. Content-shaped skeletons (below) compose these so a
+ * loading list/grid reserves the same space the real content will occupy —
+ * avoiding the layout shift a centered spinner causes when data lands.
+ * `motion-safe:` keeps the pulse off for users who prefer reduced motion.
+ */
+export function Skeleton({ className }: { className?: string }) {
+  return (
+    <div
+      className={clsx('motion-safe:animate-pulse rounded bg-primary-100/70', className)}
+      aria-hidden="true"
+    />
+  );
+}
+
+function PlantCardSkeleton() {
+  return (
+    <div className="overflow-hidden rounded-xl border border-primary-100/70 bg-paper shadow-journal">
+      <Skeleton className="aspect-square w-full rounded-none" />
+      <div className="space-y-2 p-3">
+        <Skeleton className="h-4 w-3/4" />
+        <Skeleton className="h-3 w-1/2" />
+      </div>
+    </div>
+  );
+}
+
+/** Grid of plant-card placeholders mirroring the real PlantsPage grid. */
+export function PlantGridSkeleton({ count = 10 }: { count?: number }) {
+  return (
+    <div
+      className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5"
+      role="status"
+      aria-label="Loading plants"
+    >
+      {Array.from({ length: count }).map((_, i) => (
+        <PlantCardSkeleton key={i} />
+      ))}
+      <span className="sr-only">Loading plants…</span>
+    </div>
+  );
+}
+
+function ListRowSkeleton() {
+  return (
+    <div className="flex items-center gap-4 py-3">
+      <Skeleton className="h-9 w-9 rounded-full" />
+      <div className="flex-1 space-y-2">
+        <Skeleton className="h-4 w-1/3" />
+        <Skeleton className="h-3 w-1/4" />
+      </div>
+    </div>
+  );
+}
+
+/** Stack of row placeholders for task/activity lists. */
+export function ListSkeleton({ rows = 4 }: { rows?: number }) {
+  return (
+    <div role="status" aria-label="Loading">
+      {Array.from({ length: rows }).map((_, i) => (
+        <ListRowSkeleton key={i} />
+      ))}
+      <span className="sr-only">Loading…</span>
+    </div>
+  );
+}

--- a/frontend/src/components/Toaster.tsx
+++ b/frontend/src/components/Toaster.tsx
@@ -1,0 +1,85 @@
+import { createPortal } from 'react-dom';
+import {
+  CheckCircleIcon,
+  XCircleIcon,
+  InformationCircleIcon,
+  XMarkIcon,
+} from '@heroicons/react/24/outline';
+import clsx from 'clsx';
+import { useToastStore, type ToastVariant } from '@/store/toastStore';
+
+const variantConfig: Record<
+  ToastVariant,
+  { icon: typeof CheckCircleIcon; bg: string; text: string; iconColor: string }
+> = {
+  success: {
+    icon: CheckCircleIcon,
+    bg: 'bg-green-50 ring-green-200/70',
+    text: 'text-green-900',
+    iconColor: 'text-green-600',
+  },
+  error: {
+    icon: XCircleIcon,
+    bg: 'bg-red-50 ring-red-200/70',
+    text: 'text-red-900',
+    iconColor: 'text-red-600',
+  },
+  info: {
+    icon: InformationCircleIcon,
+    bg: 'bg-sky-50 ring-sky-200/70',
+    text: 'text-sky-900',
+    iconColor: 'text-sky-600',
+  },
+};
+
+/**
+ * Transient notification stack. Mount once near the app root. The container is
+ * a persistent polite live region so screen readers announce toasts as they're
+ * inserted; each toast also has a dismiss button for keyboard/AT users since
+ * auto-dismiss alone isn't accessible.
+ */
+export function Toaster() {
+  const toasts = useToastStore((s) => s.toasts);
+  const dismiss = useToastStore((s) => s.dismiss);
+
+  if (typeof document === 'undefined') return null;
+
+  return createPortal(
+    <div
+      className="pointer-events-none fixed bottom-4 right-4 z-50 flex w-full max-w-sm flex-col gap-2"
+      role="region"
+      aria-label="Notifications"
+      aria-live="polite"
+    >
+      {toasts.map((t) => {
+        const c = variantConfig[t.variant];
+        const Icon = c.icon;
+        return (
+          <div
+            key={t.id}
+            className={clsx(
+              'pointer-events-auto flex items-start gap-3 rounded-md p-4 shadow-lg ring-1',
+              c.bg
+            )}
+          >
+            <Icon className={clsx('h-5 w-5 flex-shrink-0', c.iconColor)} aria-hidden="true" />
+            <p className={clsx('flex-1 text-sm', c.text)}>{t.message}</p>
+            <button
+              type="button"
+              onClick={() => dismiss(t.id)}
+              aria-label="Dismiss notification"
+              className={clsx(
+                'flex-shrink-0 rounded p-0.5 opacity-70 transition-opacity hover:opacity-100',
+                'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2',
+                c.text
+              )}
+            >
+              <XMarkIcon className="h-4 w-4" aria-hidden="true" />
+            </button>
+          </div>
+        );
+      })}
+    </div>,
+    document.body
+  );
+}

--- a/frontend/src/features/auth/LoginPage.tsx
+++ b/frontend/src/features/auth/LoginPage.tsx
@@ -1,8 +1,10 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import { useAuthStore } from '@/store/authStore';
 import { authService } from '@/services/authService';
 import { getErrorMessage } from '@/services/api';
@@ -12,15 +14,21 @@ import { Alert } from '@/components/Alert';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { AuthShell } from './AuthShell';
 
-const loginSchema = z.object({
-  email: z.string().email('Please enter a valid email address'),
-  password: z.string().min(1, 'Password is required'),
-});
+// Built per-render from the active locale so validation messages are
+// translated (zod resolves the message at schema-construction time, so the
+// schema has to be rebuilt when the language changes — not defined at module
+// load when no `t` exists yet).
+const makeLoginSchema = (t: TFunction) =>
+  z.object({
+    email: z.string().email(t('auth.invalidEmail')),
+    password: z.string().min(1, t('auth.passwordRequired')),
+  });
 
-type LoginFormData = z.infer<typeof loginSchema>;
+type LoginFormData = z.infer<ReturnType<typeof makeLoginSchema>>;
 
 export function LoginPage() {
   useDocumentTitle('Sign in');
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const location = useLocation();
   const { setUser, setTokens } = useAuthStore();
@@ -28,6 +36,7 @@ export function LoginPage() {
   const [isLoading, setIsLoading] = useState(false);
 
   const from = (location.state as { from?: { pathname: string } })?.from?.pathname || '/dashboard';
+  const loginSchema = useMemo(() => makeLoginSchema(t), [t]);
 
   const {
     register,

--- a/frontend/src/features/dashboard/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/DashboardPage.tsx
@@ -22,6 +22,7 @@ import { getErrorMessage } from '@/services/api';
 import clsx from 'clsx';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { taskTypeLabels, taskTypeStyles } from '@/utils/taskTypeConfig';
+import { toast } from '@/store/toastStore';
 
 function formatDueDate(dateString: string): string {
   const date = new Date(dateString);
@@ -122,7 +123,9 @@ export function DashboardPage() {
     mutationFn: (taskId: string) => taskService.completeTask(taskId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['tasks'] });
+      toast.success('Task completed');
     },
+    onError: (err) => toast.error(getErrorMessage(err)),
   });
 
   const handleCompleteTask = async (taskId: string) => {

--- a/frontend/src/features/dashboard/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/DashboardPage.tsx
@@ -12,7 +12,7 @@ import { ClimateCard } from './ClimateCard';
 import { Card, CardHeader } from '@/components/Card';
 import { Button } from '@/components/Button';
 import { PageHeader } from '@/components/PageHeader';
-import { LoadingSpinner } from '@/components/LoadingSpinner';
+import { PlantGridSkeleton, ListSkeleton } from '@/components/Skeleton';
 import { EmptyState } from '@/components/EmptyState';
 import { EmptyActivity } from '@/components/illustrations/EmptyActivity';
 import { Alert } from '@/components/Alert';
@@ -190,8 +190,8 @@ export function DashboardPage() {
         </div>
 
         {tasksLoading ? (
-          <div className="flex justify-center py-12">
-            <LoadingSpinner />
+          <div className="px-6 py-2">
+            <ListSkeleton rows={4} />
           </div>
         ) : tasksError ? (
           <div className="p-6">
@@ -235,9 +235,7 @@ export function DashboardPage() {
         />
 
         {plantsLoading ? (
-          <div className="flex justify-center py-8">
-            <LoadingSpinner />
-          </div>
+          <PlantGridSkeleton count={8} />
         ) : plantsError ? (
           <Alert variant="error">{getErrorMessage(plantsError)}</Alert>
         ) : !plants || plants.length === 0 ? (

--- a/frontend/src/features/dashboard/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/DashboardPage.tsx
@@ -18,58 +18,10 @@ import { EmptyActivity } from '@/components/illustrations/EmptyActivity';
 import { Alert } from '@/components/Alert';
 import { SprigDivider } from '@/components/brand/SprigDivider';
 import { DashboardHeaderArt } from '@/components/headers/DashboardHeaderArt';
-import { WaterDropIcon } from '@/components/icons/WaterDropIcon';
-import { FertilizeIcon } from '@/components/icons/FertilizeIcon';
-import { PruneIcon } from '@/components/icons/PruneIcon';
-import { RepotIcon } from '@/components/icons/RepotIcon';
-import { CustomTaskIcon } from '@/components/icons/CustomTaskIcon';
 import { getErrorMessage } from '@/services/api';
 import clsx from 'clsx';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
-
-const taskTypeLabels: Record<string, string> = {
-  water: 'Water',
-  fertilize: 'Fertilize',
-  prune: 'Prune',
-  repot: 'Repot',
-  custom: 'Custom',
-};
-
-/**
- * Task-type styling. Each kind gets its own botanical icon and a soft
- * background tinted to a brand-adjacent hue (no raw Tailwind primaries).
- * Keeps the row scannable while staying inside the journal palette.
- */
-const taskTypeStyles: Record<
-  string,
-  { Icon: (p: { className?: string }) => JSX.Element; chip: string; iconColor: string }
-> = {
-  water: {
-    Icon: WaterDropIcon,
-    chip: 'bg-sky-50 text-sky-900 ring-sky-200/70',
-    iconColor: 'text-sky-700',
-  },
-  fertilize: {
-    Icon: FertilizeIcon,
-    chip: 'bg-primary-50 text-primary-900 ring-primary-200/70',
-    iconColor: 'text-primary-700',
-  },
-  prune: {
-    Icon: PruneIcon,
-    chip: 'bg-accent-50 text-accent-900 ring-accent-200/70',
-    iconColor: 'text-accent-700',
-  },
-  repot: {
-    Icon: RepotIcon,
-    chip: 'bg-amber-50 text-amber-900 ring-amber-200/70',
-    iconColor: 'text-amber-800',
-  },
-  custom: {
-    Icon: CustomTaskIcon,
-    chip: 'bg-stone-100 text-stone-900 ring-stone-200/70',
-    iconColor: 'text-stone-700',
-  },
-};
+import { taskTypeLabels, taskTypeStyles } from '@/utils/taskTypeConfig';
 
 function formatDueDate(dateString: string): string {
   const date = new Date(dateString);

--- a/frontend/src/features/plants/AddPlantPage.tsx
+++ b/frontend/src/features/plants/AddPlantPage.tsx
@@ -18,6 +18,7 @@ import { SpeciesCombobox } from '@/components/SpeciesCombobox';
 import { SuggestedCareCard } from './SuggestedCareCard';
 import { generatePlantName } from '@/utils/plantNameGenerator';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
+import { toast } from '@/store/toastStore';
 
 const MAX_BYTES = 5 * 1024 * 1024;
 const ACCEPTED_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
@@ -178,6 +179,7 @@ export function AddPlantPage() {
         ordinal: existing && existing.length > 0 ? 'subsequent' : 'first',
       });
       queryClient.invalidateQueries({ queryKey: ['plants'] });
+      toast.success(`${plant.name} added`);
       navigate(`/plants/${plant.id}`);
     },
     onError: (err) => {

--- a/frontend/src/features/plants/AddPlantPage.tsx
+++ b/frontend/src/features/plants/AddPlantPage.tsx
@@ -1,9 +1,11 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import { ArrowLeftIcon, SparklesIcon, CameraIcon } from '@heroicons/react/24/outline';
 import { plantService, IdentificationSuggestion } from '@/services/plantService';
 import { taskService } from '@/services/taskService';
@@ -23,15 +25,17 @@ import { toast } from '@/store/toastStore';
 const MAX_BYTES = 5 * 1024 * 1024;
 const ACCEPTED_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
 
-const addPlantSchema = z.object({
-  name: z.string().min(1, 'Name is required').max(100, 'Name is too long'),
-  species: z.string().max(100, 'Species name is too long').optional(),
-  location: z.string().max(100, 'Location is too long').optional(),
-  notes: z.string().max(1000, 'Notes are too long').optional(),
-  tags: z.string().max(200, 'Too many tags').optional(),
-});
+// Rebuilt per-render from the active locale so validation messages translate.
+const makeAddPlantSchema = (t: TFunction) =>
+  z.object({
+    name: z.string().min(1, t('validation.nameRequired')).max(100, t('validation.nameTooLong')),
+    species: z.string().max(100, t('validation.speciesTooLong')).optional(),
+    location: z.string().max(100, t('validation.locationTooLong')).optional(),
+    notes: z.string().max(1000, t('validation.notesTooLong')).optional(),
+    tags: z.string().max(200, t('validation.tooManyTags')).optional(),
+  });
 
-type AddPlantFormData = z.infer<typeof addPlantSchema>;
+type AddPlantFormData = z.infer<ReturnType<typeof makeAddPlantSchema>>;
 
 async function fileToBase64(file: File): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -44,8 +48,10 @@ async function fileToBase64(file: File): Promise<string> {
 
 export function AddPlantPage() {
   useDocumentTitle('Add plant');
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const addPlantSchema = useMemo(() => makeAddPlantSchema(t), [t]);
   const [error, setError] = useState<string | null>(null);
   const [pickedFile, setPickedFile] = useState<File | null>(null);
   const [pickedPreview, setPickedPreview] = useState<string | null>(null);

--- a/frontend/src/features/plants/PlantDetailPage.tsx
+++ b/frontend/src/features/plants/PlantDetailPage.tsx
@@ -30,6 +30,7 @@ import { CareReportCard } from './CareReportCard';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
 import clsx from 'clsx';
 import { taskTypeLabels, taskTypeStyle } from '@/utils/taskTypeConfig';
+import { toast } from '@/store/toastStore';
 
 function formatDate(dateString: string | null): string {
   if (!dateString) return 'Never';
@@ -67,8 +68,10 @@ export function PlantDetailPage() {
     mutationFn: () => plantService.deletePlant(plantId!),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['plants'] });
+      toast.success('Plant deleted');
       navigate('/plants');
     },
+    onError: (err) => toast.error(getErrorMessage(err)),
   });
 
   const completeTaskMutation = useMutation({
@@ -76,7 +79,9 @@ export function PlantDetailPage() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['plants', plantId] });
       queryClient.invalidateQueries({ queryKey: ['tasks'] });
+      toast.success('Task completed');
     },
+    onError: (err) => toast.error(getErrorMessage(err)),
   });
 
   const snoozeTaskMutation = useMutation({
@@ -85,7 +90,9 @@ export function PlantDetailPage() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['plants', plantId] });
       queryClient.invalidateQueries({ queryKey: ['tasks'] });
+      toast.info('Task snoozed');
     },
+    onError: (err) => toast.error(getErrorMessage(err)),
   });
 
   if (isLoading) {

--- a/frontend/src/features/plants/PlantDetailPage.tsx
+++ b/frontend/src/features/plants/PlantDetailPage.tsx
@@ -29,22 +29,7 @@ import { CareGuideCard } from './CareGuideCard';
 import { CareReportCard } from './CareReportCard';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
 import clsx from 'clsx';
-
-const taskTypeLabels: Record<string, string> = {
-  water: 'Water',
-  fertilize: 'Fertilize',
-  prune: 'Prune',
-  repot: 'Repot',
-  custom: 'Custom',
-};
-
-const taskTypeColors: Record<string, string> = {
-  water: 'bg-blue-100 text-blue-900',
-  fertilize: 'bg-green-100 text-green-900',
-  prune: 'bg-orange-100 text-orange-900',
-  repot: 'bg-purple-100 text-purple-900',
-  custom: 'bg-gray-100 text-gray-900',
-};
+import { taskTypeLabels, taskTypeStyle } from '@/utils/taskTypeConfig';
 
 function formatDate(dateString: string | null): string {
   if (!dateString) return 'Never';
@@ -357,7 +342,7 @@ function TaskRow({
         <span
           className={clsx(
             'inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium',
-            taskTypeColors[task.type]
+            taskTypeStyle(task.type).chip
           )}
         >
           {task.customType || taskTypeLabels[task.type]}

--- a/frontend/src/features/plants/PlantsPage.tsx
+++ b/frontend/src/features/plants/PlantsPage.tsx
@@ -12,7 +12,7 @@ import { plantService } from '@/services/plantService';
 import { Button } from '@/components/Button';
 import { Card } from '@/components/Card';
 import { PageHeader } from '@/components/PageHeader';
-import { LoadingSpinner } from '@/components/LoadingSpinner';
+import { PlantGridSkeleton, ListSkeleton } from '@/components/Skeleton';
 import { EmptyState } from '@/components/EmptyState';
 import { EmptyPlants } from '@/components/illustrations/EmptyPlants';
 import { Alert } from '@/components/Alert';
@@ -122,9 +122,11 @@ export function PlantsPage() {
 
       {/* Plant list */}
       {isLoading ? (
-        <div className="flex justify-center py-12">
-          <LoadingSpinner size="lg" />
-        </div>
+        viewMode === 'grid' ? (
+          <PlantGridSkeleton />
+        ) : (
+          <ListSkeleton rows={6} />
+        )
       ) : error ? (
         <Alert variant="error">{getErrorMessage(error)}</Alert>
       ) : !filteredPlants || filteredPlants.length === 0 ? (

--- a/frontend/src/features/tasks/TasksPage.tsx
+++ b/frontend/src/features/tasks/TasksPage.tsx
@@ -16,6 +16,7 @@ import { getErrorMessage } from '@/services/api';
 import clsx from 'clsx';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { taskTypeLabels, taskTypeStyles } from '@/utils/taskTypeConfig';
+import { toast } from '@/store/toastStore';
 
 type FilterType = 'all' | 'mine' | 'overdue' | 'today' | 'week';
 
@@ -78,7 +79,9 @@ export function TasksPage() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['tasks'] });
       queryClient.invalidateQueries({ queryKey: ['plants'] });
+      toast.success('Task completed');
     },
+    onError: (err) => toast.error(getErrorMessage(err)),
   });
 
   const filteredTasks = tasks?.filter((task) => {

--- a/frontend/src/features/tasks/TasksPage.tsx
+++ b/frontend/src/features/tasks/TasksPage.tsx
@@ -15,58 +15,9 @@ import { Alert } from '@/components/Alert';
 import { getErrorMessage } from '@/services/api';
 import clsx from 'clsx';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
-import { WaterDropIcon } from '@/components/icons/WaterDropIcon';
-import { FertilizeIcon } from '@/components/icons/FertilizeIcon';
-import { PruneIcon } from '@/components/icons/PruneIcon';
-import { RepotIcon } from '@/components/icons/RepotIcon';
-import { CustomTaskIcon } from '@/components/icons/CustomTaskIcon';
+import { taskTypeLabels, taskTypeStyles } from '@/utils/taskTypeConfig';
 
 type FilterType = 'all' | 'mine' | 'overdue' | 'today' | 'week';
-
-const taskTypeLabels: Record<string, string> = {
-  water: 'Water',
-  fertilize: 'Fertilize',
-  prune: 'Prune',
-  repot: 'Repot',
-  custom: 'Custom',
-};
-
-/**
- * Each task type gets a botanical icon paired with a soft brand-tinted
- * chip. Keeps each row scannable on a `bg-paper` card without leaning on
- * raw Tailwind primaries (the prior blue/green/orange chips clashed with
- * the journal palette).
- */
-const taskTypeStyles: Record<
-  string,
-  { Icon: (p: { className?: string }) => JSX.Element; chip: string; iconColor: string }
-> = {
-  water: {
-    Icon: WaterDropIcon,
-    chip: 'bg-sky-50 text-sky-900 ring-sky-200/70',
-    iconColor: 'text-sky-700',
-  },
-  fertilize: {
-    Icon: FertilizeIcon,
-    chip: 'bg-primary-50 text-primary-900 ring-primary-200/70',
-    iconColor: 'text-primary-700',
-  },
-  prune: {
-    Icon: PruneIcon,
-    chip: 'bg-accent-50 text-accent-900 ring-accent-200/70',
-    iconColor: 'text-accent-700',
-  },
-  repot: {
-    Icon: RepotIcon,
-    chip: 'bg-amber-50 text-amber-900 ring-amber-200/70',
-    iconColor: 'text-amber-800',
-  },
-  custom: {
-    Icon: CustomTaskIcon,
-    chip: 'bg-stone-100 text-stone-900 ring-stone-200/70',
-    iconColor: 'text-stone-700',
-  },
-};
 
 function formatDueDate(dateString: string): string {
   const date = new Date(dateString);

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -99,6 +99,14 @@ export const en = {
     email: 'Email',
     sms: 'Text message',
   },
+  validation: {
+    nameRequired: 'Name is required',
+    nameTooLong: 'Name is too long',
+    speciesTooLong: 'Species name is too long',
+    locationTooLong: 'Location is too long',
+    notesTooLong: 'Notes are too long',
+    tooManyTags: 'Too many tags',
+  },
 };
 
 // Recursively widen string-literal types to `string` so other locales supply

--- a/frontend/src/i18n/locales/es.ts
+++ b/frontend/src/i18n/locales/es.ts
@@ -100,4 +100,12 @@ export const es: Translation = {
     email: 'Correo',
     sms: 'Mensaje de texto',
   },
+  validation: {
+    nameRequired: 'El nombre es obligatorio',
+    nameTooLong: 'El nombre es demasiado largo',
+    speciesTooLong: 'El nombre de la especie es demasiado largo',
+    locationTooLong: 'La ubicación es demasiado larga',
+    notesTooLong: 'Las notas son demasiado largas',
+    tooManyTags: 'Demasiadas etiquetas',
+  },
 };

--- a/frontend/src/store/toastStore.ts
+++ b/frontend/src/store/toastStore.ts
@@ -1,0 +1,51 @@
+import { create } from 'zustand';
+
+export type ToastVariant = 'success' | 'error' | 'info';
+
+export interface Toast {
+  id: number;
+  variant: ToastVariant;
+  message: string;
+}
+
+interface ToastState {
+  toasts: Toast[];
+  add: (variant: ToastVariant, message: string) => void;
+  dismiss: (id: number) => void;
+}
+
+// Module-level counter for stable keys (avoids Math.random/Date collisions and
+// keeps ids deterministic across renders).
+let nextId = 0;
+const DURATION_MS: Record<ToastVariant, number> = {
+  // Errors linger a little longer so they stay readable.
+  error: 6000,
+  success: 4000,
+  info: 4000,
+};
+
+export const useToastStore = create<ToastState>((set) => ({
+  toasts: [],
+  add: (variant, message) => {
+    const id = nextId++;
+    set((s) => ({ toasts: [...s.toasts, { id, variant, message }] }));
+    if (typeof window !== 'undefined') {
+      window.setTimeout(() => {
+        set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) }));
+      }, DURATION_MS[variant]);
+    }
+  },
+  dismiss: (id) => set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) })),
+}));
+
+/**
+ * Imperative helper so non-component code (mutation callbacks, services) can
+ * fire a toast without a hook — mirrors the `toast.success(...)` ergonomics of
+ * libraries like sonner, but with zero added bundle weight (we already ship
+ * zustand). Render <Toaster /> once near the app root to display them.
+ */
+export const toast = {
+  success: (message: string) => useToastStore.getState().add('success', message),
+  error: (message: string) => useToastStore.getState().add('error', message),
+  info: (message: string) => useToastStore.getState().add('info', message),
+};

--- a/frontend/src/utils/taskTypeConfig.ts
+++ b/frontend/src/utils/taskTypeConfig.ts
@@ -1,0 +1,67 @@
+import { WaterDropIcon } from '@/components/icons/WaterDropIcon';
+import { FertilizeIcon } from '@/components/icons/FertilizeIcon';
+import { PruneIcon } from '@/components/icons/PruneIcon';
+import { RepotIcon } from '@/components/icons/RepotIcon';
+import { CustomTaskIcon } from '@/components/icons/CustomTaskIcon';
+
+/**
+ * Single source of truth for how each task type is labelled and styled.
+ *
+ * These maps used to be copy-pasted (byte-identical) across TasksPage,
+ * DashboardPage, and PlantDetailPage — so adding a task type or retinting a
+ * chip meant editing three files and risked drift. Centralizing here keeps
+ * the journal palette consistent and makes the type set extendable in one
+ * place.
+ */
+export const taskTypeLabels: Record<string, string> = {
+  water: 'Water',
+  fertilize: 'Fertilize',
+  prune: 'Prune',
+  repot: 'Repot',
+  custom: 'Custom',
+};
+
+export interface TaskTypeStyle {
+  Icon: (p: { className?: string }) => JSX.Element;
+  /** Soft brand-tinted chip background + ring (no raw Tailwind primaries). */
+  chip: string;
+  iconColor: string;
+}
+
+export const taskTypeStyles: Record<string, TaskTypeStyle> = {
+  water: {
+    Icon: WaterDropIcon,
+    chip: 'bg-sky-50 text-sky-900 ring-sky-200/70',
+    iconColor: 'text-sky-700',
+  },
+  fertilize: {
+    Icon: FertilizeIcon,
+    chip: 'bg-primary-50 text-primary-900 ring-primary-200/70',
+    iconColor: 'text-primary-700',
+  },
+  prune: {
+    Icon: PruneIcon,
+    chip: 'bg-accent-50 text-accent-900 ring-accent-200/70',
+    iconColor: 'text-accent-700',
+  },
+  repot: {
+    Icon: RepotIcon,
+    chip: 'bg-amber-50 text-amber-900 ring-amber-200/70',
+    iconColor: 'text-amber-800',
+  },
+  custom: {
+    Icon: CustomTaskIcon,
+    chip: 'bg-stone-100 text-stone-900 ring-stone-200/70',
+    iconColor: 'text-stone-700',
+  },
+};
+
+/** Human label for a task type, falling back to the raw key. */
+export function taskTypeLabel(type: string): string {
+  return taskTypeLabels[type] ?? type;
+}
+
+/** Style entry for a task type, falling back to the `custom` styling. */
+export function taskTypeStyle(type: string): TaskTypeStyle {
+  return taskTypeStyles[type] ?? taskTypeStyles.custom;
+}

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -2,6 +2,9 @@ import '@testing-library/jest-dom';
 import { afterAll, afterEach, beforeAll, beforeEach, vi } from 'vitest';
 import { cleanup } from '@testing-library/react';
 import { server } from './msw/server';
+// Initialize i18next so components rendered in tests resolve real strings
+// (e.g. zod validation messages built from `t(...)`) instead of raw keys.
+import '@/i18n';
 
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
 afterEach(() => server.resetHandlers());

--- a/frontend/tests/unit/store/toastStore.test.ts
+++ b/frontend/tests/unit/store/toastStore.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { useToastStore, toast } from '@/store/toastStore';
+
+describe('toastStore', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    useToastStore.setState({ toasts: [] });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('adds a toast with the given variant and message', () => {
+    toast.success('Saved');
+    const { toasts } = useToastStore.getState();
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0]).toMatchObject({ variant: 'success', message: 'Saved' });
+  });
+
+  it('assigns unique ids to successive toasts', () => {
+    toast.success('one');
+    toast.error('two');
+    const ids = useToastStore.getState().toasts.map((t) => t.id);
+    expect(new Set(ids).size).toBe(2);
+  });
+
+  it('auto-dismisses a success toast after its duration', () => {
+    toast.success('bye');
+    expect(useToastStore.getState().toasts).toHaveLength(1);
+    vi.advanceTimersByTime(4000);
+    expect(useToastStore.getState().toasts).toHaveLength(0);
+  });
+
+  it('keeps error toasts longer than success toasts', () => {
+    toast.error('still here');
+    vi.advanceTimersByTime(4000);
+    expect(useToastStore.getState().toasts).toHaveLength(1);
+    vi.advanceTimersByTime(2000);
+    expect(useToastStore.getState().toasts).toHaveLength(0);
+  });
+
+  it('dismisses a specific toast by id', () => {
+    toast.info('a');
+    toast.info('b');
+    const [first] = useToastStore.getState().toasts;
+    useToastStore.getState().dismiss(first.id);
+    const remaining = useToastStore.getState().toasts;
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].message).toBe('b');
+  });
+});


### PR DESCRIPTION
Four P2 frontend quality improvements (separate commits for review).

### 1. `refactor` centralize task-type config
`taskTypeLabels` + `taskTypeStyles` were copy-pasted byte-identical across TasksPage/DashboardPage, and PlantDetailPage carried a third diverging `taskTypeColors` map. One source of truth in `utils/taskTypeConfig.ts`; PlantDetailPage now uses the same palette. Net −~90 lines.

### 2. `feat` toast notifications
Mutations gave no post-success feedback. Adds a **dependency-free** toast — a small zustand store (zero bundle-budget risk vs sonner) + an accessible `<Toaster />` (polite live region, per-toast dismiss, portaled). Wired into task complete/snooze, plant add/delete with error fallbacks. 5 unit tests.

### 3. `feat` skeleton loaders
Centered spinners reserved no space → layout shift on data load. Adds content-shaped `PlantGridSkeleton`/`ListSkeleton` (aria-labelled, motion-safe pulse) replacing the spinner on PlantsPage + Dashboard sections.

### 4. `refactor` zod validation i18n
Form schemas hardcoded English at module scope. Converted LoginPage + AddPlantPage to `makeSchema(t)` factories using existing `auth.*` keys + a new `validation.*` namespace (en + es). Initialized i18next in `tests/setup.ts` so component tests resolve real strings.

## Verification
typecheck ✓ · lint (max-warnings 0) ✓ · 167 unit tests ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)