### PR TITLE
chore(infra): wire CI/CD OIDC role + disable unsafe staging auto-deploy

### DIFF
--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -1,8 +1,18 @@
 name: Deploy to Staging
 
+# ⚠️ DISABLED auto-deploy on push. The Terraform backend uses a single state
+# key (`terraform.tfstate`, no workspace / no per-env key — see backend.tf),
+# so this job's `terraform apply -var-file=staging` runs against the SAME
+# state that holds production. Because resource names embed
+# `${var.environment}`, a staging apply would rename every `-production`
+# resource to `-staging` — i.e. destroy the live Cognito pool / DynamoDB /
+# API / CloudFront. This never fired before only because CD had no AWS creds.
+#
+# DO NOT re-enable `push: main` until staging has an ISOLATED state, e.g.
+# `terraform init -backend-config="key=staging/terraform.tfstate"` in the
+# init step here (and a real, separate staging stack is intended). Left as
+# manual-only so a human who understands the above can still trigger it.
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
 
 concurrency:

--- a/infrastructure/environments/production/terraform.tfvars
+++ b/infrastructure/environments/production/terraform.tfvars
@@ -10,3 +10,10 @@ dmarc_rua_email    = "dmarc@familygreenhouse.net"
 # Perenual: only the secret NAME goes through Terraform. The actual API key
 # was put into Secrets Manager via the AWS CLI and is never tracked by IAC.
 perenual_api_key_secret_id = "family-greenhouse/perenual-api-key"
+
+# CI/CD: provisions the GitHub OIDC provider + deploy role (modules/cicd).
+# The role ARN goes into the AWS_DEPLOY_ROLE_ARN + AWS_PRODUCTION_ROLE_ARN
+# repo secrets. Trust is bound to this repo's main branch + v* tags +
+# the 'production' GitHub environment.
+github_org  = "ChelseaKR"
+github_repo = "family-greenhouse"


### PR DESCRIPTION
Wires up the CD pipeline credentials and fixes a latent catastrophic state-sharing bug surfaced by doing so.

## CI/CD OIDC (applied to prod)
- Set `github_org`/`github_repo` in prod tfvars → `modules/cicd` provisions the GitHub OIDC provider + an AdministratorAccess deploy role (org/repo **user-confirmed**).
- Role ARN set as `AWS_DEPLOY_ROLE_ARN` + `AWS_PRODUCTION_ROLE_ARN` repo secrets → the v\*-tag production pipeline can now authenticate (previously failed at *Configure AWS credentials*).
- Committing the tfvars so `main`'s `var.github_org` stays non-empty — otherwise a `terraform apply` from main computes `count=0` and **destroys** the role.
- `production` GitHub environment created. **Note:** the required-reviewers approval gate needs a GitHub paid plan for private repos (422 on free) — the env exists but is unprotected, so the prod pipeline deploys on tag without a human gate.

## ⚠️ Safety fix: disable staging auto-deploy
The Terraform backend uses a **single** state key shared between staging and production (no workspace / per-env key). `cd-staging` ran `terraform apply -var-file=staging` on `push: main` — which would rename every `-production` resource to `-staging`, **destroying the live Cognito/DynamoDB/API/CloudFront**. It never fired only because CD had no creds (just added). Switched cd-staging to `workflow_dispatch`-only until staging has isolated state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)