### PR TITLE
feat: plant lifecycle (active/died/gave_away) instead of hard delete

### DIFF
--- a/backend/src/handlers/plants/handler.ts
+++ b/backend/src/handlers/plants/handler.ts
@@ -27,11 +27,14 @@ import { s3, IMAGES_BUCKET } from '../../utils/s3.js';
 import { audit } from '../../utils/auditLog.js';
 import { logger } from '../../utils/logger.js';
 
-// GET /plants
+// GET /plants?filter=active|past|all  (default: active)
 export const listPlants = createHandler(
   async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
     const { user } = event as AuthenticatedEvent;
-    const plants = await plantService.getPlants(user.householdId!);
+    const raw = event.queryStringParameters?.filter;
+    const filter: plantService.PlantFilter =
+      raw === 'past' || raw === 'all' ? raw : 'active';
+    const plants = await plantService.getPlants(user.householdId!, filter);
     return successResponse(plants);
   }
 )
@@ -134,6 +137,22 @@ export const updatePlant = createHandler(
 
     if (!plant) {
       throw createHttpError(404, 'Plant not found');
+    }
+
+    // Record the lifecycle outcome on the activity feed (feeds the
+    // plant-survival metric). Best-effort, same as plant.created.
+    if (validatedBody.status === 'died' || validatedBody.status === 'gave_away') {
+      activity
+        .recordActivity({
+          type: validatedBody.status === 'died' ? 'plant.died' : 'plant.gave_away',
+          householdId: user.householdId!,
+          actorId: user.userId,
+          actorName: await cognitoUsers.getUserName(user.userId, user.email),
+          payload: { plantId: plant.id, plantName: plant.name },
+        })
+        .catch((err) => {
+          logger.warn({ err }, 'activity_record_failed');
+        });
     }
 
     return successResponse(plant);

--- a/backend/src/local-server.ts
+++ b/backend/src/local-server.ts
@@ -879,12 +879,15 @@ app.post('/households/join', authMiddleware, (req, res) => {
 
 app.get('/plants', authMiddleware, (req, res) => {
   const user = (req as any).user;
+  const filter = req.query.filter === 'past' || req.query.filter === 'all' ? req.query.filter : 'active';
   const plants: Plant[] = [];
 
   for (const plant of db.plants.values()) {
-    if (plant.householdId === user.householdId) {
-      plants.push(plant);
-    }
+    if (plant.householdId !== user.householdId) continue;
+    const status = plant.status ?? 'active';
+    if (filter === 'active' && status !== 'active') continue;
+    if (filter === 'past' && status === 'active') continue;
+    plants.push(plant);
   }
 
   res.json(plants);
@@ -900,7 +903,9 @@ app.post('/plants', authMiddleware, (req, res) => {
 
   const h = db.households.get(user.householdId);
   const plan = PLANS[h?.planId ?? 'seedling'];
-  const existing = [...db.plants.values()].filter((p) => p.householdId === user.householdId);
+  const existing = [...db.plants.values()].filter(
+    (p) => p.householdId === user.householdId && (p.status ?? 'active') === 'active'
+  );
   if (existing.length >= plan.maxPlants) {
     return res.status(402).json({
       message: `Your ${plan.name} plan is limited to ${plan.maxPlants} plants. Upgrade to add more.`,
@@ -918,6 +923,8 @@ app.post('/plants', authMiddleware, (req, res) => {
     location: location || null,
     imageUrl: null,
     notes: notes || null,
+    status: 'active',
+    statusChangedAt: null,
     tags: Array.isArray(tags)
       ? tags
           .map((t: unknown) => String(t).trim())
@@ -973,7 +980,7 @@ app.put('/plants/:id', authMiddleware, (req, res) => {
     return res.status(404).json({ message: 'Plant not found' });
   }
 
-  const { name, species, location, notes, tags, perenualSpeciesId } = req.body;
+  const { name, species, location, notes, tags, perenualSpeciesId, status } = req.body;
 
   plant.name = name ?? plant.name;
   plant.species = species ?? plant.species;
@@ -989,6 +996,10 @@ app.put('/plants/:id', authMiddleware, (req, res) => {
     plant.perenualSpeciesId = null;
   } else if (typeof perenualSpeciesId === 'number' && perenualSpeciesId > 0) {
     plant.perenualSpeciesId = perenualSpeciesId;
+  }
+  if (status === 'active' || status === 'died' || status === 'gave_away') {
+    plant.status = status;
+    plant.statusChangedAt = new Date().toISOString();
   }
   plant.updatedAt = new Date().toISOString();
 

--- a/backend/src/models/schemas.ts
+++ b/backend/src/models/schemas.ts
@@ -60,6 +60,8 @@ export const createPlantSchema = z.object({
   perenualSpeciesId: z.number().int().positive().optional(),
 });
 
+export const plantStatusEnum = z.enum(['active', 'died', 'gave_away']);
+
 export const updatePlantSchema = z.object({
   name: z.string().min(1).max(100).optional(),
   species: z.string().max(100).optional().nullable(),
@@ -67,6 +69,10 @@ export const updatePlantSchema = z.object({
   notes: z.string().max(1000).optional().nullable(),
   tags: tagsSchema,
   perenualSpeciesId: z.number().int().positive().nullable().optional(),
+  // Lifecycle transition. Setting 'died'/'gave_away' records an outcome
+  // (drops the plant out of active views/cap/reminders, keeps history);
+  // 'active' restores it.
+  status: plantStatusEnum.optional(),
 });
 
 // Task schemas

--- a/backend/src/models/types.ts
+++ b/backend/src/models/types.ts
@@ -43,6 +43,16 @@ export interface HouseholdInvite {
   expiresAt: string;
 }
 
+/**
+ * Plant lifecycle. We don't "delete" a plant you cared for — we record its
+ * outcome, so the history (and the plant-survival metric) survives. `active`
+ * plants are the ones being cared for; `died`/`gave_away` are past outcomes
+ * that drop out of the default list, the plan cap, and the reminder scan but
+ * keep all their history. True hard-delete is reserved for mistakes.
+ * Legacy rows with no `status` are treated as `active`.
+ */
+export type PlantStatus = 'active' | 'died' | 'gave_away';
+
 export interface Plant {
   id: string;
   householdId: string;
@@ -51,6 +61,10 @@ export interface Plant {
   location: string | null;
   imageUrl: string | null;
   notes: string | null;
+  /** Lifecycle status; absent on legacy rows → treated as 'active'. */
+  status: PlantStatus;
+  /** When status last changed (set on died/gave_away/restore). */
+  statusChangedAt?: string | null;
   /** Free-form tags for filtering. Max 10 tags, ≤40 chars each. */
   tags: string[];
   /** Perenual species id, set when the user picks an enrichment-backed

--- a/backend/src/services/activity.ts
+++ b/backend/src/services/activity.ts
@@ -17,6 +17,8 @@ export type ActivityType =
   | 'task.completed'
   | 'plant.created'
   | 'plant.deleted'
+  | 'plant.died'
+  | 'plant.gave_away'
   | 'photo.uploaded'
   | 'member.joined'
   | 'member.left';

--- a/backend/src/services/plantService.ts
+++ b/backend/src/services/plantService.ts
@@ -18,7 +18,7 @@ import {
 import { S3Client, ListObjectsV2Command, DeleteObjectsCommand } from '@aws-sdk/client-s3';
 import { v4 as uuid } from 'uuid';
 import { dynamodb, TABLE_NAME } from '../utils/dynamodb.js';
-import { Plant, DynamoDBItem } from '../models/types.js';
+import { Plant, PlantStatus, DynamoDBItem } from '../models/types.js';
 import { CreatePlantInput, UpdatePlantInput } from '../models/schemas.js';
 import { optionalEnv } from '../utils/env.js';
 import { logger } from '../utils/logger.js';
@@ -45,6 +45,8 @@ export async function createPlant(
     location: input.location || null,
     imageUrl: null,
     notes: input.notes || null,
+    status: 'active',
+    statusChangedAt: null,
     tags,
     perenualSpeciesId: input.perenualSpeciesId ?? null,
     createdAt: now,
@@ -87,6 +89,8 @@ export async function getPlant(householdId: string, plantId: string): Promise<Pl
     location: result.Item.location as string | null,
     imageUrl: result.Item.imageUrl as string | null,
     notes: result.Item.notes as string | null,
+    status: (result.Item.status as PlantStatus | undefined) ?? 'active',
+    statusChangedAt: (result.Item.statusChangedAt as string | null | undefined) ?? null,
     tags: (result.Item.tags as string[] | undefined) ?? [],
     perenualSpeciesId: (result.Item.perenualSpeciesId as number | undefined) ?? null,
     createdAt: result.Item.createdAt as string,
@@ -100,7 +104,20 @@ export async function getPlant(householdId: string, plantId: string): Promise<Pl
 // pagination needs early if a workload trends bigger.
 export const MAX_QUERY_LIMIT = 200;
 
-export async function getPlants(householdId: string): Promise<Plant[]> {
+/**
+ * List a household's plants, filtered by lifecycle.
+ *   - 'active' (default): the plants being cared for — this is what the cap
+ *     counts and the main list shows.
+ *   - 'past': died + gave_away (the history view).
+ *   - 'all': everything.
+ * Filtering is in-memory; a household is capped well under MAX_QUERY_LIMIT.
+ */
+export type PlantFilter = 'active' | 'past' | 'all';
+
+export async function getPlants(
+  householdId: string,
+  filter: PlantFilter = 'active'
+): Promise<Plant[]> {
   const result = await dynamodb.send(
     new QueryCommand({
       TableName: TABLE_NAME,
@@ -113,20 +130,28 @@ export async function getPlants(householdId: string): Promise<Plant[]> {
     })
   );
 
-  return (result.Items || []).map((item) => ({
-    id: item.id as string,
-    householdId: item.householdId as string,
-    name: item.name as string,
-    species: item.species as string | null,
-    location: item.location as string | null,
-    imageUrl: item.imageUrl as string | null,
-    notes: item.notes as string | null,
-    tags: (item.tags as string[] | undefined) ?? [],
-    perenualSpeciesId: (item.perenualSpeciesId as number | undefined) ?? null,
-    createdAt: item.createdAt as string,
-    createdBy: item.createdBy as string,
-    updatedAt: item.updatedAt as string,
-  }));
+  return (result.Items || [])
+    .map((item) => ({
+      id: item.id as string,
+      householdId: item.householdId as string,
+      name: item.name as string,
+      species: item.species as string | null,
+      location: item.location as string | null,
+      imageUrl: item.imageUrl as string | null,
+      notes: item.notes as string | null,
+      status: (item.status as PlantStatus | undefined) ?? 'active',
+      statusChangedAt: (item.statusChangedAt as string | null | undefined) ?? null,
+      tags: (item.tags as string[] | undefined) ?? [],
+      perenualSpeciesId: (item.perenualSpeciesId as number | undefined) ?? null,
+      createdAt: item.createdAt as string,
+      createdBy: item.createdBy as string,
+      updatedAt: item.updatedAt as string,
+    }))
+    .filter((p) => {
+      if (filter === 'all') return true;
+      if (filter === 'past') return p.status !== 'active';
+      return p.status === 'active';
+    });
 }
 
 export async function updatePlant(
@@ -178,6 +203,14 @@ export async function updatePlant(
     expressionAttributeValues[':perenualSpeciesId'] = input.perenualSpeciesId;
   }
 
+  if (input.status !== undefined) {
+    updateExpressions.push('#status = :status', '#statusChangedAt = :statusChangedAt');
+    expressionAttributeNames['#status'] = 'status';
+    expressionAttributeNames['#statusChangedAt'] = 'statusChangedAt';
+    expressionAttributeValues[':status'] = input.status;
+    expressionAttributeValues[':statusChangedAt'] = new Date().toISOString();
+  }
+
   updateExpressions.push('#updatedAt = :updatedAt');
   expressionAttributeNames['#updatedAt'] = 'updatedAt';
   expressionAttributeValues[':updatedAt'] = new Date().toISOString();
@@ -209,6 +242,8 @@ export async function updatePlant(
     location: result.Attributes.location as string | null,
     imageUrl: result.Attributes.imageUrl as string | null,
     notes: result.Attributes.notes as string | null,
+    status: (result.Attributes.status as PlantStatus | undefined) ?? 'active',
+    statusChangedAt: (result.Attributes.statusChangedAt as string | null | undefined) ?? null,
     tags: (result.Attributes.tags as string[] | undefined) ?? [],
     perenualSpeciesId: (result.Attributes.perenualSpeciesId as number | undefined) ?? null,
     createdAt: result.Attributes.createdAt as string,
@@ -285,6 +320,8 @@ export async function deletePlant(householdId: string, plantId: string): Promise
         location: (item.location as string | null | undefined) ?? null,
         imageUrl: (item.imageUrl as string | null | undefined) ?? null,
         notes: (item.notes as string | null | undefined) ?? null,
+        status: (item.status as PlantStatus | undefined) ?? 'active',
+        statusChangedAt: (item.statusChangedAt as string | null | undefined) ?? null,
         tags: (item.tags as string[] | undefined) ?? [],
         perenualSpeciesId: (item.perenualSpeciesId as number | null | undefined) ?? null,
         createdAt: item.createdAt as string,

--- a/backend/src/services/reminders.ts
+++ b/backend/src/services/reminders.ts
@@ -12,6 +12,7 @@
  */
 import * as householdService from './householdService.js';
 import * as taskService from './taskService.js';
+import * as plantService from './plantService.js';
 import * as notifier from './notifier.js';
 
 const DUE_WINDOW_MS = 24 * 60 * 60 * 1000;
@@ -29,10 +30,15 @@ export async function remindHousehold(
   const nowIso = now.toISOString();
   const cutoff = new Date(now.getTime() + DUE_WINDOW_MS).toISOString();
 
+  // Don't remind about plants that are no longer active (died / gave away).
+  // getPlants defaults to active-only, so any task whose plant isn't in this
+  // set belongs to a past plant and is skipped.
+  const activePlantIds = new Set((await plantService.getPlants(householdId)).map((p) => p.id));
+
   let sent = 0;
   for (const member of members) {
     const tasks = await taskService.getTasks(householdId, { assignedTo: member.userId });
-    const due = tasks.filter((t) => t.nextDue <= cutoff);
+    const due = tasks.filter((t) => t.nextDue <= cutoff && activePlantIds.has(t.plantId));
     if (due.length === 0) continue;
 
     const overdue = due.filter((t) => t.nextDue < nowIso).length;

--- a/backend/tests/unit/handlers/plants.test.ts
+++ b/backend/tests/unit/handlers/plants.test.ts
@@ -83,7 +83,7 @@ describe('plants handler', () => {
     expect(res.statusCode).toBe(200);
     const body = JSON.parse(res.body);
     expect(body).toHaveLength(1);
-    expect(plantService.getPlants).toHaveBeenCalledWith('hh-1');
+    expect(plantService.getPlants).toHaveBeenCalledWith('hh-1', 'active');
   });
 
   it('listPlants returns 403 when user has no household', async () => {

--- a/backend/tests/unit/services/plantService.test.ts
+++ b/backend/tests/unit/services/plantService.test.ts
@@ -96,10 +96,17 @@ describe('plantService', () => {
 
       const result = await getPlant('household-123', 'plant-123');
 
-      // Service hydrates a `tags` array (defaulting to []) and a
-      // perenualSpeciesId (defaulting to null) so the response shape stays
-      // stable for clients that always expect the fields.
-      expect(result).toEqual({ ...mockPlant, tags: [], perenualSpeciesId: null });
+      // Service hydrates a `tags` array (defaulting to []), a
+      // perenualSpeciesId (defaulting to null), and the lifecycle status
+      // (legacy rows with no status hydrate to 'active') so the response
+      // shape stays stable for clients that always expect the fields.
+      expect(result).toEqual({
+        ...mockPlant,
+        tags: [],
+        perenualSpeciesId: null,
+        status: 'active',
+        statusChangedAt: null,
+      });
     });
 
     it('should return null if plant not found', async () => {
@@ -297,6 +304,27 @@ describe('plantService', () => {
       const result = await getPlants('household-123');
 
       expect(result).toEqual([]);
+    });
+
+    it('filters by lifecycle status (legacy rows count as active)', async () => {
+      const { dynamodb } = await import('../../../src/utils/dynamodb');
+      const { getPlants } = await import('../../../src/services/plantService');
+
+      const rows = [
+        { id: 'a', name: 'Active', householdId: 'h' }, // no status → active
+        { id: 'b', name: 'Explicit', householdId: 'h', status: 'active' },
+        { id: 'c', name: 'Dead', householdId: 'h', status: 'died' },
+        { id: 'd', name: 'Gifted', householdId: 'h', status: 'gave_away' },
+      ];
+      // One mock per call (default active, then past, then all).
+      vi.mocked(dynamodb.send)
+        .mockResolvedValueOnce({ Items: rows })
+        .mockResolvedValueOnce({ Items: rows })
+        .mockResolvedValueOnce({ Items: rows });
+
+      expect((await getPlants('h')).map((p) => p.id)).toEqual(['a', 'b']);
+      expect((await getPlants('h', 'past')).map((p) => p.id)).toEqual(['c', 'd']);
+      expect((await getPlants('h', 'all')).map((p) => p.id)).toEqual(['a', 'b', 'c', 'd']);
     });
   });
 });

--- a/backend/tests/unit/services/reminders.test.ts
+++ b/backend/tests/unit/services/reminders.test.ts
@@ -7,9 +7,19 @@ vi.mock('../../../src/services/householdService.js', () => ({
 vi.mock('../../../src/services/taskService.js', () => ({
   getTasks: vi.fn(),
 }));
+vi.mock('../../../src/services/plantService.js', () => ({
+  getPlants: vi.fn(),
+}));
 vi.mock('../../../src/services/notifier.js', () => ({
   sendToUser: vi.fn(),
 }));
+
+// Default: every household has one active plant 'p1' so task fixtures (which
+// reference plantId 'p1') aren't filtered out as belonging to a past plant.
+async function mockActivePlants(ids: string[] = ['p1']) {
+  const plants = await import('../../../src/services/plantService.js');
+  vi.mocked(plants.getPlants).mockResolvedValue(ids.map((id) => ({ id })) as never);
+}
 
 const NOW = new Date('2026-06-01T12:00:00.000Z');
 const soon = new Date(NOW.getTime() + 60 * 60 * 1000).toISOString(); // +1h
@@ -39,10 +49,14 @@ describe('reminders service', () => {
     vi.mocked(tasks.getTasks).mockImplementation((_hh, filters) => {
       // u1 has one overdue + one due-soon; u2 has only a far-future task.
       if ((filters as { assignedTo?: string })?.assignedTo === 'u1') {
-        return Promise.resolve([{ nextDue: past }, { nextDue: soon }] as never);
+        return Promise.resolve([
+          { nextDue: past, plantId: 'p1' },
+          { nextDue: soon, plantId: 'p1' },
+        ] as never);
       }
-      return Promise.resolve([{ nextDue: farFuture }] as never);
+      return Promise.resolve([{ nextDue: farFuture, plantId: 'p1' }] as never);
     });
+    await mockActivePlants(['p1']);
 
     const sent = await remindHousehold('hh', NOW);
     expect(sent).toBe(1);
@@ -50,6 +64,24 @@ describe('reminders service', () => {
     const [recipient, payload] = vi.mocked(notifier.sendToUser).mock.calls[0];
     expect(recipient).toEqual({ userId: 'u1', email: 'a@x.com' });
     expect((payload as { body: string }).body).toBe('1 overdue, 1 due soon');
+  });
+
+  it('skips tasks belonging to non-active (died/gave-away) plants', async () => {
+    const household = await import('../../../src/services/householdService.js');
+    const tasks = await import('../../../src/services/taskService.js');
+    const notifier = await import('../../../src/services/notifier.js');
+    const { remindHousehold } = await import('../../../src/services/reminders.js');
+
+    vi.mocked(household.getHouseholdMembers).mockResolvedValue([
+      { householdId: 'hh', userId: 'u1', name: 'A', email: 'a@x.com', role: 'admin', joinedAt: '' },
+    ] as never);
+    // Due task, but its plant is not in the active set → no reminder.
+    vi.mocked(tasks.getTasks).mockResolvedValue([{ nextDue: past, plantId: 'dead-plant' }] as never);
+    await mockActivePlants(['p1']); // 'dead-plant' is absent
+
+    const sent = await remindHousehold('hh', NOW);
+    expect(sent).toBe(0);
+    expect(notifier.sendToUser).not.toHaveBeenCalled();
   });
 
   it('remindAllHouseholds scans every household and survives one failing', async () => {
@@ -72,7 +104,8 @@ describe('reminders service', () => {
         },
       ] as never);
     });
-    vi.mocked(tasks.getTasks).mockResolvedValue([{ nextDue: soon }] as never);
+    vi.mocked(tasks.getTasks).mockResolvedValue([{ nextDue: soon, plantId: 'p1' }] as never);
+    await mockActivePlants(['p1']);
 
     const result = await remindAllHouseholds(NOW);
     // …but hhB is still processed.

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -40,7 +40,7 @@ export function CommandPalette() {
 
   const { data: plants } = useQuery({
     queryKey: ['plants'],
-    queryFn: plantService.getPlants,
+    queryFn: () => plantService.getPlants(),
     enabled: isAuthenticated && open,
   });
 

--- a/frontend/src/features/analytics/AnalyticsPage.tsx
+++ b/frontend/src/features/analytics/AnalyticsPage.tsx
@@ -72,7 +72,7 @@ export function AnalyticsPage() {
 
   const { data: plants } = useQuery({
     queryKey: ['plants'],
-    queryFn: plantService.getPlants,
+    queryFn: () => plantService.getPlants(),
     enabled: !!householdId,
   });
 

--- a/frontend/src/features/dashboard/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/DashboardPage.tsx
@@ -99,7 +99,7 @@ export function DashboardPage() {
     error: plantsError,
   } = useQuery({
     queryKey: ['plants'],
-    queryFn: plantService.getPlants,
+    queryFn: () => plantService.getPlants(),
   });
 
   useOverdueAlerts(upcomingTasks);

--- a/frontend/src/features/plants/BulkApplyTemplateDialog.tsx
+++ b/frontend/src/features/plants/BulkApplyTemplateDialog.tsx
@@ -27,7 +27,7 @@ export function BulkApplyTemplateDialog({ isOpen, onClose }: BulkApplyTemplateDi
 
   const { data: plants } = useQuery({
     queryKey: ['plants'],
-    queryFn: plantService.getPlants,
+    queryFn: () => plantService.getPlants(),
     enabled: isOpen,
   });
 

--- a/frontend/src/features/plants/PlantDetailPage.tsx
+++ b/frontend/src/features/plants/PlantDetailPage.tsx
@@ -28,6 +28,7 @@ import { CareGuidanceCard } from './CareGuidanceCard';
 import { CareGuideCard } from './CareGuideCard';
 import { CareReportCard } from './CareReportCard';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
+import { RemovePlantDialog } from './RemovePlantDialog';
 import clsx from 'clsx';
 import { taskTypeLabels, taskTypeStyle } from '@/utils/taskTypeConfig';
 import { toast } from '@/store/toastStore';
@@ -48,6 +49,7 @@ export function PlantDetailPage() {
   const [showAddTask, setShowAddTask] = useState(false);
   const [showEditPlant, setShowEditPlant] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [showRemove, setShowRemove] = useState(false);
   const [editingTask, setEditingTask] = useState<Task | null>(null);
 
   const {
@@ -70,6 +72,24 @@ export function PlantDetailPage() {
       queryClient.invalidateQueries({ queryKey: ['plants'] });
       toast.success('Plant deleted');
       navigate('/plants');
+    },
+    onError: (err) => toast.error(getErrorMessage(err)),
+  });
+
+  const statusMutation = useMutation({
+    mutationFn: (status: 'active' | 'died' | 'gave_away') =>
+      plantService.setPlantStatus(plantId!, status),
+    onSuccess: (_data, status) => {
+      queryClient.invalidateQueries({ queryKey: ['plants'] });
+      queryClient.invalidateQueries({ queryKey: ['plants', plantId] });
+      setShowRemove(false);
+      if (status === 'active') {
+        toast.success('Plant restored');
+      } else {
+        // It's left the active list — back to the (active) plants view.
+        toast.success(status === 'died' ? 'Recorded as died' : 'Recorded as given away');
+        navigate('/plants');
+      }
     },
     onError: (err) => toast.error(getErrorMessage(err)),
   });
@@ -169,7 +189,19 @@ export function PlantDetailPage() {
         <div className="flex-1">
           <div className="flex items-start justify-between">
             <div>
-              <h1 className="text-2xl font-bold text-gray-900">{plant.name}</h1>
+              <div className="flex items-center gap-2">
+                <h1 className="text-2xl font-bold text-gray-900">{plant.name}</h1>
+                {plant.status === 'died' && (
+                  <span className="inline-flex items-center rounded-full bg-stone-100 px-2.5 py-0.5 text-xs font-medium text-stone-700">
+                    Died
+                  </span>
+                )}
+                {plant.status === 'gave_away' && (
+                  <span className="inline-flex items-center rounded-full bg-sky-50 px-2.5 py-0.5 text-xs font-medium text-sky-900 ring-1 ring-sky-200/70">
+                    Gave away
+                  </span>
+                )}
+              </div>
               {plant.species && <p className="text-lg text-gray-500 italic">{plant.species}</p>}
             </div>
             <div className="flex gap-2">
@@ -181,14 +213,25 @@ export function PlantDetailPage() {
               >
                 Edit
               </Button>
-              <Button
-                variant="danger"
-                size="sm"
-                onClick={() => setShowDeleteConfirm(true)}
-                leftIcon={<TrashIcon className="h-4 w-4" aria-hidden="true" />}
-              >
-                Delete
-              </Button>
+              {(plant.status ?? 'active') === 'active' ? (
+                <Button
+                  variant="danger"
+                  size="sm"
+                  onClick={() => setShowRemove(true)}
+                  leftIcon={<TrashIcon className="h-4 w-4" aria-hidden="true" />}
+                >
+                  Remove
+                </Button>
+              ) : (
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => statusMutation.mutate('active')}
+                  isLoading={statusMutation.isPending}
+                >
+                  Restore
+                </Button>
+              )}
             </div>
           </div>
 
@@ -300,12 +343,26 @@ export function PlantDetailPage() {
         <EditTaskModal task={editingTask} isOpen={true} onClose={() => setEditingTask(null)} />
       )}
 
+      <RemovePlantDialog
+        isOpen={showRemove}
+        plantName={plant.name}
+        isLoading={statusMutation.isPending || deleteMutation.isPending}
+        onClose={() => setShowRemove(false)}
+        onDied={() => statusMutation.mutate('died')}
+        onGaveAway={() => statusMutation.mutate('gave_away')}
+        onDelete={() => {
+          // Permanent delete gets a second, explicit confirm.
+          setShowRemove(false);
+          setShowDeleteConfirm(true);
+        }}
+      />
+
       <ConfirmDialog
         isOpen={showDeleteConfirm}
         onClose={() => setShowDeleteConfirm(false)}
         onConfirm={() => deleteMutation.mutate()}
         title="Delete plant"
-        message={`Are you sure you want to delete "${plant.name}"? This will also delete all associated tasks and history.`}
+        message={`Are you sure you want to delete "${plant.name}"? This permanently removes the plant and all its tasks and history. Use "It died" or "I gave it away" instead if you want to keep the record.`}
         confirmLabel="Delete"
         isLoading={deleteMutation.isPending}
       />

--- a/frontend/src/features/plants/PlantsPage.tsx
+++ b/frontend/src/features/plants/PlantsPage.tsx
@@ -29,14 +29,18 @@ export function PlantsPage() {
   const [viewMode, setViewMode] = useState<ViewMode>('grid');
   const [searchQuery, setSearchQuery] = useState('');
   const [bulkOpen, setBulkOpen] = useState(false);
+  // 'active' is the default living collection; 'past' shows died/gave-away
+  // plants whose history we keep. Active stays under the bare ['plants'] key
+  // so existing invalidations + the add-flow's cache read keep working.
+  const [view, setView] = useState<'active' | 'past'>('active');
 
   const {
     data: plants,
     isLoading,
     error,
   } = useQuery({
-    queryKey: ['plants'],
-    queryFn: plantService.getPlants,
+    queryKey: view === 'active' ? ['plants'] : ['plants', 'past'],
+    queryFn: () => plantService.getPlants(view),
   });
 
   const filteredPlants = plants?.filter(
@@ -71,6 +75,27 @@ export function PlantsPage() {
       />
 
       <BulkApplyTemplateDialog isOpen={bulkOpen} onClose={() => setBulkOpen(false)} />
+
+      {/* Active vs past (died / gave away) collection */}
+      <div className="flex gap-1 border-b border-primary-100/70" role="tablist" aria-label="Plant collection">
+        {(['active', 'past'] as const).map((v) => (
+          <button
+            key={v}
+            type="button"
+            role="tab"
+            aria-selected={view === v}
+            onClick={() => setView(v)}
+            className={clsx(
+              '-mb-px border-b-2 px-3 py-2 text-sm font-medium min-h-touch',
+              view === v
+                ? 'border-primary-600 text-primary-800'
+                : 'border-transparent text-gray-500 hover:text-gray-700'
+            )}
+          >
+            {v === 'active' ? 'Active' : 'Past plants'}
+          </button>
+        ))}
+      </div>
 
       {/* Search and filters */}
       <div className="flex flex-col sm:flex-row gap-4">

--- a/frontend/src/features/plants/RemovePlantDialog.tsx
+++ b/frontend/src/features/plants/RemovePlantDialog.tsx
@@ -1,0 +1,114 @@
+import { Fragment } from 'react';
+import { Dialog, Transition } from '@headlessui/react';
+import { Button } from '@/components/Button';
+
+interface RemovePlantDialogProps {
+  isOpen: boolean;
+  plantName: string;
+  isLoading?: boolean;
+  onClose: () => void;
+  /** Record an outcome — keeps history, removes from active views, restorable. */
+  onDied: () => void;
+  onGaveAway: () => void;
+  /** Permanent hard delete — for mistakes/duplicates. Cannot be undone. */
+  onDelete: () => void;
+}
+
+/**
+ * Removing a plant you cared for isn't a single "delete" — we ask what
+ * happened so the history (and the plant-survival metric) survives. "It died"
+ * and "I gave it away" record an outcome and can be undone; "Delete
+ * permanently" is the irreversible escape hatch for mistakes/duplicates.
+ */
+export function RemovePlantDialog({
+  isOpen,
+  plantName,
+  isLoading = false,
+  onClose,
+  onDied,
+  onGaveAway,
+  onDelete,
+}: RemovePlantDialogProps) {
+  return (
+    <Transition.Root show={isOpen} as={Fragment}>
+      <Dialog as="div" className="relative z-50" onClose={onClose}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-gray-500/75 transition-opacity" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 z-10 overflow-y-auto">
+          <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+              enterTo="opacity-100 translate-y-0 sm:scale-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100 translate-y-0 sm:scale-100"
+              leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+            >
+              <Dialog.Panel className="relative w-full transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:max-w-lg sm:p-6">
+                <Dialog.Title
+                  as="h3"
+                  className="font-serif text-xl font-semibold leading-tight tracking-tight text-gray-900"
+                >
+                  Remove {plantName}?
+                </Dialog.Title>
+                <p className="mt-2 text-sm leading-relaxed text-gray-600">
+                  Tell us what happened. Recording an outcome keeps this plant&apos;s history and
+                  you can restore it later.
+                </p>
+
+                <div className="mt-5 flex flex-col gap-2">
+                  <Button
+                    variant="secondary"
+                    onClick={onGaveAway}
+                    disabled={isLoading}
+                    className="w-full justify-center"
+                  >
+                    I gave it away
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    onClick={onDied}
+                    disabled={isLoading}
+                    className="w-full justify-center"
+                  >
+                    It died
+                  </Button>
+                  <button
+                    type="button"
+                    onClick={onDelete}
+                    disabled={isLoading}
+                    className="mt-1 text-sm text-red-700 underline underline-offset-2 hover:text-red-800 disabled:opacity-50 min-h-touch"
+                  >
+                    Delete permanently (this can&apos;t be undone)
+                  </button>
+                </div>
+
+                <div className="mt-5 sm:mt-4">
+                  <button
+                    type="button"
+                    onClick={onClose}
+                    disabled={isLoading}
+                    className="w-full text-sm text-gray-600 hover:text-gray-800 disabled:opacity-50 min-h-touch"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition.Root>
+  );
+}

--- a/frontend/src/services/plantService.ts
+++ b/frontend/src/services/plantService.ts
@@ -1,6 +1,11 @@
 import { api } from './api';
 import { track } from './analytics';
 
+export type PlantStatus = 'active' | 'died' | 'gave_away';
+
+/** List filter mirroring the backend: active (default), past, or all. */
+export type PlantFilter = 'active' | 'past' | 'all';
+
 export interface Plant {
   id: string;
   householdId: string;
@@ -9,6 +14,9 @@ export interface Plant {
   location: string | null;
   imageUrl: string | null;
   notes: string | null;
+  /** Lifecycle status; legacy rows may omit it → treat as 'active'. */
+  status?: PlantStatus;
+  statusChangedAt?: string | null;
   tags?: string[];
   perenualSpeciesId?: number | null;
   createdAt: string;
@@ -32,6 +40,7 @@ export interface UpdatePlantData {
   notes?: string;
   tags?: string[];
   perenualSpeciesId?: number | null;
+  status?: PlantStatus;
 }
 
 export interface PlantWithTasks extends Plant {
@@ -80,8 +89,14 @@ export interface PlantPhoto {
 }
 
 export const plantService = {
-  async getPlants(): Promise<Plant[]> {
-    const response = await api.get<Plant[]>('/plants');
+  async getPlants(filter: PlantFilter = 'active'): Promise<Plant[]> {
+    const response = await api.get<Plant[]>('/plants', { params: { filter } });
+    return response.data;
+  },
+
+  /** Record a lifecycle outcome (died / gave_away) or restore to active. */
+  async setPlantStatus(id: string, status: PlantStatus): Promise<Plant> {
+    const response = await api.put<Plant>(`/plants/${id}`, { status });
     return response.data;
   },
 

--- a/frontend/tests/unit/features/RemovePlantDialog.test.tsx
+++ b/frontend/tests/unit/features/RemovePlantDialog.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { RemovePlantDialog } from '@/features/plants/RemovePlantDialog';
+
+function setup() {
+  const onClose = vi.fn();
+  const onDied = vi.fn();
+  const onGaveAway = vi.fn();
+  const onDelete = vi.fn();
+  render(
+    <RemovePlantDialog
+      isOpen
+      plantName="Monstera"
+      onClose={onClose}
+      onDied={onDied}
+      onGaveAway={onGaveAway}
+      onDelete={onDelete}
+    />
+  );
+  return { onClose, onDied, onGaveAway, onDelete };
+}
+
+describe('RemovePlantDialog', () => {
+  it('offers the three outcomes and names the plant', () => {
+    setup();
+    expect(screen.getByText('Remove Monstera?')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /i gave it away/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /it died/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /delete permanently/i })).toBeInTheDocument();
+  });
+
+  it('routes each choice to the right handler', async () => {
+    const user = userEvent.setup();
+    const { onDied, onGaveAway, onDelete } = setup();
+
+    await user.click(screen.getByRole('button', { name: /it died/i }));
+    expect(onDied).toHaveBeenCalledOnce();
+
+    await user.click(screen.getByRole('button', { name: /i gave it away/i }));
+    expect(onGaveAway).toHaveBeenCalledOnce();
+
+    await user.click(screen.getByRole('button', { name: /delete permanently/i }));
+    expect(onDelete).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
Implements the lifecycle/status model we chose over a generic soft-delete: you don't *delete* a plant you cared for, you record its **outcome**, so the history — and the plant-survival north-star metric — survives.

## Behaviour
- A plant has a `status`: `active` (default), `died`, or `gave_away`. Legacy rows with no status hydrate to `active`.
- `died` / `gave_away` plants drop out of: the **active list**, the **plan cap** (the cap counts `getPlants()`, now active-only), and the **reminder scan** (their tasks are skipped). Their history is **kept**, and they're **restorable** (set back to active).
- **Hard delete still exists** for genuine mistakes/duplicates — behind a second confirm.

## API (no new routes — Lambda-code deploy only)
- `PUT /plants/{id}` accepts `status` (sets `statusChangedAt`, posts a `plant.died`/`plant.gave_away` activity event).
- `GET /plants?filter=active|past|all` (default `active`).

## Frontend
- **PlantDetailPage**: status badge; a **Remove** dialog offering *It died* / *I gave it away* / *Delete permanently*; a **Restore** action for past plants.
- **PlantsPage**: **Active / Past plants** tabs.
- `plantService.setPlantStatus` + a `filter` arg; fixed 4 call sites that passed `getPlants` bare as a queryFn.

## Verification
backend 367 unit + 83 integration ✓ · frontend 169 (+3 new) ✓ · typecheck/lint ✓ · api-spec drift ✓ · local-server mirrored for dev parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)