### PR TITLE
feat(infra): DLQ for async invocations + audit alarms

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -125,6 +125,7 @@ module "monitoring" {
   dynamodb_table_name   = module.database.table_name
   api_endpoint          = module.api.api_gateway_endpoint
   monthly_budget_usd    = var.monthly_budget_usd
+  lambda_dlq_name       = module.api.lambda_dlq_name
 }
 
 # NOTE: the WAF (`modules/security`) was removed for cost (~$8-16/mo) — its

--- a/infrastructure/modules/api/main.tf
+++ b/infrastructure/modules/api/main.tf
@@ -146,6 +146,12 @@ resource "aws_iam_role_policy" "lambda" {
         Resource = "*"
       },
       {
+        # Send failed async invocations to the dead-letter queue.
+        Effect   = "Allow"
+        Action   = ["sqs:SendMessage"]
+        Resource = aws_sqs_queue.lambda_dlq.arn
+      },
+      {
         # Bedrock for the chat handler. Two ARN shapes are needed:
         #   - The foundation-model ARN (the underlying Claude or Titan
         #     weights) is global (no account in the ARN).
@@ -293,6 +299,13 @@ resource "aws_lambda_function" "handlers" {
 
   tracing_config {
     mode = "Active"
+  }
+
+  # Failed async invocations (the EventBridge-driven `reminders` Lambda) land
+  # in the DLQ after Lambda's internal retries instead of vanishing. No-op for
+  # the sync API-Gateway handlers, which return errors to the caller.
+  dead_letter_config {
+    target_arn = aws_sqs_queue.lambda_dlq.arn
   }
 
   tags = {
@@ -469,6 +482,15 @@ resource "aws_cloudwatch_event_rule" "reminders" {
 resource "aws_cloudwatch_event_target" "reminders" {
   rule = aws_cloudwatch_event_rule.reminders.name
   arn  = aws_lambda_function.handlers["reminders"].arn
+
+  # Bounded retry, then dead-letter so a delivery failure isn't lost silently.
+  retry_policy {
+    maximum_retry_attempts       = 4
+    maximum_event_age_in_seconds = 3600
+  }
+  dead_letter_config {
+    arn = aws_sqs_queue.lambda_dlq.arn
+  }
 }
 
 resource "aws_lambda_permission" "reminders_eventbridge" {
@@ -477,4 +499,37 @@ resource "aws_lambda_permission" "reminders_eventbridge" {
   function_name = aws_lambda_function.handlers["reminders"].function_name
   principal     = "events.amazonaws.com"
   source_arn    = aws_cloudwatch_event_rule.reminders.arn
+}
+
+# Dead-letter queue for failed ASYNCHRONOUS Lambda invocations. The only async
+# path today is the hourly reminders scan (EventBridge → reminders Lambda); a
+# sync API-Gateway invoke returns its error to the caller and doesn't use this.
+# Without a DLQ, an async failure after Lambda's 2 internal retries is lost
+# silently — a whole hour of reminders could vanish with no trace. The queue +
+# the monitoring alarm on its depth make that visible. 14-day retention gives
+# ample time to inspect/redrive.
+resource "aws_sqs_queue" "lambda_dlq" {
+  name                      = "${var.project_name}-lambda-dlq-${var.environment}"
+  message_retention_seconds = 1209600 # 14 days
+
+  tags = {
+    Name = "${var.project_name}-lambda-dlq-${var.environment}"
+  }
+}
+
+# SQS queue policy: allow EventBridge to send dead-lettered events here.
+resource "aws_sqs_queue_policy" "lambda_dlq" {
+  queue_url = aws_sqs_queue.lambda_dlq.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "events.amazonaws.com" }
+      Action    = "sqs:SendMessage"
+      Resource  = aws_sqs_queue.lambda_dlq.arn
+      Condition = {
+        ArnEquals = { "aws:SourceArn" = aws_cloudwatch_event_rule.reminders.arn }
+      }
+    }]
+  })
 }

--- a/infrastructure/modules/api/outputs.tf
+++ b/infrastructure/modules/api/outputs.tf
@@ -22,3 +22,8 @@ output "lambda_function_names" {
   description = "Lambda function names"
   value       = [for k, v in aws_lambda_function.handlers : v.function_name]
 }
