### PR TITLE
fix(infra): isolate staging Terraform state (close prod-destruction landmine)

### DIFF
--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -1,17 +1,16 @@
 name: Deploy to Staging
 
-# ⚠️ DISABLED auto-deploy on push. The Terraform backend uses a single state
-# key (`terraform.tfstate`, no workspace / no per-env key — see backend.tf),
-# so this job's `terraform apply -var-file=staging` runs against the SAME
-# state that holds production. Because resource names embed
-# `${var.environment}`, a staging apply would rename every `-production`
-# resource to `-staging` — i.e. destroy the live Cognito pool / DynamoDB /
-# API / CloudFront. This never fired before only because CD had no AWS creds.
+# State is now ISOLATED: the Terraform Apply step below inits with
+# `-backend-config="key=staging/terraform.tfstate"`, so staging has its own
+# state file and a staging apply can no longer touch the production stack
+# (which lives under the default `terraform.tfstate` key). The prod-destruction
+# landmine is closed.
 #
-# DO NOT re-enable `push: main` until staging has an ISOLATED state, e.g.
-# `terraform init -backend-config="key=staging/terraform.tfstate"` in the
-# init step here (and a real, separate staging stack is intended). Left as
-# manual-only so a human who understands the above can still trigger it.
+# Still kept MANUAL (workflow_dispatch only), deliberately: a staging apply now
+# stands up a full *separate* staging stack (Cognito/DDB/API/CloudFront...),
+# which costs money — that should be an intentional choice, not something every
+# push to main provisions. Re-enable `push: main` only when a standing staging
+# environment is actually wanted.
 on:
   workflow_dispatch:
 
@@ -96,8 +95,9 @@ jobs:
           terraform_version: 1.5.7
           terraform_wrapper: false
 
-      - name: Terraform Init
-        run: terraform init
+      - name: Terraform Init (isolated staging state)
+        # Staging gets its OWN state key so it can never apply onto prod's state.
+        run: terraform init -backend-config="key=staging/terraform.tfstate"
 
       - name: Terraform Plan
         run: terraform plan -var-file=environments/staging/terraform.tfvars -out=tfplan

--- a/infrastructure/backend.tf
+++ b/infrastructure/backend.tf
@@ -20,7 +20,13 @@
 #
 terraform {
   backend "s3" {
-    bucket         = "family-greenhouse-tfstate-014248889144"
+    bucket = "family-greenhouse-tfstate-014248889144"
+    # This is the PRODUCTION state key. Per-environment isolation is done at
+    # init time, NOT here: staging runs `terraform init
+    # -backend-config="key=staging/terraform.tfstate"` (see scripts/deploy.sh
+    # + cd-staging.yml) so it gets its own state and can never apply onto prod.
+    # Do not parameterize this default to anything other than the prod key, or
+    # a plain `terraform init` for prod would target the wrong (empty) state.
     key            = "terraform.tfstate"
     region         = "us-east-1"
     encrypt        = true

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -30,7 +30,18 @@ npm --workspace backend run build
 # Terraform
 echo "Applying Terraform..."
 cd infrastructure
-terraform init
+# Per-environment state isolation. Production keeps the original
+# `terraform.tfstate` key (backend.tf default) so its existing state is
+# untouched; staging gets its OWN key. Without this the two environments
+# share one state file — and a `terraform apply -var-file=staging` against
+# the prod-populated state would rename every `-production` resource to
+# `-staging` and destroy the live stack. `-reconfigure` re-points the backend
+# cleanly when alternating environments locally.
+if [[ "$ENVIRONMENT" == "staging" ]]; then
+    terraform init -reconfigure -backend-config="key=staging/terraform.tfstate"
+else
+    terraform init -reconfigure
+fi
 terraform apply -var-file="environments/${ENVIRONMENT}/terraform.tfvars" -auto-approve
 
 # Read outputs needed for the frontend build + asset sync


### PR DESCRIPTION
Properly closes the shared-state landmine (previously just mitigated by disabling staging auto-deploy).

- **Production keeps** the default `terraform.tfstate` key — state untouched (verified `terraform plan` = no changes after `-reconfigure`).
- **Staging** now inits with `-backend-config="key=staging/terraform.tfstate"` in both `scripts/deploy.sh` and `cd-staging.yml` → its own state; a staging apply can no longer touch prod.
- `deploy.sh` uses `-reconfigure` to switch backends cleanly when alternating envs locally; `backend.tf` documents the convention.
- `cd-staging` stays manual-only (a staging apply now provisions a separate billable stack — intentional choice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)