### PR TITLE
chore(repo): security policy + daily actions dependabot during node20 deprecation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,11 +55,13 @@ updates:
       - frontend
 
   # --- GitHub Actions ---
+  # Daily while the Node 20 runner deprecation window is open (GitHub forces
+  # actions onto Node 24 starting 2026-06-16; checkout@v4 / setup-node@v4 /
+  # codecov@v4 need major bumps). Drop back to weekly once those land.
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
-      day: monday
+      interval: daily
     labels:
       - dependencies
       - ci

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+Family Greenhouse is a small, actively maintained project. Security reports
+are read and acted on quickly — thank you for taking the time.
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for security problems.**
+
+- Preferred: use GitHub's private vulnerability reporting
+  ("Security" tab → "Report a vulnerability") on this repository.
+- Or email: security@familygreenhouse.net
+
+You can expect an acknowledgement within 72 hours. Please include enough
+detail to reproduce (endpoint, request shape, account state). Reports
+affecting other users' data are treated as the highest severity.
+
+## Scope
+
+- The application at https://familygreenhouse.net and its API
+- This repository's code and infrastructure definitions
+
+Out of scope: denial-of-service volume testing, social engineering, and
+findings that require a compromised device or account. Automated scanning
+against production is discouraged — the same code runs locally
+(`npm --workspace backend run dev`), so most findings can be demonstrated
+offline.
+
+## Disclosure
+
+Coordinated disclosure is appreciated; fixes for confirmed reports are
+typically deployed within days. Past security reviews and their remediations
+are documented in `docs/reviews/` and `docs/security-review-2026-05-31.md`.


### PR DESCRIPTION
- SECURITY.md: private vulnerability reporting + security@ contact, scope,
  disclosure expectations (prerequisite for going public).
- dependabot github-actions cadence weekly -> daily until the forced Node 24
  runner migration (2026-06-16) bumps land (checkout/setup-node/codecov v4).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
