### PR TITLE
fix(infra): drop WAF association — HTTP API v2 unsupported by WAFv2

### DIFF
--- a/infrastructure/modules/security/main.tf
+++ b/infrastructure/modules/security/main.tf
@@ -134,10 +134,13 @@ resource "aws_wafv2_web_acl_logging_configuration" "api" {
   resource_arn            = aws_wafv2_web_acl.api.arn
 }
 
-# Associate the regional web ACL with the API Gateway stage. HTTP API (v2)
-# stages have supported WAFv2 association since 2021 — the previous note
-# claiming otherwise was stale, so the ACL existed but protected nothing.
-resource "aws_wafv2_web_acl_association" "api" {
-  resource_arn = var.api_gateway_stage_arn
-  web_acl_arn  = aws_wafv2_web_acl.api.arn
-}
+# NOTE: WAFv2 CANNOT be associated with an API Gateway *HTTP* API (v2).
+# AWS WAF supports REST API stages, ALB, CloudFront, AppSync, Cognito, and App
+# Runner — but not apigatewayv2 HTTP APIs: AssociateWebACL rejects the
+# `/apis/<id>/stages/<stage>` ARN with WAFInvalidParameterException. (An earlier
+# attempt to associate it here failed in production for exactly this reason.)
+#
+# The regional web ACL above is retained but unassociated. To actually enforce
+# it, front the HTTP API with CloudFront and attach a CLOUDFRONT-scoped ACL
+# there, or migrate the API to a REST API. Until then, edge protection relies on
+# the CloudFront WAF (frontend module) + the API's stage-level throttling.


### PR DESCRIPTION
## What happened
During the production deploy, `aws_wafv2_web_acl_association.api` (added in #8) failed:
```
WAFInvalidParameterException: The ARN isn't valid ... /apis/<id>/stages/production
```
**AWS WAFv2 does not support API Gateway *HTTP* APIs (v2)** — only REST API stages, ALB, CloudFront, AppSync, Cognito, and App Runner. The "stale" comment removed in #8 was actually correct; the audit's premise ("HTTP APIs support WAF since 2021") was wrong.

## Fix
Remove the association resource; document the real constraint and the actual path to enforce the ACL (front the HTTP API with CloudFront + a CLOUDFRONT-scoped ACL, or migrate to a REST API). The regional web ACL is retained but unassociated — **no resource destroyed in prod**; WAF posture is unchanged from before #8 (it was never associated).

The rest of #8/#10 applied cleanly to prod (/health route, Route53 monitor, cost budget, Lambda env vars). `terraform validate` + `fmt` clean.