### PR TITLE
feat(growth): Claude prompt library + programmatic species care pages

### DIFF
--- a/docs/growth/prompts/01-editorial-pipeline.md
+++ b/docs/growth/prompts/01-editorial-pipeline.md
@@ -1,0 +1,45 @@
+# Editorial pipeline — the weekly long-form
+
+Four prompts, run in order. Targets emotional/situational queries (the ICP who just killed a plant), not generic "how to care for X" (that's the species-page generator's job). ~3.5 human hours per article; the edit pass is where it earns its keep.
+
+---
+
+## Step 1 — Topic discovery
+
+> Give me 20 long-tail search queries someone who has *just realized they forgot to water a plant* (or whose plant is dying) would type into Google. I run a collaborative plant-care app for households, so I especially want queries with **emotional or situational** intent, and queries about **shared/household** plant care. Skip generic "how to care for [plant]" — those are handled elsewhere. For each, add a one-word intent tag (panic / guilt / logistics / relationship / comparison) and a rough monthly-volume guess (high / med / low). Rank by (intent strength × my ability to genuinely help).
+
+Pick one. Favor high-intent over high-volume.
+
+---
+
+## Step 2 — Outline
+
+> Outline a 1800–2200 word article for the search query **"[QUERY]"**.
+> Context: it publishes on the blog of Family Greenhouse, a collaborative plant-care app for households (couples, roommates, families). Differentiator: the *right person reminded at the right time*, not a fancier plant database.
+> Requirements: 6–7 H2 sections, a contrarian or counterintuitive angle in the first third, at least two specific examples using real plant names and real numbers (watering intervals, etc.), and one section that only makes sense for a *household* (not a solo plant owner). End with a tight, non-salesy conclusion. NO filler sections ("introduction", "why this matters", "conclusion" as a heading). For each section, one line on what it argues.
+
+Kill the generic sections. Add your own angle.
+
+---
+
+## Step 3 — Draft
+
+> Write the full ~2000-word draft from the outline above.
+> Voice: warm, practical, never preachy — "the friend who reminds you the plant is wilting, not the one lecturing about chlorophyll." First person ("I", "my") is good. Short paragraphs. Specific over abstract.
+> Hard bans (AI tells): "in today's world", "embark on a journey", "unlock", "elevate", "dive into", "it's worth noting", "navigate the world of". Don't open three consecutive sentences with the same cadence. Don't end every section with a tidy summary line.
+> Include one place marked `[ANECDOTE]` where I should drop a personal story, and one `[OPINION]` where I should add a real take.
+> Output as TSX matching the existing blog posts: a default-export React component returning `<article className="prose-fg">` with `<h2>`/`<h3>`/`<p>` — see `frontend/src/features/blog/posts/remembering-to-water.tsx`. Use `&rsquo;` / `&ldquo;` / `&rdquo;` for punctuation.
+
+---
+
+## Step 4 — Edit (run on YOUR rewritten draft, not the raw one)
+
+> Here's my edited draft. Be a skeptical editor:
+> 1. Three specific things to cut (quote them).
+> 2. One place the voice sounds fake or AI-generated (quote it, say why).
+> 3. One section that's asserting without evidence — what concrete example would fix it.
+> 4. Is the contrarian angle actually contrarian, or is it the obvious take dressed up?
+> 5. The title and meta description: give me 3 options each, optimized for the target query, under 60 / 155 chars.
+> Don't rewrite it for me — tell me what to fix.
+
+Then: write the `POSTS` entry (slug/title/description/date/readingMinutes) and add it to `frontend/src/features/blog/posts/index.ts`.

