### PR TITLE
fix(deploy): deploy.sh handler list + Function URL invoke grant (unapplied)

### DIFF
--- a/infrastructure/modules/api/main.tf
+++ b/infrastructure/modules/api/main.tf
@@ -452,6 +452,21 @@ resource "aws_lambda_permission" "chat_stream_url" {
   function_url_auth_type = "NONE"
 }
 
+# Since the October 2025 Lambda policy change, NONE-auth Function URLs reject
+# requests with 403 unless the resource policy grants lambda:InvokeFunction in
+# ADDITION to lambda:InvokeFunctionUrl. Verified empirically on first deploy:
+# with only the statement above, every URL call returned the front-door
+# "Forbidden ... urls-auth" body and the function was never invoked. The
+# function_url_auth_type condition keeps this grant URL-only — it does not
+# permit direct Invoke calls.
+resource "aws_lambda_permission" "chat_stream_url_invoke" {
+  statement_id           = "AllowPublicFunctionUrlInvokeFunction"
+  action                 = "lambda:InvokeFunction"
+  function_name          = aws_lambda_function.chat_stream.function_name
+  principal              = "*"
+  function_url_auth_type = "NONE"
+}
+
 # API Routes
 resource "aws_apigatewayv2_integration" "handlers" {
   for_each = local.lambda_handlers

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -84,7 +84,10 @@ aws cloudfront create-invalidation \
 # repackage each bundle as `handler.mjs` so Node resolves the right module
 # regardless of the zip's package.json.
 echo "Deploying Lambda functions..."
-HANDLERS=(auth plants tasks households me billing notifications species climate apiKeys api reminders chat)
+# chat-stream is the Function-URL streaming handler (bundle chat-stream.js);
+# digests is the EventBridge weekly/yearly email job. Keep this list in sync
+# with infrastructure/modules/api locals + the CD workflow's deploy loop.
+HANDLERS=(auth plants tasks households me billing notifications species climate apiKeys api reminders chat digests chat-stream)
 for handler in "${HANDLERS[@]}"; do
     FUNCTION_NAME="family-greenhouse-${handler}-${ENVIRONMENT}"
     SRC="backend/dist/${handler}.js"


### PR DESCRIPTION
Two fixes discovered during the manual production deploy (CD is billing-blocked):

1. **scripts/deploy.sh** — the Lambda loop was missing `digests` and `chat-stream`; manual deploys silently skipped them. (The CD workflow got the equivalent fix in #49.)
2. **Chat-stream Function URL 403** — since AWS's October 2025 policy change, NONE-auth Function URLs return a front-door 403 unless the resource policy grants `lambda:InvokeFunction` alongside `lambda:InvokeFunctionUrl`. Verified empirically: handler never invoked, AWS "urls-auth" Forbidden body. The added grant carries the `function_url_auth_type = "NONE"` condition, so it applies only to URL invocations, not direct SDK `Invoke`.

⚠️ **The new permission is committed but NOT applied to production** — it grants principal `*` (condition-scoped) and warrants a human look. After merging: `cd infrastructure && terraform apply -var-file=environments/production/terraform.tfvars`. Streaming remains off (`PRODUCTION_CHAT_STREAM_URL` unset) so nothing user-facing depends on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)