### PR TITLE
ci: add Semgrep SAST (OSS, tokenless)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,33 @@ jobs:
             | tar -xz -C /tmp gitleaks
           /tmp/gitleaks detect --source . --config .gitleaks.toml --redact --no-banner --verbose
 
+  sast:
+    name: SAST (Semgrep)
+    runs-on: ubuntu-latest
+    # Semgrep OSS is free and tokenless (CodeQL would need GitHub Advanced
+    # Security, which isn't available on this private repo's plan). Runs the
+    # community rulesets relevant to our stack and gates on ERROR-severity
+    # findings only — high-confidence issues, low false-positive noise. Tune
+    # the rulesets / severity as the codebase grows.
+    container:
+      image: semgrep/semgrep
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Semgrep scan
+        run: |
+          semgrep scan \
+            --config p/javascript \
+            --config p/typescript \
+            --config p/react \
+            --config p/nodejs \
+            --config p/owasp-top-ten \
+            --config p/secrets \
+            --severity ERROR \
+            --error \
+            --metrics off
+
   terraform-validate:
     name: Terraform Validate
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes R5. CodeQL needs GitHub Advanced Security (not on this private repo's plan), so adds **Semgrep OSS** — free, tokenless.

New `sast` job runs the community rulesets for our stack (`p/javascript`, `p/typescript`, `p/react`, `p/nodejs`, `p/owasp-top-ten`, `p/secrets`) and gates on **ERROR severity only** (high-confidence, low false-positive). Tune as the codebase grows.

> Note: like all CI here, this can't run until the repo's GitHub Actions minutes are restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)