### PR TITLE
docs: CONTRIBUTING.md + ADRs (process maturity)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# Contributing to Family Greenhouse
+
+A collaborative plant-care app for households. This is how we make changes here.
+
+## Setup
+
+Node 20+, npm 10+. From the repo root:
+
+```bash
+npm install                       # installs across all workspaces
+npm --workspace backend run dev   # local Express mock at :4000 (seeds a household)
+npm --workspace frontend run dev  # Vite dev server at :3000
+```
+
+Sign in at http://localhost:3000 with `test@example.com` / `password123`.
+
+## The change workflow
+
+1. **Branch off `main`** — `fix/…`, `feat/…`, `chore/…`, `docs/…`, `ci/…`.
+2. Make the change. Match the surrounding code's style, comment density, and idioms.
+3. **Open a PR to `main`.** CI must pass.
+4. Squash-merge (the history is one commit per PR).
+
+`main` is the deploy branch: a `v*` tag deploys production; merges are the unit of review.
+
+## Quality gates (don't fight them — they catch real things)
+
+Three tiers, all enforced:
+
+- **pre-commit** (husky + lint-staged): ESLint + Prettier on changed files.
+- **pre-push**: `npm run typecheck` + `npm test` (full suite).
+- **CI** (`.github/workflows/ci.yml`): lint, typecheck, frontend+backend tests, Semgrep SAST, gitleaks, `npm audit`, terraform validate, build, Lighthouse, bundle-size, Playwright e2e + a11y.
+
+Run locally before pushing: `npm run typecheck && npm run lint && npm test`.
+
+## Commit messages — conventional commits (enforced by commitlint)
+
+```
+type(scope): subject in lowercase, ≤100 chars
+```
+
+Types: `feat` `fix` `docs` `style` `refactor` `perf` `test` `chore` `ci` `build` `revert`. **The subject must be lowercase** (commitlint rejects `Bump` / capitalized first words — a common Dependabot-PR gotcha). Body explains *why*, not *what*.
+
+## Conventions that matter
+
+- **TypeScript is strict.** No `any` escape hatches; no `@ts-ignore` (the one exception is `local-server.ts`, the dev-only mock).
+- **Validate at the boundary.** Every request body goes through a Zod schema (`backend/src/models/schemas.ts`); never trust input.
+- **Integrations degrade, never throw.** Perenual/Plant.id/OpenWeather/SES/SNS return `null`/log-line on failure so the app stays usable. Keep that pattern.
+- **DynamoDB is one table.** New access patterns are PK/SK/GSI design decisions — see [`docs/architecture.md`](docs/architecture.md) and write an ADR if it's non-obvious.
+- **New API route?** Add the `// METHOD /path` handler comment, the Terraform route, and the OpenAPI entry — `scripts/check-api-spec.mjs` (in CI) fails on drift.
+- **Accessibility is a release gate.** WCAG 2.2 AA, enforced by axe + Lighthouse in CI. See [`docs/accessibility.md`](docs/accessibility.md).
+- **No secrets in the repo.** gitleaks is blocking. Secrets go in AWS Secrets Manager / Lambda env / GitHub secrets.
+
+## Architecture decisions
+
+Significant or non-obvious decisions get an ADR — see [`docs/adr/`](docs/adr/). Add one (copy the template) when you make a choice a future contributor would otherwise have to reverse-engineer.
+
+## Docs you'll want
+
+`docs/development.md` (dev loop), `docs/architecture.md` (how it fits together), `docs/deployment.md`, `docs/testing.md`, `docs/runbooks.md` + `docs/incidents.md` (when prod breaks), `docs/compliance.md`.

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,14 @@
+# 0001 — Record architecture decisions
+
+**Status:** Accepted (2026-06-10)
+
+## Context
+Significant decisions (storage model, auth, deferrals, a reversal like the WAF) were captured only in commit messages, inline comments, and review docs — scattered and easy to lose. New contributors (and future-us) re-litigate settled questions.
+
+## Decision
+Keep lightweight ADRs in `docs/adr/`, one file per decision, numbered. Capture Context / Decision / Consequences. Write one for non-obvious choices and for anything someone might reasonably try to reverse.
+
+## Consequences
+- A durable, greppable trail of *why*.
+- Small per-decision overhead; we only write them for decisions that warrant it.
+- Backfilling old decisions is best-effort, done when the area is next touched.

--- a/docs/adr/0002-serverless-on-aws.md
+++ b/docs/adr/0002-serverless-on-aws.md
@@ -1,0 +1,16 @@
+# 0002 — Serverless on AWS, single region
+
+**Status:** Accepted
+
+## Context
+A solo-built household app with unpredictable, low early traffic needs to cost ~nothing at zero usage and scale without ops. Options weighed: containers (ECS/Fargate, always-on cost), a PaaS (Render/Fly, simpler but less control + own lock-in), or serverless on AWS.
+
+## Decision
+Serverless on AWS, single region (us-east-1): API Gateway HTTP API → Lambda (one per handler group) → DynamoDB, with Cognito, S3, SES/SNS, CloudFront, EventBridge. Everything in Terraform.
+
+## Consequences
+- **Scales to zero** — the running app costs ~$2–3/mo; no idle compute.
+- **Operationally light** — no servers to patch; AWS-managed everything.
+- **Trade-off: AWS lock-in.** Every layer is AWS; migrating off is months of work. Accepted as the right call for cost/ops at this stage — revisit only if a customer needs multi-cloud.
+- **Trade-off: single region.** A regional outage takes the app down. Multi-region (Global Tables + failover) is deliberately deferred — see `docs/deferred-resilience.md`; trigger is a B2B SLA or material non-US user base. DR is covered by PITR (drilled — `docs/runbooks.md`).
+- Cold starts exist but are acceptable at this scale (chat Lambda sized higher for the Bedrock loop).

