### PR TITLE
fix(ci): unblock main — api-spec coverage, semgrep finding, formatting, size budgets

### DIFF
--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -34,16 +34,22 @@ jobs:
     steps:
       - name: Determine version
         id: version
+        # Workflow-dispatch input flows through an env var, never ${{ }}
+        # interpolation inside `run:` — github context in a run script is a
+        # shell-injection vector (semgrep run-shell-injection).
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          if [ "${{ github.event_name }}" == "push" ]; then
+          if [ "$GITHUB_EVENT_NAME" == "push" ]; then
             echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
           else
-            echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+            echo "version=$INPUT_VERSION" >> $GITHUB_OUTPUT
           fi
 
       - name: Validate version format
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
           if [[ ! $VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Invalid version format: $VERSION"
             exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ Run locally before pushing: `npm run typecheck && npm run lint && npm test`.
 type(scope): subject in lowercase, ≤100 chars
 ```
 
-Types: `feat` `fix` `docs` `style` `refactor` `perf` `test` `chore` `ci` `build` `revert`. **The subject must be lowercase** (commitlint rejects `Bump` / capitalized first words — a common Dependabot-PR gotcha). Body explains *why*, not *what*.
+Types: `feat` `fix` `docs` `style` `refactor` `perf` `test` `chore` `ci` `build` `revert`. **The subject must be lowercase** (commitlint rejects `Bump` / capitalized first words — a common Dependabot-PR gotcha). Body explains _why_, not _what_.
 
 ## Conventions that matter
 

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -3,12 +3,15 @@
 **Status:** Accepted (2026-06-10)
 
 ## Context
+
 Significant decisions (storage model, auth, deferrals, a reversal like the WAF) were captured only in commit messages, inline comments, and review docs — scattered and easy to lose. New contributors (and future-us) re-litigate settled questions.
 
 ## Decision
+
 Keep lightweight ADRs in `docs/adr/`, one file per decision, numbered. Capture Context / Decision / Consequences. Write one for non-obvious choices and for anything someone might reasonably try to reverse.
 
 ## Consequences
-- A durable, greppable trail of *why*.
+
+- A durable, greppable trail of _why_.
 - Small per-decision overhead; we only write them for decisions that warrant it.
 - Backfilling old decisions is best-effort, done when the area is next touched.

--- a/docs/adr/0002-serverless-on-aws.md
+++ b/docs/adr/0002-serverless-on-aws.md
@@ -3,12 +3,15 @@
 **Status:** Accepted
 
 ## Context
+
 A solo-built household app with unpredictable, low early traffic needs to cost ~nothing at zero usage and scale without ops. Options weighed: containers (ECS/Fargate, always-on cost), a PaaS (Render/Fly, simpler but less control + own lock-in), or serverless on AWS.
 
 ## Decision
+
 Serverless on AWS, single region (us-east-1): API Gateway HTTP API → Lambda (one per handler group) → DynamoDB, with Cognito, S3, SES/SNS, CloudFront, EventBridge. Everything in Terraform.
 
 ## Consequences
+
 - **Scales to zero** — the running app costs ~$2–3/mo; no idle compute.
 - **Operationally light** — no servers to patch; AWS-managed everything.
 - **Trade-off: AWS lock-in.** Every layer is AWS; migrating off is months of work. Accepted as the right call for cost/ops at this stage — revisit only if a customer needs multi-cloud.

--- a/docs/adr/0003-single-table-dynamodb.md
+++ b/docs/adr/0003-single-table-dynamodb.md
@@ -3,12 +3,15 @@
 **Status:** Accepted
 
 ## Context
+
 The data is hierarchical and access is almost always household-scoped (a household's plants, a plant's tasks, a household's activity feed). A relational store would mean managing a server/connection pool (anti-serverless) and join-heavy queries; multiple DynamoDB tables would scatter related entities and multiply the things to provision.
 
 ## Decision
+
 One DynamoDB table, on-demand (PAY_PER_REQUEST), single-table design: entity type encoded in the `SK` prefix (`HOUSEHOLD#`, `MEMBER#`, `PLANT#`, `TASK#`, …) under a household `PK`, with GSIs for the cross-cutting reads (tasks-by-due-date, tasks-by-assignee, API-key-by-hash). TTL on ephemeral rows (invites, caches, the Stripe-event ledger).
 
 ## Consequences
+
 - **Single-digit-ms reads** on the known access patterns; no connection management; scales with traffic.
 - **On-demand billing** fits bursty/low traffic (no capacity planning); revisit provisioned+autoscaling only at sustained high volume.
 - **Trade-off: access patterns are designed up front.** A genuinely new query shape may need a new GSI — a deliberate change, not an ad-hoc `WHERE`. New non-obvious patterns warrant an ADR.

--- a/docs/adr/0004-no-waf-on-http-api.md
+++ b/docs/adr/0004-no-waf-on-http-api.md
@@ -3,12 +3,15 @@
 **Status:** Accepted (2026-06)
 
 ## Context
-A regional WAFv2 web ACL (rate-limit + AWS managed rule groups) had been provisioned with the intent of protecting the API. It was never actually associated — and an attempt to associate it failed in production: **WAFv2 cannot attach to an API Gateway *HTTP* API (apigatewayv2)**. WAF supports REST API stages, ALB, CloudFront, AppSync, Cognito, and App Runner — not HTTP APIs. So the ACL cost ~$8–16/mo and protected nothing.
+
+A regional WAFv2 web ACL (rate-limit + AWS managed rule groups) had been provisioned with the intent of protecting the API. It was never actually associated — and an attempt to associate it failed in production: **WAFv2 cannot attach to an API Gateway _HTTP_ API (apigatewayv2)**. WAF supports REST API stages, ALB, CloudFront, AppSync, Cognito, and App Runner — not HTTP APIs. So the ACL cost ~$8–16/mo and protected nothing.
 
 ## Decision
+
 Remove the regional WAF entirely (`modules/security` deleted). Edge/abuse defense rests on: API Gateway stage **throttling** (100 burst / 50 rate), **Cognito threat protection** (PLUS tier), and **in-code rate limiting** (per-IP on auth, per-user on writes).
 
 ## Consequences
+
 - Saves ~$8–16/mo; removes a false sense of protection.
 - **Trade-off: no managed-rule WAF at the edge** (e.g. generic SQLi/bad-input signatures). Low marginal value here — the API is a small JSON surface with parameterized DynamoDB (no SQL) and Zod validation.
 - To reintroduce a real edge WAF, front the HTTP API with **CloudFront** and attach a **CLOUDFRONT-scoped** ACL there, or migrate to a REST API. Reconsider at scale or on a security-driven requirement.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,6 +1,6 @@
 # Architecture Decision Records
 
-Short, dated records of significant or non-obvious technical decisions — the *why* behind choices a future contributor (or future you) would otherwise have to reverse-engineer or accidentally undo.
+Short, dated records of significant or non-obvious technical decisions — the _why_ behind choices a future contributor (or future you) would otherwise have to reverse-engineer or accidentally undo.
 
 ## Format
 
@@ -9,16 +9,16 @@ One file per decision: `NNNN-short-title.md`, numbered sequentially. Each has: *
 ## When to write one
 
 - A choice with real trade-offs that wasn't obvious (storage model, auth provider, framework, a deliberate deferral).
-- A decision someone might reasonably try to reverse later — capture *why not* so they don't relearn it the hard way.
+- A decision someone might reasonably try to reverse later — capture _why not_ so they don't relearn it the hard way.
 - Not every PR. Routine changes don't need an ADR.
 
 ## Index
 
-| # | Title | Status |
-|---|-------|--------|
-| [0001](0001-record-architecture-decisions.md) | Record architecture decisions | Accepted |
-| [0002](0002-serverless-on-aws.md) | Serverless on AWS, single region | Accepted |
-| [0003](0003-single-table-dynamodb.md) | Single-table DynamoDB | Accepted |
-| [0004](0004-no-waf-on-http-api.md) | No WAF on the HTTP API (it's unsupported) | Accepted |
+| #                                             | Title                                     | Status   |
+| --------------------------------------------- | ----------------------------------------- | -------- |
+| [0001](0001-record-architecture-decisions.md) | Record architecture decisions             | Accepted |
+| [0002](0002-serverless-on-aws.md)             | Serverless on AWS, single region          | Accepted |
+| [0003](0003-single-table-dynamodb.md)         | Single-table DynamoDB                     | Accepted |
+| [0004](0004-no-waf-on-http-api.md)            | No WAF on the HTTP API (it's unsupported) | Accepted |
 
 > Several earlier decisions (Cognito for auth, React+Vite+TanStack Query, gated external integrations) are documented inline in `docs/architecture.md` / `docs/strategy-review.md` and could be backfilled as ADRs when next touched.

--- a/docs/api-spec.yaml
+++ b/docs/api-spec.yaml
@@ -823,6 +823,119 @@ paths:
       responses:
         '200': { $ref: '#/components/responses/Ok' }
 
+  # --- 2026-06 roadmap wave: claiming, vacation, import, share, health,
+  # --- digests, phone verification, public-API writes ---
+  /tasks/{id}/claim:
+    post:
+      summary: Claim an unassigned ("up for grabs") task (409 if already claimed)
+      tags: [Tasks]
+      parameters: [{ $ref: '#/components/parameters/TaskId' }]
+      responses:
+        '200': { $ref: '#/components/responses/Ok' }
+  /tasks/{id}/unclaim:
+    post:
+      summary: Release a task you claimed (assignee only)
+      tags: [Tasks]
+      parameters: [{ $ref: '#/components/parameters/TaskId' }]
+      responses:
+        '200': { $ref: '#/components/responses/Ok' }
+  /tasks/vacation:
+    get:
+      summary: List active and upcoming vacation coverage windows
+      tags: [Tasks]
+      responses:
+        '200': { $ref: '#/components/responses/Ok' }
+    put:
+      summary: Set a vacation coverage window (admin required to set for others)
+      tags: [Tasks]
+      responses:
+        '200': { $ref: '#/components/responses/Ok' }
+  /tasks/vacation/{userId}:
+    delete:
+      summary: Clear a member's vacation window (self or admin)
+      tags: [Tasks]
+      parameters:
+        - { name: userId, in: path, required: true, schema: { type: string } }
+      responses:
+        '200': { $ref: '#/components/responses/Ok' }
+  /plants/import:
+    post:
+      summary: Bulk import up to 100 plants (+tasks); partial success at plan cap
+      tags: [Plants]
+      responses:
+        '200': { $ref: '#/components/responses/Ok' }
+  /plants/{id}/share:
+    post:
+      summary: Mint a 14-day cutting-share link for a plant snapshot
+      tags: [Plants]
+      parameters: [{ $ref: '#/components/parameters/PlantId' }]
+      responses:
+        '200': { $ref: '#/components/responses/Ok' }
+  /plants/shared/{code}:
+    get:
+      summary: Public preview of a shared cutting card (snapshot + household name)
+      tags: [Plants]
+      security: []
+      parameters:
+        - { name: code, in: path, required: true, schema: { type: string } }
+      responses:
+        '200': { $ref: '#/components/responses/Ok' }
+  /plants/shared/{code}/accept:
+    post:
+      summary: Copy a shared cutting into the caller's household (plan-capped)
+      tags: [Plants]
+      parameters:
+        - { name: code, in: path, required: true, schema: { type: string } }
+      responses:
+        '201': { $ref: '#/components/responses/Ok' }
+  /plants/{id}/health-check:
+    post:
+      summary: Leaf-health assessment of an uploaded photo (Bedrock vision)
+      tags: [Plants]
+      parameters: [{ $ref: '#/components/parameters/PlantId' }]
+      responses:
+        '200': { $ref: '#/components/responses/Ok' }
+  /notifications/run-digests:
+    post:
+      summary: Manually trigger the weekly plants-at-risk digest (admin, rate-limited)
+      tags: [Notifications]
+      responses:
+        '200': { $ref: '#/components/responses/Ok' }
+  /notifications/run-year-recap:
+    post:
+      summary: Manually trigger the year-in-review recap email (admin, rate-limited)
+      tags: [Notifications]
+      responses:
+        '200': { $ref: '#/components/responses/Ok' }
+  /notifications/phone/start-verification:
+    post:
+      summary: Send an SMS verification code to a phone number (3/hour)
+      tags: [Notifications]
+      responses:
+        '200': { $ref: '#/components/responses/Ok' }
+  /notifications/phone/confirm-verification:
+    post:
+      summary: Confirm the SMS code and mark the phone verified
+      tags: [Notifications]
+      responses:
+        '200': { $ref: '#/components/responses/Ok' }
+  /api/v1/tasks/{id}/complete:
+    post:
+      summary: Complete a task via API key (requires write:tasks scope)
+      tags: [Public API]
+      security: [{ apiKeyAuth: [] }]
+      parameters: [{ $ref: '#/components/parameters/TaskId' }]
+      responses:
+        '200': { $ref: '#/components/responses/Ok' }
+  /api/v1/tasks/{id}/snooze:
+    post:
+      summary: Snooze a task via API key (requires write:tasks scope)
+      tags: [Public API]
+      security: [{ apiKeyAuth: [] }]
+      parameters: [{ $ref: '#/components/parameters/TaskId' }]
+      responses:
+        '200': { $ref: '#/components/responses/Ok' }
+
 components:
   securitySchemes:
     bearerAuth:

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -34,7 +34,7 @@ Add to the privacy policy (US/California users).
 > **Your California privacy rights (CCPA/CPRA)**
 > We **do not sell or share** your personal information, and we never have.
 > You can access or delete your data at any time from **Settings → Account**
-> (export as JSON/CSV; permanent deletion via *Delete account*), or email
+> (export as JSON/CSV; permanent deletion via _Delete account_), or email
 > <support@familygreenhouse.net>. We will not discriminate against you for
 > exercising these rights.
 
@@ -51,7 +51,7 @@ For any EU user/customer:
 - **Data subject rights:** access + erasure are self-serve (export / delete account). Document the request path in the privacy policy.
 - **Sub-processors:** AWS (hosting), Stripe (billing), and the optional enrichment APIs (Perenual, Plant.id, OpenWeather) when enabled. Maintain a public sub-processor list; each has a standard DPA you reference rather than negotiate.
 - **DPA:** offer AWS's and Stripe's standard DPAs by reference; provide a short Family-Greenhouse DPA addendum for B2B customers who ask. Not needed for consumer users in most cases, but have a template ready.
-- **Account deletion caveat to disclose:** `DELETE /me` removes login + personal data but preserves household *activity history* under a pseudonymized member name (so a shared household's record stays coherent). State this explicitly in the privacy policy.
+- **Account deletion caveat to disclose:** `DELETE /me` removes login + personal data but preserves household _activity history_ under a pseudonymized member name (so a shared household's record stays coherent). State this explicitly in the privacy policy.
 
 ---
 
@@ -60,7 +60,7 @@ For any EU user/customer:
 SMS notifications are currently **gated off** (`SMS_NOTIFICATIONS_ENABLED` unset). **Do not enable SMS in production until all of the following exist**, or you risk TCPA liability (statutory damages per message):
 
 1. **Explicit, logged opt-in** — the user must affirmatively check a box to receive SMS, with consent timestamp + the exact consent language stored. A pre-checked box is not consent.
-2. **Phone-number verification** — send a one-time code and verify it before the number can receive any notification (prevents sending to a number the user mistyped or doesn't own). *This flow does not exist yet — it's the blocking work item.*
+2. **Phone-number verification** — send a one-time code and verify it before the number can receive any notification (prevents sending to a number the user mistyped or doesn't own). _This flow does not exist yet — it's the blocking work item._
 3. **STOP / unsubscribe** — honor inbound STOP, and include opt-out guidance ("Reply STOP to unsubscribe") in messages. Wire SNS opt-out handling.
 4. **Quiet hours / DND** — already implemented (`isInDndWindow`); keep it.
 5. **Records** — retain consent + opt-out records.

--- a/docs/growth/prompts/01-editorial-pipeline.md
+++ b/docs/growth/prompts/01-editorial-pipeline.md
@@ -6,7 +6,7 @@ Four prompts, run in order. Targets emotional/situational queries (the ICP who j
 
 ## Step 1 — Topic discovery
 
-> Give me 20 long-tail search queries someone who has *just realized they forgot to water a plant* (or whose plant is dying) would type into Google. I run a collaborative plant-care app for households, so I especially want queries with **emotional or situational** intent, and queries about **shared/household** plant care. Skip generic "how to care for [plant]" — those are handled elsewhere. For each, add a one-word intent tag (panic / guilt / logistics / relationship / comparison) and a rough monthly-volume guess (high / med / low). Rank by (intent strength × my ability to genuinely help).
+> Give me 20 long-tail search queries someone who has _just realized they forgot to water a plant_ (or whose plant is dying) would type into Google. I run a collaborative plant-care app for households, so I especially want queries with **emotional or situational** intent, and queries about **shared/household** plant care. Skip generic "how to care for [plant]" — those are handled elsewhere. For each, add a one-word intent tag (panic / guilt / logistics / relationship / comparison) and a rough monthly-volume guess (high / med / low). Rank by (intent strength × my ability to genuinely help).
 
 Pick one. Favor high-intent over high-volume.
 
@@ -15,8 +15,8 @@ Pick one. Favor high-intent over high-volume.
 ## Step 2 — Outline
 
 > Outline a 1800–2200 word article for the search query **"[QUERY]"**.
-> Context: it publishes on the blog of Family Greenhouse, a collaborative plant-care app for households (couples, roommates, families). Differentiator: the *right person reminded at the right time*, not a fancier plant database.
-> Requirements: 6–7 H2 sections, a contrarian or counterintuitive angle in the first third, at least two specific examples using real plant names and real numbers (watering intervals, etc.), and one section that only makes sense for a *household* (not a solo plant owner). End with a tight, non-salesy conclusion. NO filler sections ("introduction", "why this matters", "conclusion" as a heading). For each section, one line on what it argues.
+> Context: it publishes on the blog of Family Greenhouse, a collaborative plant-care app for households (couples, roommates, families). Differentiator: the _right person reminded at the right time_, not a fancier plant database.
+> Requirements: 6–7 H2 sections, a contrarian or counterintuitive angle in the first third, at least two specific examples using real plant names and real numbers (watering intervals, etc.), and one section that only makes sense for a _household_ (not a solo plant owner). End with a tight, non-salesy conclusion. NO filler sections ("introduction", "why this matters", "conclusion" as a heading). For each section, one line on what it argues.
 
 Kill the generic sections. Add your own angle.
 
@@ -35,11 +35,12 @@ Kill the generic sections. Add your own angle.
 ## Step 4 — Edit (run on YOUR rewritten draft, not the raw one)
 
 > Here's my edited draft. Be a skeptical editor:
+>
 > 1. Three specific things to cut (quote them).
 > 2. One place the voice sounds fake or AI-generated (quote it, say why).
 > 3. One section that's asserting without evidence — what concrete example would fix it.
 > 4. Is the contrarian angle actually contrarian, or is it the obvious take dressed up?
 > 5. The title and meta description: give me 3 options each, optimized for the target query, under 60 / 155 chars.
-> Don't rewrite it for me — tell me what to fix.
+>    Don't rewrite it for me — tell me what to fix.
 
 Then: write the `POSTS` entry (slug/title/description/date/readingMinutes) and add it to `frontend/src/features/blog/posts/index.ts`.

--- a/docs/growth/prompts/02-species-care-page.md
+++ b/docs/growth/prompts/02-species-care-page.md
@@ -14,11 +14,12 @@ The discipline that makes this work (and keeps Google happy): **the model writes
 >
 > **Voice:** warm, practical, never preachy — the friend who reminds you the plant's wilting, not the one lecturing about chlorophyll. Plain words. Specific numbers from the data. Light humor only in the `honestBit`, never in the care instructions a worried owner is reading. Bans: "in today's world", "unlock", "elevate", "dive into", "lush green companion", "thrive in your space".
 >
-> **The differentiator you must weave in once, naturally:** this plant's care is easy to *know* and easy to *forget* — and in a shared home the failure mode is "I thought you watered it." One section (`sharedCare`) should address keeping the plant alive when more than one person lives there. Don't make it an ad; make it genuinely useful.
+> **The differentiator you must weave in once, naturally:** this plant's care is easy to _know_ and easy to _forget_ — and in a shared home the failure mode is "I thought you watered it." One section (`sharedCare`) should address keeping the plant alive when more than one person lives there. Don't make it an ad; make it genuinely useful.
 >
 > **SEO:** the `faqs` (3–4) should answer the actual long-tail questions people type ("how often", "why yellow leaves", "is it toxic to cats", "how much light"). Keep each answer 1–3 sentences, grounded.
 >
 > DATA:
+>
 > ```
 > commonName: [e.g. Pothos]
 > alsoKnownAs: [Devil's Ivy, Epipremnum aureum]
@@ -33,6 +34,7 @@ The discipline that makes this work (and keeps Google happy): **the model writes
 > ```
 >
 > Output ONLY this JSON (no prose around it):
+>
 > ```ts
 > {
 >   slug: string,            // kebab-case, e.g. "pothos"

--- a/docs/growth/prompts/03-repurpose.md
+++ b/docs/growth/prompts/03-repurpose.md
@@ -14,12 +14,13 @@ One article → four distribution assets in one prompt. Amortizes the writing co
 > 4. **Cross-link block**: which 2 of my other articles/care pages this should link to, and the one-line anchor text for each.
 >
 > ARTICLE:
+>
 > ```
 > [paste]
 > ```
 
 ## Rules of the road (so this doesn't get you banned)
 
-- **Reddit:** comment 80%, post 20%. Build karma first. One *earned* product mention per week max. If it feels like a chore, stop — performative Reddit is worse than none. (Your `marketing-plan.md` already says this.)
+- **Reddit:** comment 80%, post 20%. Build karma first. One _earned_ product mention per week max. If it feels like a chore, stop — performative Reddit is worse than none. (Your `marketing-plan.md` already says this.)
 - **Twitter:** only if you'd genuinely enjoy posting 2–3×/week. Otherwise skip.
 - **Newsletter:** publish biweekly, not weekly — an empty cadence is worse than a slower one.

--- a/docs/growth/prompts/04-research-synthesis.md
+++ b/docs/growth/prompts/04-research-synthesis.md
@@ -12,12 +12,13 @@ Your strategy doc's #1 priority is real telemetry from the first users. This tur
 > 2. **The job they're hiring us for** — in their words, not mine. Is it "remember to water" or "stop fighting with my partner about chores" or something I didn't expect?
 > 3. **Friction**: where did people say (or imply) they almost didn't sign up / almost gave up.
 > 4. **Feature requests vs. underlying needs** — separate the literal ask from the need behind it.
-> 5. **The one thing** the data says I should build/fix next, and why — and the one thing on my roadmap this data suggests is *less* important than I think.
+> 5. **The one thing** the data says I should build/fix next, and why — and the one thing on my roadmap this data suggests is _less_ important than I think.
 > 6. **Quotes I could use** (with permission) as testimonials or landing-page copy.
 >
 > Be blunt. If the replies don't actually support a clear next step, say so rather than inventing one.
 >
 > REPLIES:
+>
 > ```
 > [paste, one per line or separated by ---]
 > ```

--- a/docs/growth/prompts/README.md
+++ b/docs/growth/prompts/README.md
@@ -6,25 +6,25 @@ These are Tier 1 (copy-paste). Tier 2 is the batch generator that runs the speci
 
 ## The one rule
 
-**Claude gets you 70% of the way; you do the 30% that makes it sound like a person.** Ship nothing that's 100% model output. The 30% is: the intro, the conclusion, one real opinion or anecdote, and cutting whatever feels generic. That ratio is the whole strategy — Claude-perfect content reads like every other AI blog and *ranks worse* than human-edited content.
+**Claude gets you 70% of the way; you do the 30% that makes it sound like a person.** Ship nothing that's 100% model output. The 30% is: the intro, the conclusion, one real opinion or anecdote, and cutting whatever feels generic. That ratio is the whole strategy — Claude-perfect content reads like every other AI blog and _ranks worse_ than human-edited content.
 
 ## Guardrails (every prompt assumes these)
 
-1. **Ground facts; never free-write care advice.** Care pages are generated *from* the species data you paste in, not from the model's memory. Wrong watering advice destroys trust and rankings. If a field is missing, omit that section — don't invent it.
+1. **Ground facts; never free-write care advice.** Care pages are generated _from_ the species data you paste in, not from the model's memory. Wrong watering advice destroys trust and rankings. If a field is missing, omit that section — don't invent it.
 2. **Brand voice** (from `docs/brand.md`): warm, practical, never preachy. The friend who reminds you the plant's wilting, not the one lecturing about chlorophyll. Light humor only at the edges, never in instructions a worried plant-owner is reading.
 3. **No AI tells.** Banned: "in today's world", "embark on a journey", "unlock", "elevate", "dive into", "it's worth noting", "navigate the world of", em-dash-everything, the rule-of-three cadence on every sentence.
-4. **Unique value per page.** Every page needs the angle no competitor has: the **collaborative-household hook** ("here's the cadence — and how to make sure *someone* actually does it"). A page that's just reworded plant facts is a doorway page Google deindexes.
+4. **Unique value per page.** Every page needs the angle no competitor has: the **collaborative-household hook** ("here's the cadence — and how to make sure _someone_ actually does it"). A page that's just reworded plant facts is a doorway page Google deindexes.
 5. **Human-in-the-loop, in batches.** Approve 10–20 at a time. Reject thin ones; don't ship volume for its own sake.
 6. **Publish in waves, watch Search Console.** 20 pages → confirm they index and quality signals hold → then scale.
 
 ## Files
 
-| Prompt | Use for |
-|--------|---------|
+| Prompt                     | Use for                                                       |
+| -------------------------- | ------------------------------------------------------------- |
 | `01-editorial-pipeline.md` | The weekly long-form article (topic → outline → draft → edit) |
-| `02-species-care-page.md` | ⭐ Grounded programmatic care page — the scale lever |
-| `03-repurpose.md` | Fan one article out to tweet / Reddit / email / cross-links |
-| `04-research-synthesis.md` | Turn signup-survey replies into a prioritized themes list |
+| `02-species-care-page.md`  | ⭐ Grounded programmatic care page — the scale lever          |
+| `03-repurpose.md`          | Fan one article out to tweet / Reddit / email / cross-links   |
+| `04-research-synthesis.md` | Turn signup-survey replies into a prioritized themes list     |
 
 ## A note on the model
 

--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -91,7 +91,7 @@ Then re-run `GET /health` and the smoke check. **Frontend** rollback = re-sync t
 
 > ✅ **Drilled 2026-06-09** against the live table (restore to a throwaway table, validated, deleted). PITR is enabled; the procedure below works.
 > **Observed RTO ≈ 3.5 min** (35-item table → ACTIVE; larger tables take longer — minutes, not seconds, even when small). **RPO ≈ 5 min** (DynamoDB PITR's restore granularity — you can lose up to ~5 min of writes).
-> ⚠️ Restoring is non-destructive *if* you restore to a NEW table (below). Never restore over the live table.
+> ⚠️ Restoring is non-destructive _if_ you restore to a NEW table (below). Never restore over the live table.
 
 1. Confirm PITR + the restorable window:
    ```bash

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,17 +27,17 @@
     {
       "name": "Initial JS (brotli)",
       "path": "dist/assets/index-*.js",
-      "limit": "56 kB"
+      "limit": "62 kB"
     },
     {
       "name": "Vendor chunk (brotli)",
       "path": "dist/assets/vendor-*.js",
-      "limit": "55 kB"
+      "limit": "51 kB"
     },
     {
       "name": "All JS combined (brotli)",
       "path": "dist/assets/*.js",
-      "limit": "270 kB"
+      "limit": "312 kB"
     },
     {
       "name": "CSS (brotli)",

--- a/frontend/src/features/care/CareGuidePage.tsx
+++ b/frontend/src/features/care/CareGuidePage.tsx
@@ -175,8 +175,8 @@ export function CareGuidePage() {
             Stop guessing when you watered it
           </p>
           <p className="mt-2 text-sm text-gray-600">
-            Family Greenhouse tracks your {guide.commonName.toLowerCase()}’s schedule and reminds the
-            right person — so “I thought you watered it” stops being a thing. Free for up to 10
+            Family Greenhouse tracks your {guide.commonName.toLowerCase()}’s schedule and reminds
+            the right person — so “I thought you watered it” stops being a thing. Free for up to 10
             plants, no card.
           </p>
           <div className="mt-4">


### PR DESCRIPTION
First real CI signal since billing was fixed (GitHub Pro). Jobs had failed-to-start since Jun 10, so these gates never ran on #41/#47/#49/#50:

- **api-spec gate**: documents the 16 routes added in #49 (90 routes total now)
- **Semgrep (blocking)**: workflow_dispatch version input now flows through `env:` instead of `${{ }}` in `run:` (run-shell-injection)
- **prettier**: 14 files (mostly docs from #41/#47) formatted
- **size-limit**: re-baselined per the documented regression-gate policy — index 62 kB, all-JS 312 kB (15 new lazy-loaded features), vendor *tightened* 55→51 kB
- gitignore terraform plan files

Local verification: spec gate ✓, prettier ✓, CI-identical semgrep sweep 0 findings ✓, measured brotli sizes within new budgets ✓, unit suites + typecheck still green ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)