### PR TITLE
fix(ci): drop size-limit time plugin, measure file sizes (brotli) only

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,27 +22,31 @@
     "lighthouse:mobile": "lhci autorun --config=lighthouserc.mobile.cjs",
     "size": "size-limit"
   },
-  "_size-limit-note": "Budgets are REGRESSION GATES set ~8% above the current measured size (brotli), not aspirational targets — the old values (40/60/230/10) were below what the app has ever shipped, so the check was permanently red and gated nothing. Trimming the bundle further (the index chunk and Tailwind CSS are the candidates) is tracked as future work for when real-device Lighthouse data shows it matters. Keep these tight: lower them whenever a real reduction lands.",
+  "_size-limit-note": "Budgets are REGRESSION GATES set ~8% above the current measured size (brotli), not aspirational targets — the old values (40/60/230/10) were below what the app has ever shipped, so the check was permanently red and gated nothing. Trimming the bundle further (the index chunk and Tailwind CSS are the candidates) is tracked as future work for when real-device Lighthouse data shows it matters. Keep these tight: lower them whenever a real reduction lands. Measured with @size-limit/file (brotli) only — the preset-app 'time' plugin ran headless Chrome to estimate JS execution time, gated nothing (no time budgets), and broke CI+local runs with puppeteer navigation timeouts.",
   "size-limit": [
     {
       "name": "Initial JS (brotli)",
       "path": "dist/assets/index-*.js",
-      "limit": "62 kB"
+      "limit": "62 kB",
+      "brotli": true
     },
     {
       "name": "Vendor chunk (brotli)",
       "path": "dist/assets/vendor-*.js",
-      "limit": "51 kB"
+      "limit": "51 kB",
+      "brotli": true
     },
     {
       "name": "All JS combined (brotli)",
       "path": "dist/assets/*.js",
-      "limit": "312 kB"
+      "limit": "312 kB",
+      "brotli": true
     },
     {
       "name": "CSS (brotli)",
       "path": "dist/assets/*.css",
-      "limit": "15 kB"
+      "limit": "15 kB",
+      "brotli": true
     }
   ],
   "dependencies": {
@@ -73,7 +77,7 @@
     "@hookform/resolvers": "^3.3.4",
     "@lhci/cli": "^0.15.1",
     "@playwright/test": "^1.43.0",
-    "@size-limit/preset-app": "^12.1.0",
+    "@size-limit/file": "^12.1.0",
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "^14.2.2",
     "@testing-library/user-event": "^14.5.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -603,7 +603,7 @@
         "@hookform/resolvers": "^3.3.4",
         "@lhci/cli": "^0.15.1",
         "@playwright/test": "^1.43.0",
-        "@size-limit/preset-app": "^12.1.0",
+        "@size-limit/file": "^12.1.0",
         "@testing-library/jest-dom": "^6.4.2",
         "@testing-library/react": "^14.2.2",
         "@testing-library/user-event": "^14.5.2",
@@ -5988,56 +5988,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@sitespeed.io/tracium": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@sitespeed.io/tracium/-/tracium-0.3.3.tgz",
-      "integrity": "sha512-dNZafjM93Y+F+sfwTO5gTpsGXlnc/0Q+c2+62ViqP3gkMWvHEMSKkaEHgVJLcLg3i/g19GSIPziiKpgyne07Bw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "debug": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@size-limit/file": {
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/@size-limit/file/-/file-12.1.0.tgz",
       "integrity": "sha512-eGwDcIufnNnvJRzv3liDOn6MAOGgmOTUdpeGQ2KuRTlgIgO54AJH1ilvktlJc6PIjNfwpYY0dOGyap1QgM1swQ==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "size-limit": "12.1.0"
-      }
-    },
-    "node_modules/@size-limit/preset-app": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@size-limit/preset-app/-/preset-app-12.1.0.tgz",
-      "integrity": "sha512-pGGOxzDMM6MUXCzTwUjIcgex9RYbGdvQYni1rUtsZ1oojm7JvOSbBMiJPe9PhpmDq/aMsVzjP1oN0guq1RptVw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@size-limit/file": "12.1.0",
-        "@size-limit/time": "12.1.0",
-        "size-limit": "12.1.0"
-      },
-      "peerDependencies": {
-        "size-limit": "12.1.0"
-      }
-    },
-    "node_modules/@size-limit/time": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@size-limit/time/-/time-12.1.0.tgz",
-      "integrity": "sha512-ekYPeZcvkPSLsHtqNmz7F5jx3R0HV7CpY7kGasBW2yKR3NrD0JWMAcswS9OCR8OzK9hyLACRTNYTpLI9PXLczQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "estimo": "^3.0.5"
-      },
       "engines": {
         "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
       },
@@ -10441,36 +10397,6 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/estimo": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/estimo/-/estimo-3.0.5.tgz",
-      "integrity": "sha512-Q9asaAAM3KZc4Ckr8GMcJWYc3hNCf0KnmhkfzHuAWmqGoPssQoe5Mb8et1CYmmkeMfPTlUyeBHRi53Bedvnl1Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sitespeed.io/tracium": "0.3.3",
-        "commander": "12.0.0",
-        "find-chrome-bin": "2.0.4",
-        "nanoid": "5.1.5",
-        "puppeteer-core": "24.22.0"
-      },
-      "bin": {
-        "estimo": "scripts/cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/estimo/node_modules/commander": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.0.0.tgz",
-      "integrity": "sha512-MwVNWlYjDTtOjX5PiD7o5pK0UrFU/OYgcJfjjK4RaHZETNtjJqrZa9Y9ds88+A+f+d5lv+561eZ+yCKoS3gbAA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/estraverse": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
@@ -10983,19 +10909,6 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/find-chrome-bin": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/find-chrome-bin/-/find-chrome-bin-2.0.4.tgz",
-      "integrity": "sha512-iKiqIb7FsA0hwnq0vvDay4RsmHUFLvWVquTb59XVlxfHS68XaWZfEjriF2vTZ3k/plicyKZxMJLqxKt10kSOtQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@puppeteer/browsers": "2.10.10"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
     },
     "node_modules/find-up": {
       "version": "7.0.0",
@@ -14736,25 +14649,6 @@
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
-      }
-    },
-    "node_modules/nanoid": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
-      "integrity": "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
       }
     },
     "node_modules/nanospinner": {


### PR DESCRIPTION
@size-limit/preset-app bundles the 'time' plugin, which boots headless
Chrome via estimo/puppeteer to estimate JS execution time. It gated
nothing (budgets are size-only), and broke both CI and local runs with
puppeteer navigation timeouts. @size-limit/file with brotli: true keeps
the budgets identical and the check deterministic.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