--- a/docs/adr/0003-single-table-dynamodb.md
+++ b/docs/adr/0003-single-table-dynamodb.md
@@ -1,0 +1,16 @@
+# 0003 — Single-table DynamoDB
+
+**Status:** Accepted
+
+## Context
+The data is hierarchical and access is almost always household-scoped (a household's plants, a plant's tasks, a household's activity feed). A relational store would mean managing a server/connection pool (anti-serverless) and join-heavy queries; multiple DynamoDB tables would scatter related entities and multiply the things to provision.
+
+## Decision
+One DynamoDB table, on-demand (PAY_PER_REQUEST), single-table design: entity type encoded in the `SK` prefix (`HOUSEHOLD#`, `MEMBER#`, `PLANT#`, `TASK#`, …) under a household `PK`, with GSIs for the cross-cutting reads (tasks-by-due-date, tasks-by-assignee, API-key-by-hash). TTL on ephemeral rows (invites, caches, the Stripe-event ledger).
+
+## Consequences
+- **Single-digit-ms reads** on the known access patterns; no connection management; scales with traffic.
+- **On-demand billing** fits bursty/low traffic (no capacity planning); revisit provisioned+autoscaling only at sustained high volume.
+- **Trade-off: access patterns are designed up front.** A genuinely new query shape may need a new GSI — a deliberate change, not an ad-hoc `WHERE`. New non-obvious patterns warrant an ADR.
+- **Trade-off: no relational integrity / ad-hoc analytics.** Cross-entity consistency is handled with `TransactWrite` where it matters; analytics is computed in-app, not via SQL.
+- A curated static catalog backs species autocomplete so the app works even with Perenual off.

--- a/docs/adr/0004-no-waf-on-http-api.md
+++ b/docs/adr/0004-no-waf-on-http-api.md
@@ -1,0 +1,14 @@
+# 0004 — No WAF on the HTTP API (it's unsupported)
+
+**Status:** Accepted (2026-06)
+
+## Context
+A regional WAFv2 web ACL (rate-limit + AWS managed rule groups) had been provisioned with the intent of protecting the API. It was never actually associated — and an attempt to associate it failed in production: **WAFv2 cannot attach to an API Gateway *HTTP* API (apigatewayv2)**. WAF supports REST API stages, ALB, CloudFront, AppSync, Cognito, and App Runner — not HTTP APIs. So the ACL cost ~$8–16/mo and protected nothing.
+
+## Decision
+Remove the regional WAF entirely (`modules/security` deleted). Edge/abuse defense rests on: API Gateway stage **throttling** (100 burst / 50 rate), **Cognito threat protection** (PLUS tier), and **in-code rate limiting** (per-IP on auth, per-user on writes).
+
+## Consequences
+- Saves ~$8–16/mo; removes a false sense of protection.
+- **Trade-off: no managed-rule WAF at the edge** (e.g. generic SQLi/bad-input signatures). Low marginal value here — the API is a small JSON surface with parameterized DynamoDB (no SQL) and Zod validation.
+- To reintroduce a real edge WAF, front the HTTP API with **CloudFront** and attach a **CLOUDFRONT-scoped** ACL there, or migrate to a REST API. Reconsider at scale or on a security-driven requirement.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,24 @@
+# Architecture Decision Records
+
+Short, dated records of significant or non-obvious technical decisions — the *why* behind choices a future contributor (or future you) would otherwise have to reverse-engineer or accidentally undo.
+
+## Format
+
+One file per decision: `NNNN-short-title.md`, numbered sequentially. Each has: **Status** (Proposed / Accepted / Superseded by NNNN), **Context** (the forces at play), **Decision** (what we chose), **Consequences** (the trade-off we accepted). Keep them short — a screen or less.
+
+## When to write one
+
+- A choice with real trade-offs that wasn't obvious (storage model, auth provider, framework, a deliberate deferral).
+- A decision someone might reasonably try to reverse later — capture *why not* so they don't relearn it the hard way.
+- Not every PR. Routine changes don't need an ADR.
+
+## Index
+
+| # | Title | Status |
+|---|-------|--------|
+| [0001](0001-record-architecture-decisions.md) | Record architecture decisions | Accepted |
+| [0002](0002-serverless-on-aws.md) | Serverless on AWS, single region | Accepted |
+| [0003](0003-single-table-dynamodb.md) | Single-table DynamoDB | Accepted |
+| [0004](0004-no-waf-on-http-api.md) | No WAF on the HTTP API (it's unsupported) | Accepted |
+
+> Several earlier decisions (Cognito for auth, React+Vite+TanStack Query, gated external integrations) are documented inline in `docs/architecture.md` / `docs/strategy-review.md` and could be backfilled as ADRs when next touched.


### PR DESCRIPTION
Closes the R7 docs items.

- **CONTRIBUTING.md** — setup, branch/PR workflow, the three quality gates, conventional-commits (incl. the lowercase-subject gotcha), and the conventions that matter.
- **docs/adr/** — ADR practice + index + 4 backfilled decisions: meta, serverless-on-AWS (lock-in + single-region trade), single-table DynamoDB, no-WAF-on-HTTP-API (this session's reversal).

**arm64 deliberately deferred** (other R7 item): ~$0 now + needs a full prod code re-publish + awkward terraform/`ignore_changes` interaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)