+
+output "lambda_dlq_name" {
+  description = "Name of the Lambda/EventBridge dead-letter queue (monitoring alarms on its depth)."
+  value       = aws_sqs_queue.lambda_dlq.name
+}

--- a/infrastructure/modules/monitoring/main.tf
+++ b/infrastructure/modules/monitoring/main.tf
@@ -366,3 +366,67 @@ resource "aws_cloudwatch_metric_alarm" "api_health" {
     Name = "${var.project_name}-api-health-alarm-${var.environment}"
   }
 }
+
+# Dead-letter queue depth. Any message here = an async invocation (the hourly
+# reminders scan) failed past its retries and was dropped to the DLQ — silent
+# data loss we want to know about immediately. treat_missing_data=notBreaching
+# so a normally-empty queue (no metric emitted) doesn't false-alarm.
+resource "aws_cloudwatch_metric_alarm" "lambda_dlq_depth" {
+  count = var.lambda_dlq_name == "" ? 0 : 1
+
+  alarm_name          = "${var.project_name}-lambda-dlq-not-empty-${var.environment}"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "ApproximateNumberOfMessagesVisible"
+  namespace           = "AWS/SQS"
+  period              = 300
+  statistic           = "Maximum"
+  threshold           = 0
+  alarm_description   = "Messages in the Lambda DLQ — an async invocation (reminders) failed and was dead-lettered. Inspect + redrive."
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    QueueName = var.lambda_dlq_name
+  }
+
+  tags = {
+    Name = "${var.project_name}-lambda-dlq-alarm-${var.environment}"
+  }
+}
+
+# Audit alarm: failed-login spike (possible credential stuffing / brute force).
+# A metric filter turns the structured audit log line (pino JSON,
+# `event: "auth.login.failure"`) on the auth Lambda's log group into a metric;
+# the alarm pages when it spikes. The log group is Lambda-auto-created, so it
+# must exist (the auth fn has run in prod) for the filter to apply.
+resource "aws_cloudwatch_log_metric_filter" "auth_login_failure" {
+  name           = "${var.project_name}-auth-login-failure-${var.environment}"
+  log_group_name = "/aws/lambda/${var.project_name}-auth-${var.environment}"
+  pattern        = "{ $.event = \"auth.login.failure\" }"
+
+  metric_transformation {
+    name          = "AuthLoginFailures"
+    namespace     = "FamilyGreenhouse/Audit"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "auth_login_failure_spike" {
+  alarm_name          = "${var.project_name}-auth-login-failure-spike-${var.environment}"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = aws_cloudwatch_log_metric_filter.auth_login_failure.metric_transformation[0].name
+  namespace           = "FamilyGreenhouse/Audit"
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 10
+  alarm_description   = "More than 10 failed logins in 5 min — possible credential stuffing / brute force."
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+  treat_missing_data  = "notBreaching"
+
+  tags = {
+    Name = "${var.project_name}-auth-login-failure-alarm-${var.environment}"
+  }
+}

--- a/infrastructure/modules/monitoring/variables.tf
+++ b/infrastructure/modules/monitoring/variables.tf
@@ -41,3 +41,9 @@ variable "monthly_budget_usd" {
   type        = string
   default     = "50"
 }
+
+variable "lambda_dlq_name" {
+  description = "Name of the Lambda/EventBridge dead-letter queue to alarm on. Empty disables the DLQ alarm."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
Closes R4 — applied to prod (additive: 5 add / 15 change / 0 destroy, plan now clean).

- **Dead-letter queue** (SQS, 14-day retention) for failed *async* invocations — the hourly reminders scan could previously fail past its retries and vanish silently. Wired to the EventBridge target (bounded retry + DLQ) and every Lambda's `dead_letter_config`; IAM + queue policy added.
- **DLQ-depth alarm** (> 0 → SNS): any dead-lettered message pages.
- **Failed-login alarm**: metric filter on the auth Lambda's structured logs (`event: "auth.login.failure"`) + alarm on >10/5min → SNS (brute-force / credential-stuffing signal).

Applied in two phases (queue+IAM, then Lambda DLQ config) to dodge the IAM-propagation race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)