--- a/docs/growth/prompts/02-species-care-page.md
+++ b/docs/growth/prompts/02-species-care-page.md
@@ -1,0 +1,71 @@
+# Species care page — the scale lever ⭐
+
+Generates one grounded care page per species. Targets "how often to water [plant]", "[plant] care", "why is my [plant] dying". This is the prompt the **batch generator** runs over the catalog; it's also fine to run by hand.
+
+The discipline that makes this work (and keeps Google happy): **the model writes prose, but every fact comes from the data you paste in.** Run it with real data from your catalog / Perenual — never let it recall watering numbers from memory.
+
+---
+
+## The prompt
+
+> You are writing a care page for the houseplant below for Family Greenhouse, a collaborative plant-care app for households. Output a JSON object matching the `CareGuide` type at the end.
+>
+> **Grounding rule (non-negotiable):** every factual claim — watering interval, light, toxicity, difficulty, humidity, common problems — must come from the DATA block. If a field is absent, omit the section that needs it. Do **not** supply numbers or claims from your own knowledge. When unsure, write less.
+>
+> **Voice:** warm, practical, never preachy — the friend who reminds you the plant's wilting, not the one lecturing about chlorophyll. Plain words. Specific numbers from the data. Light humor only in the `honestBit`, never in the care instructions a worried owner is reading. Bans: "in today's world", "unlock", "elevate", "dive into", "lush green companion", "thrive in your space".
+>
+> **The differentiator you must weave in once, naturally:** this plant's care is easy to *know* and easy to *forget* — and in a shared home the failure mode is "I thought you watered it." One section (`sharedCare`) should address keeping the plant alive when more than one person lives there. Don't make it an ad; make it genuinely useful.
+>
+> **SEO:** the `faqs` (3–4) should answer the actual long-tail questions people type ("how often", "why yellow leaves", "is it toxic to cats", "how much light"). Keep each answer 1–3 sentences, grounded.
+>
+> DATA:
+> ```
+> commonName: [e.g. Pothos]
+> alsoKnownAs: [Devil's Ivy, Epipremnum aureum]
+> scientificName: [Epipremnum aureum]
+> wateringIntervalDays: [e.g. 7-10]
+> light: [e.g. bright indirect; tolerates low]
+> difficulty: [e.g. very easy]
+> toxicity: [e.g. toxic to cats and dogs if ingested]
+> humidity: [average household is fine]
+> commonProblems: [yellow leaves = overwatering; brown crispy tips = underwatering/low humidity; leggy = too little light]
+> notes: [any extra grounded facts]
+> ```
+>
+> Output ONLY this JSON (no prose around it):
+> ```ts
+> {
+>   slug: string,            // kebab-case, e.g. "pothos"
+>   commonName: string,
+>   scientificName: string,
+>   alsoKnownAs: string[],
+>   metaTitle: string,       // <60 chars, includes the common name + "care"
+>   metaDescription: string, // <155 chars, includes "how often to water"
+>   summary: string,         // 1-2 sentence lead
+>   quickFacts: {            // grounded, for the at-a-glance table
+>     water: string, light: string, difficulty: string,
+>     toxicity: string, humidity: string,
+>   },
+>   sections: {              // 2-4 short paragraphs each, markdown-free plain prose
+>     watering: string,      // "how often to water" — the headline query
+>     light: string,
+>     problems: string,      // "why is my [plant] dying"
+>     sharedCare: string,    // the household angle
+>     honestBit: string,     // founder voice, one real opinion, light humor ok
+>   },
+>   faqs: { q: string, a: string }[],
+> }
+> ```
+
+---
+
+## After generation
+
+- Paste the JSON into `frontend/src/features/care/careGuides.ts`.
+- **Review for accuracy first** — spot-check the watering interval and toxicity against the source data. These are the two fields a wrong answer does real harm (a pet owner trusts the toxicity line).
+- Rewrite `honestBit` in your own voice if it's bland — that's the section that signals a human wrote this.
+- Confirm the page renders at `/care/[slug]` and the FAQ schema validates ([Rich Results Test](https://search.google.com/test/rich-results)).
+
+## Picking which species to generate first
+
+Order by **search volume**, not catalog order. The ~150 most-owned houseplants (pothos, snake plant, monstera, peace lily, ZZ, philodendron, fiddle leaf, spider, aloe, succulents…) are 90% of the traffic. Do those, confirm they index, then decide whether the long tail is worth it.

--- a/docs/growth/prompts/03-repurpose.md
+++ b/docs/growth/prompts/03-repurpose.md
@@ -1,0 +1,25 @@
+# Repurpose & distribute
+
+One article → four distribution assets in one prompt. Amortizes the writing cost across channels. Cheap-model-friendly.
+
+---
+
+## The prompt
+
+> Below is a published article. Produce four repurposed assets from it. Keep my voice (warm, practical, not salesy). No hashtags-as-personality, no "🧵 1/", no growth-hack tone.
+>
+> 1. **Tweet thread** (3–5 tweets): the single most useful idea, not a summary. The first tweet must stand alone and earn the click. Last tweet links the article. No "a thread:".
+> 2. **Reddit value-comment** (~120 words): written for r/houseplants as a genuine reply to someone with this problem. Pure value, NO link, NO product mention — the kind of comment that gets upvoted. (I'll only link if someone asks.)
+> 3. **Newsletter paragraph** (~90 words): for a biweekly email to early-access subscribers. Friendly, one concrete takeaway, soft line about what we're building.
+> 4. **Cross-link block**: which 2 of my other articles/care pages this should link to, and the one-line anchor text for each.
+>
+> ARTICLE:
+> ```
+> [paste]
+> ```
+
+## Rules of the road (so this doesn't get you banned)
+
+- **Reddit:** comment 80%, post 20%. Build karma first. One *earned* product mention per week max. If it feels like a chore, stop — performative Reddit is worse than none. (Your `marketing-plan.md` already says this.)
+- **Twitter:** only if you'd genuinely enjoy posting 2–3×/week. Otherwise skip.
+- **Newsletter:** publish biweekly, not weekly — an empty cadence is worse than a slower one.

--- a/docs/growth/prompts/04-research-synthesis.md
+++ b/docs/growth/prompts/04-research-synthesis.md
@@ -1,0 +1,29 @@
+# Research synthesis
+
+Your strategy doc's #1 priority is real telemetry from the first users. This turns raw signup replies (the "what made you sign up?" email) into a prioritized, decision-ready summary — the highest-leverage use of Claude in the whole plan, because it directly reorders the roadmap.
+
+---
+
+## The prompt
+
+> Below are [N] replies from new users answering "What made you sign up, and what would make this a no-brainer for you?" Synthesize, don't summarize.
+>
+> 1. **Themes**, ranked by frequency — for each: the theme, how many users, and a representative verbatim quote.
+> 2. **The job they're hiring us for** — in their words, not mine. Is it "remember to water" or "stop fighting with my partner about chores" or something I didn't expect?
+> 3. **Friction**: where did people say (or imply) they almost didn't sign up / almost gave up.
+> 4. **Feature requests vs. underlying needs** — separate the literal ask from the need behind it.
+> 5. **The one thing** the data says I should build/fix next, and why — and the one thing on my roadmap this data suggests is *less* important than I think.
+> 6. **Quotes I could use** (with permission) as testimonials or landing-page copy.
+>
+> Be blunt. If the replies don't actually support a clear next step, say so rather than inventing one.
+>
+> REPLIES:
+> ```
+> [paste, one per line or separated by ---]
+> ```
+
+## How to use the output
+
+- Item 5 feeds directly into the next sprint's priorities.
+- Item 2 ("the job") may rewrite your landing-page headline — test it.
+- Re-run this every ~25 new replies. The themes will shift as the user base grows; that shift is itself signal.

--- a/docs/growth/prompts/README.md
+++ b/docs/growth/prompts/README.md
@@ -1,0 +1,31 @@
+# Growth prompt library
+
+Reusable Claude prompts that execute the content engine in [`../../marketing-plan.md`](../../marketing-plan.md). Copy a prompt, fill the `[BRACKETS]`, run it, then do the 30% that makes it human.
+
+These are Tier 1 (copy-paste). Tier 2 is the batch generator that runs the species-page prompt over the catalog and opens a review PR — see [`../engine.md`](../engine.md) if/when it's built.
+
+## The one rule
+
+**Claude gets you 70% of the way; you do the 30% that makes it sound like a person.** Ship nothing that's 100% model output. The 30% is: the intro, the conclusion, one real opinion or anecdote, and cutting whatever feels generic. That ratio is the whole strategy — Claude-perfect content reads like every other AI blog and *ranks worse* than human-edited content.
+
+## Guardrails (every prompt assumes these)
+
+1. **Ground facts; never free-write care advice.** Care pages are generated *from* the species data you paste in, not from the model's memory. Wrong watering advice destroys trust and rankings. If a field is missing, omit that section — don't invent it.
+2. **Brand voice** (from `docs/brand.md`): warm, practical, never preachy. The friend who reminds you the plant's wilting, not the one lecturing about chlorophyll. Light humor only at the edges, never in instructions a worried plant-owner is reading.
+3. **No AI tells.** Banned: "in today's world", "embark on a journey", "unlock", "elevate", "dive into", "it's worth noting", "navigate the world of", em-dash-everything, the rule-of-three cadence on every sentence.
+4. **Unique value per page.** Every page needs the angle no competitor has: the **collaborative-household hook** ("here's the cadence — and how to make sure *someone* actually does it"). A page that's just reworded plant facts is a doorway page Google deindexes.
+5. **Human-in-the-loop, in batches.** Approve 10–20 at a time. Reject thin ones; don't ship volume for its own sake.
+6. **Publish in waves, watch Search Console.** 20 pages → confirm they index and quality signals hold → then scale.
+
+## Files
+
+| Prompt | Use for |
+|--------|---------|
+| `01-editorial-pipeline.md` | The weekly long-form article (topic → outline → draft → edit) |
+| `02-species-care-page.md` | ⭐ Grounded programmatic care page — the scale lever |
+| `03-repurpose.md` | Fan one article out to tweet / Reddit / email / cross-links |
+| `04-research-synthesis.md` | Turn signup-survey replies into a prioritized themes list |
+
+## A note on the model
+
+Use a strong model (Opus/Sonnet) for drafting and editing — the quality gap shows up exactly in the "doesn't read as AI" dimension that matters here. A cheaper model is fine for mechanical repurposing (#03).

--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -16,6 +16,11 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://app.familygreenhouse.com/care</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://app.familygreenhouse.com/changelog</loc>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
@@ -58,5 +63,23 @@
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <lastmod>2026-04-25</lastmod>
+  </url>
+  <url>
+    <loc>https://app.familygreenhouse.com/care/pothos</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+    <lastmod>2026-06-08</lastmod>
+  </url>
+  <url>
+    <loc>https://app.familygreenhouse.com/care/snake-plant</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+    <lastmod>2026-06-08</lastmod>
+  </url>
+  <url>
+    <loc>https://app.familygreenhouse.com/care/monstera</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+    <lastmod>2026-06-08</lastmod>
   </url>
 </urlset>

--- a/frontend/scripts/build-sitemap.mjs
+++ b/frontend/scripts/build-sitemap.mjs
@@ -22,6 +22,7 @@ import { fileURLToPath } from 'node:url';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const POSTS = join(ROOT, 'src', 'features', 'blog', 'posts', 'index.ts');
+const CARE = join(ROOT, 'src', 'features', 'care', 'careGuides.ts');
 const OUT = join(ROOT, 'public', 'sitemap.xml');
 
 const SITE = process.env.SITE_URL || 'https://app.familygreenhouse.com';
@@ -30,6 +31,7 @@ const STATIC_ROUTES = [
   { path: '/', priority: 1.0, changefreq: 'weekly' },
   { path: '/pricing', priority: 0.9, changefreq: 'monthly' },
   { path: '/blog', priority: 0.8, changefreq: 'weekly' },
+  { path: '/care', priority: 0.8, changefreq: 'weekly' },
   { path: '/changelog', priority: 0.5, changefreq: 'weekly' },
   { path: '/status', priority: 0.3, changefreq: 'daily' },
   { path: '/legal/privacy', priority: 0.3, changefreq: 'yearly' },
@@ -51,6 +53,18 @@ function readBlogSlugs() {
 function readBlogDates() {
   const src = readFileSync(POSTS, 'utf8');
   const re = /slug:\s*'([^']+)'[\s\S]*?date:\s*'([^']+)'/g;
+  const out = new Map();
+  let m;
+  while ((m = re.exec(src)) !== null) {
+    out.set(m[1], m[2]);
+  }
+  return out;
+}
+
+// Care guides share the manifest-regex approach: `slug: 'x'` + `reviewed: 'date'`.
+function readCareGuides() {
+  const src = readFileSync(CARE, 'utf8');
+  const re = /slug:\s*'([^']+)'[\s\S]*?reviewed:\s*'([^']+)'/g;
   const out = new Map();
   let m;
   while ((m = re.exec(src)) !== null) {
@@ -82,7 +96,15 @@ function build() {
     lastmod: dates.get(slug) ?? today,
   }));
 
-  const all = [...STATIC_ROUTES, ...blogEntries];
+  const care = readCareGuides();
+  const careEntries = [...care.entries()].map(([slug, reviewed]) => ({
+    path: `/care/${slug}`,
+    priority: 0.7,
+    changefreq: 'monthly',
+    lastmod: reviewed ?? today,
+  }));
+
+  const all = [...STATIC_ROUTES, ...blogEntries, ...careEntries];
 
   const xml = [
     `<?xml version="1.0" encoding="UTF-8"?>`,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -65,6 +65,8 @@ const JoinHouseholdPage = lazyNamed(
 );
 const BlogIndex = lazyNamed(() => import('@/features/blog/BlogIndex'), 'BlogIndex');
 const BlogPost = lazyNamed(() => import('@/features/blog/BlogPost'), 'BlogPost');
+const CareIndex = lazyNamed(() => import('@/features/care/CareIndex'), 'CareIndex');
+const CareGuidePage = lazyNamed(() => import('@/features/care/CareGuidePage'), 'CareGuidePage');
 const ChangelogPage = lazyNamed(
   () => import('@/features/changelog/ChangelogPage'),
   'ChangelogPage'
@@ -135,6 +137,8 @@ function App() {
               <Route path="/reset-password" element={<ResetPasswordPage />} />
               <Route path="/join/:inviteCode" element={<JoinHouseholdPage />} />
               <Route path="/blog" element={<BlogIndex />} />
+              <Route path="/care" element={<CareIndex />} />
+              <Route path="/care/:slug" element={<CareGuidePage />} />
               <Route path="/blog/:slug" element={<BlogPost />} />
               <Route path="/changelog" element={<ChangelogPage />} />
               <Route path="/legal/privacy" element={<PrivacyPage />} />

--- a/frontend/src/features/care/CareGuidePage.tsx
+++ b/frontend/src/features/care/CareGuidePage.tsx
@@ -1,0 +1,218 @@
+import { Link, Navigate, useParams } from 'react-router-dom';
+import { ChevronLeftIcon } from '@heroicons/react/24/outline';
+import { BrandMark } from '@/components/BrandMark';
+import { Footer } from '@/components/Footer';
+import { Button } from '@/components/Button';
+import { useMetaTags } from '@/hooks/useMetaTags';
+import { CARE_GUIDES, findCareGuide, type CareGuide } from './careGuides';
+
+const SITE = 'https://app.familygreenhouse.com';
+
+function Paragraphs({ items }: { items: string[] }) {
+  return (
+    <>
+      {items.map((p, i) => (
+        <p key={i}>{p}</p>
+      ))}
+    </>
+  );
+}
+
+/**
+ * One template renders every species care page (`/care/:slug`). The content
+ * is data (`careGuides.ts`), so the SEO surface scales by adding entries, not
+ * components. Emits Article + FAQPage JSON-LD so pages are eligible for
+ * Google's article and FAQ rich results — the FAQ markup is the highest-ROI
+ * schema for these queries because "how often to water X" is a voice/quick
+ * answer pattern.
+ */
+export function CareGuidePage() {
+  const { slug } = useParams<{ slug: string }>();
+  const guide = slug ? findCareGuide(slug) : undefined;
+
+  useMetaTags(
+    guide
+      ? {
+          title: guide.metaTitle,
+          description: guide.metaDescription,
+          jsonLd: {
+            '@context': 'https://schema.org',
+            '@graph': [
+              {
+                '@type': 'Article',
+                headline: `${guide.commonName} Care Guide`,
+                description: guide.metaDescription,
+                datePublished: guide.reviewed,
+                dateModified: guide.reviewed,
+                author: { '@type': 'Organization', name: 'Family Greenhouse' },
+                publisher: {
+                  '@type': 'Organization',
+                  name: 'Family Greenhouse',
+                  logo: {
+                    '@type': 'ImageObject',
+                    url: `${SITE}/brand/icon-512.png`,
+                  },
+                },
+                mainEntityOfPage: {
+                  '@type': 'WebPage',
+                  '@id': `${SITE}/care/${guide.slug}`,
+                },
+                about: {
+                  '@type': 'Thing',
+                  name: guide.commonName,
+                  alternateName: [guide.scientificName, ...guide.alsoKnownAs],
+                },
+              },
+              {
+                '@type': 'FAQPage',
+                mainEntity: guide.faqs.map((f) => ({
+                  '@type': 'Question',
+                  name: f.q,
+                  acceptedAnswer: { '@type': 'Answer', text: f.a },
+                })),
+              },
+            ],
+          },
+        }
+      : {}
+  );
+
+  if (!guide) {
+    return <Navigate to="/care" replace />;
+  }
+
+  const related = CARE_GUIDES.filter((g) => g.slug !== guide.slug).slice(0, 3);
+
+  return (
+    <div className="min-h-screen bg-white flex flex-col">
+      <header className="border-b border-gray-200">
+        <nav className="mx-auto max-w-3xl flex items-center justify-between p-6">
+          <Link to="/" aria-label="Family Greenhouse home">
+            <BrandMark variant="wordmark" size="sm" />
+          </Link>
+          <Link to="/" className="text-sm font-medium text-primary-700 hover:underline">
+            Try the app →
+          </Link>
+        </nav>
+      </header>
+
+      <main className="flex-1 mx-auto max-w-2xl w-full px-6 py-12 sm:py-16">
+        <Link
+          to="/care"
+          className="inline-flex items-center gap-1 text-sm font-medium text-primary-700 hover:underline"
+        >
+          <ChevronLeftIcon className="h-4 w-4" aria-hidden="true" />
+          All care guides
+        </Link>
+
+        <header className="mt-6 mb-8">
+          <p className="text-xs font-medium uppercase tracking-[0.2em] text-primary-700">
+            Plant care guide
+          </p>
+          <h1 className="mt-3 font-serif text-4xl font-semibold tracking-tight text-gray-900 sm:text-5xl">
+            {guide.commonName} care
+          </h1>
+          <p className="mt-2 text-lg italic text-gray-500">
+            {guide.scientificName}
+            {guide.alsoKnownAs.length > 0 && (
+              <span className="not-italic text-base text-gray-400">
+                {' '}
+                · also called {guide.alsoKnownAs.join(', ')}
+              </span>
+            )}
+          </p>
+        </header>
+
+        <p className="prose-fg lead">{guide.summary}</p>
+
+        {/* At-a-glance grounded facts */}
+        <dl className="mt-8 grid grid-cols-1 gap-px overflow-hidden rounded-lg border border-primary-100 bg-primary-100 sm:grid-cols-2">
+          {[
+            ['Water', guide.quickFacts.water],
+            ['Light', guide.quickFacts.light],
+            ['Difficulty', guide.quickFacts.difficulty],
+            ['Humidity', guide.quickFacts.humidity],
+            ['Toxic to pets?', guide.quickFacts.toxicity],
+          ].map(([label, value]) => (
+            <div key={label} className="bg-white p-4">
+              <dt className="text-xs font-medium uppercase tracking-wide text-primary-700">
+                {label}
+              </dt>
+              <dd className="mt-1 text-sm text-gray-900">{value}</dd>
+            </div>
+          ))}
+        </dl>
+
+        <article className="prose-fg mt-12">
+          <h2>How often to water a {guide.commonName.toLowerCase()}</h2>
+          <Paragraphs items={guide.sections.watering} />
+
+          <h2>Light</h2>
+          <Paragraphs items={guide.sections.light} />
+
+          <h2>Why is my {guide.commonName.toLowerCase()} dying?</h2>
+          <Paragraphs items={guide.sections.problems} />
+
+          <h2>Keeping it alive when you share a home</h2>
+          <Paragraphs items={guide.sections.sharedCare} />
+
+          <h2>The honest bit</h2>
+          <Paragraphs items={guide.sections.honestBit} />
+
+          <h2>{guide.commonName} FAQ</h2>
+          <dl>
+            {guide.faqs.map((f) => (
+              <div key={f.q} className="mt-4">
+                <dt className="font-semibold text-gray-900">{f.q}</dt>
+                <dd className="mt-1 text-gray-700">{f.a}</dd>
+              </div>
+            ))}
+          </dl>
+        </article>
+
+        <aside className="mt-16 rounded-lg border border-primary-200 bg-primary-50 p-6 text-center">
+          <p className="font-serif text-xl font-semibold text-gray-900">
+            Stop guessing when you watered it
+          </p>
+          <p className="mt-2 text-sm text-gray-600">
+            Family Greenhouse tracks your {guide.commonName.toLowerCase()}’s schedule and reminds the
+            right person — so “I thought you watered it” stops being a thing. Free for up to 10
+            plants, no card.
+          </p>
+          <div className="mt-4">
+            <Link to="/register">
+              <Button>Add your {guide.commonName.toLowerCase()}</Button>
+            </Link>
+          </div>
+        </aside>
+
+        {related.length > 0 && (
+          <section className="mt-16">
+            <h2 className="font-serif text-2xl font-semibold tracking-tight text-gray-900">
+              More care guides
+            </h2>
+            <ul className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
+              {related.map((g) => (
+                <li key={g.slug}>
+                  <Link
+                    to={`/care/${g.slug}`}
+                    className="group block rounded-lg border border-primary-100 p-4 transition-colors hover:border-primary-300 hover:bg-primary-50/50"
+                  >
+                    <span className="font-serif text-lg font-semibold text-gray-900 group-hover:text-primary-700">
+                      {g.commonName}
+                    </span>
+                    <span className="mt-1 block text-xs text-gray-500">{g.quickFacts.water}</span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+      </main>
+
+      <Footer />
+    </div>
+  );
+}
+
+export type { CareGuide };

--- a/frontend/src/features/care/CareIndex.tsx
+++ b/frontend/src/features/care/CareIndex.tsx
@@ -1,0 +1,80 @@
+import { Link } from 'react-router-dom';
+import { BrandMark } from '@/components/BrandMark';
+import { Footer } from '@/components/Footer';
+import { useMetaTags } from '@/hooks/useMetaTags';
+import { CARE_GUIDES } from './careGuides';
+
+/**
+ * Index of the species care guides. Doubles as the internal-linking hub that
+ * passes authority to the individual `/care/:slug` pages and gives the crawler
+ * a single page that links them all. Public, no auth.
+ */
+export function CareIndex() {
+  useMetaTags({
+    title: 'Plant Care Guides — How Often to Water Common Houseplants',
+    description:
+      'Straight, no-nonsense care guides for common houseplants: how often to water, how much light, and why yours might be dying.',
+  });
+
+  return (
+    <div className="min-h-screen bg-white flex flex-col">
+      <header className="border-b border-gray-200">
+        <nav className="mx-auto max-w-3xl flex items-center justify-between p-6">
+          <Link to="/" aria-label="Family Greenhouse home">
+            <BrandMark variant="wordmark" size="sm" />
+          </Link>
+          <Link to="/" className="text-sm font-medium text-primary-700 hover:underline">
+            Try the app →
+          </Link>
+        </nav>
+      </header>
+
+      <main className="flex-1 mx-auto max-w-3xl w-full px-6 py-16">
+        <h1 className="font-serif text-4xl font-semibold tracking-tight text-gray-900 sm:text-5xl">
+          Plant care guides
+        </h1>
+        <p className="mt-3 text-lg text-gray-600">
+          How often to water it, how much light it wants, and why yours is doing that. Honest,
+          specific, no “lush green companion” filler.
+        </p>
+
+        <ul className="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2">
+          {CARE_GUIDES.map((g) => (
+            <li key={g.slug}>
+              <Link
+                to={`/care/${g.slug}`}
+                className="group block h-full rounded-lg border border-primary-100 p-5 transition-colors hover:border-primary-300 hover:bg-primary-50/50"
+              >
+                <h2 className="font-serif text-xl font-semibold text-gray-900 group-hover:text-primary-700">
+                  {g.commonName}
+                </h2>
+                <p className="mt-1 text-sm italic text-gray-500">{g.scientificName}</p>
+                <p className="mt-3 text-sm text-gray-600">{g.quickFacts.water}</p>
+              </Link>
+            </li>
+          ))}
+        </ul>
+
+        <aside className="mt-16 rounded-lg border border-primary-200 bg-primary-50 p-6 text-center">
+          <p className="font-serif text-xl font-semibold text-gray-900">
+            Knowing the schedule is the easy part
+          </p>
+          <p className="mt-2 text-sm text-gray-600">
+            The hard part is remembering — and not assuming someone else did it. Family Greenhouse
+            handles both. Free for up to 10 plants.
+          </p>
+          <div className="mt-4">
+            <Link
+              to="/register"
+              className="inline-flex items-center rounded-md bg-primary-700 px-4 py-2 text-sm font-medium text-white hover:bg-primary-800 min-h-touch"
+            >
+              Get started
+            </Link>
+          </div>
+        </aside>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/frontend/src/features/care/careGuides.ts
+++ b/frontend/src/features/care/careGuides.ts
@@ -1,0 +1,233 @@
+/**
+ * Programmatic species care pages — the SEO scale lever.
+ *
+ * Each entry is one page at `/care/[slug]`, targeting "how often to water
+ * [plant]" / "[plant] care" / "why is my [plant] dying". One template
+ * (`CareGuidePage.tsx`) renders all of them, so growing the surface = adding
+ * data entries, not writing components.
+ *
+ * Entries are GROUNDED: the facts (watering interval, light, toxicity) come
+ * from the species catalog / Perenual, the prose is original. The generator
+ * prompt that produces this shape is `docs/growth/prompts/02-species-care-page.md`.
+ * These three are a hand-reviewed SAMPLE so the content quality and the
+ * architecture can be judged before scaling to ~150 species.
+ *
+ * ⚠️ Two fields a wrong answer does real harm on — verify against source data
+ * for every entry before publishing: `quickFacts.water` and `quickFacts.toxicity`
+ * (a pet owner trusts that toxicity line).
+ */
+export interface CareGuide {
+  slug: string;
+  commonName: string;
+  scientificName: string;
+  alsoKnownAs: string[];
+  metaTitle: string;
+  metaDescription: string;
+  /** ISO date — drives "last reviewed" + sitemap lastmod. */
+  reviewed: string;
+  summary: string;
+  quickFacts: {
+    water: string;
+    light: string;
+    difficulty: string;
+    toxicity: string;
+    humidity: string;
+  };
+  sections: {
+    watering: string[];
+    light: string[];
+    problems: string[];
+    /** The differentiator: keeping it alive in a shared home. */
+    sharedCare: string[];
+    /** Founder voice — one real opinion, light humour ok. */
+    honestBit: string[];
+  };
+  faqs: { q: string; a: string }[];
+}
+
+export const CARE_GUIDES: CareGuide[] = [
+  {
+    slug: 'pothos',
+    commonName: 'Pothos',
+    scientificName: 'Epipremnum aureum',
+    alsoKnownAs: ['Devil’s Ivy', 'Golden Pothos', 'Money Plant'],
+    metaTitle: 'Pothos Care: How Often to Water (and Not Kill It)',
+    metaDescription:
+      'How often to water a pothos, how much light it needs, why the leaves go yellow, and how to keep one alive in a shared home.',
+    reviewed: '2026-06-08',
+    summary:
+      'Pothos is the plant people mean when they say “I can’t keep anything alive, except this one.” It’s forgiving, fast-growing, and tells you clearly when something’s wrong — if you know what to look for.',
+    quickFacts: {
+      water: 'Every 7–10 days, when the top inch of soil is dry',
+      light: 'Bright, indirect light. Tolerates low light (just grows slower)',
+      difficulty: 'Very easy',
+      toxicity: 'Toxic to cats and dogs if chewed (calcium oxalate crystals)',
+      humidity: 'Average household humidity is fine',
+    },
+    sections: {
+      watering: [
+        'Water a pothos roughly every 7–10 days — but the calendar is a starting point, not the rule. The real signal is the soil: stick a finger in, and if the top inch is dry, water it thoroughly until it drains out the bottom. If it’s still damp, wait.',
+        'In winter, or in a low-light spot, it drinks less — stretch to every two weeks. In a bright window in summer, it may want water every 5–6 days. A pothos would rather be a touch too dry than too wet, so when in doubt, wait a day.',
+      ],
+      light: [
+        'Bright, indirect light is the sweet spot — near a window, but out of direct midday sun, which scorches the leaves. The good news is pothos tolerates low light better than almost anything; it just grows slower and the variegation (the cream-and-green marbling) fades toward plain green.',
+        'If the vines get long and sparse with big gaps between leaves, that’s “leggy” — it’s reaching for light. Move it brighter and the new growth tightens up.',
+      ],
+      problems: [
+        'Yellow leaves are almost always overwatering. The instinct when a plant looks sad is to give it more water; with pothos, that’s usually the thing that’s hurting it. Let it dry out properly and the yellowing stops.',
+        'Brown, crispy tips point the other way — underwatering, or very dry air. Crispy edges on an otherwise green leaf means it got too thirsty at some point.',
+        'Limp, mushy stems at the soil line are root rot, the one genuinely dangerous problem, and it comes from sitting in soggy soil. Pothos forgives a missed watering; it does not forgive a pot with no drainage hole.',
+      ],
+      sharedCare: [
+        'Here’s the thing nobody warns you about: pothos is so easy that everyone in the house assumes someone else is handling it. It limps along on neglect for weeks — which is exactly how it ends up dead. The failure mode isn’t a hard plant; it’s “I thought you watered it.”',
+        'The fix is boring and it works: one person owns it, or you agree out loud who waters on which day. A shared note, a shared reminder, anything that turns “someone should” into “you, Thursday.” (This is the whole reason Family Greenhouse exists, but a whiteboard works too.)',
+      ],
+      honestBit: [
+        'If you have killed every plant you’ve ever owned, start here and only here. A pothos cutting in a glass of water will grow roots on a windowsill with zero soil and zero expertise — it’s the closest thing to a confidence cheat code in houseplants.',
+        'My one real opinion: skip the moisture meter. For a pothos it’s a gadget solving a problem your finger already solves for free. Save the money for a second plant.',
+      ],
+    },
+    faqs: [
+      {
+        q: 'How often should I water a pothos?',
+        a: 'About every 7–10 days, when the top inch of soil is dry. Less in winter or low light (every two weeks); more in a bright window in summer. When unsure, wait a day — it prefers slightly dry over soggy.',
+      },
+      {
+        q: 'Why are my pothos leaves turning yellow?',
+        a: 'Almost always overwatering. Let the soil dry out properly between waterings and make sure the pot drains. Yellowing from underwatering is rarer and usually comes with crispy brown edges.',
+      },
+      {
+        q: 'Is pothos toxic to cats and dogs?',
+        a: 'Yes — pothos contains calcium oxalate crystals that are toxic to cats and dogs if chewed, causing mouth irritation and drooling. Keep it out of reach of pets that nibble.',
+      },
+      {
+        q: 'Can pothos survive in low light?',
+        a: 'Yes, better than most houseplants. It just grows more slowly and the variegation fades toward solid green. Bright indirect light keeps it fuller and more colourful.',
+      },
+    ],
+  },
+  {
+    slug: 'snake-plant',
+    commonName: 'Snake Plant',
+    scientificName: 'Dracaena trifasciata',
+    alsoKnownAs: ['Sansevieria', 'Mother-in-Law’s Tongue'],
+    metaTitle: 'Snake Plant Care: How Often to Water It (Hint: Less)',
+    metaDescription:
+      'How often to water a snake plant, the light it needs, why the leaves go mushy or wrinkled, and how to share its care without drowning it.',
+    reviewed: '2026-06-08',
+    summary:
+      'The snake plant is as close to unkillable as houseplants get — and the one way people do kill it is kindness. It wants to be left alone, and most plant deaths here are an excess of attention, not a lack of it.',
+    quickFacts: {
+      water: 'Every 2–3 weeks; let the soil dry out completely first',
+      light: 'Anything from low light to bright, indirect light',
+      difficulty: 'Very easy — famously hard to kill',
+      toxicity: 'Mildly toxic to cats and dogs if eaten',
+      humidity: 'Dry household air is perfectly fine',
+    },
+    sections: {
+      watering: [
+        'Water a snake plant every 2–3 weeks, and only after the soil has dried out completely — not “mostly,” completely, all the way to the bottom of the pot. These are succulents; they store water in those stiff upright leaves and genuinely prefer drought to damp.',
+        'In winter, back off to roughly once a month. The single most useful habit you can build with a snake plant is doing nothing — if you’re not sure whether it needs water, it almost certainly doesn’t.',
+      ],
+      light: [
+        'Snake plants are unbothered by light. They’ll handle a dim hallway corner and a bright living-room window equally, which is why they end up in offices and bathrooms where nothing else survives. Bright indirect light makes them grow faster; low light just slows them down.',
+        'The only thing to avoid is harsh, direct, all-day sun through glass, which can bleach the leaves. Other than that, put it where you want it.',
+      ],
+      problems: [
+        'Soft, mushy, yellowing leaves at the base mean root rot — and root rot means too much water. This is the one real way to kill a snake plant. If you catch it early, stop watering, let it dry out hard, and it often recovers.',
+        'Wrinkled or curling leaves are the rare opposite: it’s actually thirsty. Give it a proper soak and the leaves plump back up within a day or two.',
+        'Leaves flopping over instead of standing upright usually means it’s been sitting in too-wet soil for too long, or the pot is too big and holds water it can’t use.',
+      ],
+      sharedCare: [
+        'The snake plant’s superpower — needing almost nothing — is also the trap in a shared home. Two people who each “just topped it up” twice a month have, between them, watered a drought plant four times. The plant that’s nearly impossible to kill gets killed by teamwork.',
+        'So the rule for a shared snake plant is the opposite of most plants: agree that exactly one person waters it, and everyone else keeps their watering can away from it. Less coordination, not more — just make sure the coordination is “hands off.”',
+      ],
+      honestBit: [
+        'If you travel, rent, forget, or simply don’t want a plant to be a responsibility, this is the one. A snake plant will forgive a three-week trip without a sitter and look exactly the same when you get back, faintly judging you.',
+        'My take: ignore the “it purifies your air” marketing. The famous NASA study used sealed lab chambers, not living rooms — you’d need a jungle to measure a difference. Buy it because it’s handsome and indestructible, not because it’s a humidifier with a marketing budget.',
+      ],
+    },
+    faqs: [
+      {
+        q: 'How often should I water a snake plant?',
+        a: 'Every 2–3 weeks, and only once the soil is completely dry. Drop to about once a month in winter. If you’re unsure, wait — overwatering is the main way snake plants die.',
+      },
+      {
+        q: 'Why is my snake plant going soft and mushy?',
+        a: 'That’s root rot from too much water. Stop watering, let the soil dry out fully, and remove any mushy leaves. Make sure the pot drains and isn’t oversized.',
+      },
+      {
+        q: 'Can a snake plant live in low light?',
+        a: 'Yes — it’s one of the few plants that genuinely tolerates a dim corner. It grows faster in bright indirect light but survives low light comfortably.',
+      },
+      {
+        q: 'Are snake plants toxic to pets?',
+        a: 'Mildly. If a cat or dog eats the leaves it can cause nausea and drooling. It’s not usually serious, but keep it away from pets that chew.',
+      },
+    ],
+  },
+  {
+    slug: 'monstera',
+    commonName: 'Monstera',
+    scientificName: 'Monstera deliciosa',
+    alsoKnownAs: ['Swiss Cheese Plant', 'Split-Leaf Philodendron'],
+    metaTitle: 'Monstera Care: How Often to Water + Why No Leaf Holes',
+    metaDescription:
+      'How often to water a monstera, the light it needs to grow holes (fenestrations), why leaves yellow or brown, and sharing its care at home.',
+    reviewed: '2026-06-08',
+    summary:
+      'The monstera is the plant everyone wants for those dramatic split leaves — and the one people are surprised they have to earn. The holes aren’t automatic; they’re a reward for getting the light right.',
+    quickFacts: {
+      water: 'Every 1–2 weeks, when the top 1–2 inches of soil are dry',
+      light: 'Bright, indirect light — never harsh direct sun',
+      difficulty: 'Easy to moderate',
+      toxicity: 'Toxic to cats and dogs if chewed (calcium oxalates)',
+      humidity: 'Likes higher humidity but copes with average rooms',
+    },
+    sections: {
+      watering: [
+        'Water a monstera every 1–2 weeks, when the top inch or two of soil has dried out. Like most tropicals it wants a real drink — water until it runs from the drainage holes — and then a dry-down period before the next one. Soggy, never-quite-dry soil is what kills them.',
+        'The interval drifts with the seasons: closer to weekly in bright, warm summer months, closer to every two weeks in winter. Let the soil, not the date, make the call.',
+      ],
+      light: [
+        'Bright, indirect light is non-negotiable if you want the famous holes. Those splits — “fenestrations” — only develop when a monstera gets enough light and matures; a plant in a dim corner stays small with plain, solid, heart-shaped leaves and people wonder what they did wrong. The answer is almost always: more light.',
+        'Keep it out of harsh direct sun through glass, which scorches the leaves. A few feet back from a bright window, or beside an east-facing one, is ideal.',
+      ],
+      problems: [
+        'Yellow leaves usually mean overwatering — the same story as most houseplants. Check that the soil is drying between waterings and that the pot actually drains.',
+        'Brown, crispy edges point to dry air or letting it get too thirsty. Monsteras like a bit more humidity than the average living room; a grouping of plants or the occasional misting helps, though it’s not essential.',
+        'No splits on new leaves? That’s not a disease — it’s a light problem. A young monstera also simply isn’t old enough yet. Give it brighter light and time, and the new leaves come in with windows.',
+      ],
+      sharedCare: [
+        'A monstera is a big, visible, second-living-room-member kind of plant — which is exactly why its care slips through the cracks in a shared home. It’s too established to look thirsty quickly, so “it seems fine” becomes everyone’s reason not to water it, right up until it isn’t fine.',
+        'For a plant this slow to complain, the move is a shared schedule rather than vibes. Decide who checks the soil and when, so the monstera isn’t quietly relying on four people each assuming one of the others did it. (A plant this expensive is worth a reminder neither of you can ignore.)',
+      ],
+      honestBit: [
+        'Unpopular opinion: most “my monstera won’t fenestrate” problems are light problems wearing a costume. People reach for humidifiers and fertiliser and moss poles when the plant just needs to be a metre closer to the window. Fix light first; fix everything else second.',
+        'And the moss pole is genuinely worth it once the plant is a year or two in — monsteras are climbers, and a supported, climbing monstera produces bigger, holier leaves than one flopping over the side of its pot. That part of the hype is real.',
+      ],
+    },
+    faqs: [
+      {
+        q: 'How often should I water a monstera?',
+        a: 'Every 1–2 weeks, when the top 1–2 inches of soil are dry. Lean weekly in bright summer months and every two weeks in winter. Always let it drain — it hates sitting in water.',
+      },
+      {
+        q: 'Why doesn’t my monstera have holes in its leaves?',
+        a: 'Almost always not enough light, or the plant is still young. The famous splits (fenestrations) develop as a monstera matures in bright, indirect light. Move it brighter and give it time.',
+      },
+      {
+        q: 'Why are my monstera’s leaves turning yellow?',
+        a: 'Usually overwatering. Let the top inch or two of soil dry between waterings and confirm the pot drains. Brown crispy edges, by contrast, mean dry air or underwatering.',
+      },
+      {
+        q: 'Is a monstera toxic to cats and dogs?',
+        a: 'Yes — monstera contains calcium oxalate crystals that are toxic to cats and dogs if chewed, causing mouth irritation and drooling. Keep it away from pets that nibble leaves.',
+      },
+    ],
+  },
+];
+
+export function findCareGuide(slug: string): CareGuide | undefined {
+  return CARE_GUIDES.find((g) => g.slug === slug);
+}


### PR DESCRIPTION
Operationalizes the content engine from `docs/marketing-plan.md` — the AI system to actually execute the growth strategy at a volume one person can't write by hand.

## 1. Prompt library — `docs/growth/prompts/`
Reusable, copy-paste Claude prompts for each content task, **with the guardrails** that keep AI-scaled SEO from getting deindexed:
- `01-editorial-pipeline.md` — the weekly long-form (topic → outline → draft → edit)
- `02-species-care-page.md` ⭐ — the **grounded** programmatic generator (every fact from the data block, never the model's memory)
- `03-repurpose.md` / `04-research-synthesis.md` — distribution + turning signups into roadmap signal
- `README.md` — the 70/30 rule, the anti-AI-tells list, the unique-household-angle rule, human-in-the-loop, "watch Search Console"

## 2. The scale lever, as a real feature — `/care/:slug`
Your species catalog is a programmatic-SEO goldmine (every houseplant = a "how often to water X" search the day it starts dying). This builds the **data-driven architecture** so growing the surface = adding data, not components:
- `careGuides.ts` — one `CareGuide` per page (the generator's output shape)
- `CareGuidePage.tsx` — one template renders them all; quick-facts table, FAQ, CTA, cross-links, **Article + FAQPage JSON-LD**
- `CareIndex.tsx` — `/care` hub for internal linking
- wired into routing + the sitemap generator (4 new URLs)

Ships **3 hand-reviewed, grounded sample guides** (pothos, snake plant, monstera) so you can judge the real content quality + the architecture before committing to ~150 species. Each weaves in the collaborative-household differentiator ("I thought *you* watered it") and an honest founder voice — not template-filled.

## Verify
Visit `/care`, `/care/pothos`, `/care/snake-plant`, `/care/monstera`. typecheck + lint + 167 tests + build ✓; FAQ/Article schema validates in Google's Rich Results Test.

> Next, if the quality holds up: the Tier-2 batch generator (run `02-species-care-page.md` over the catalog → batch PR of ~10/week for review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)