### PR TITLE
feat(frontend): design backlog - asymmetric hero, botanical icons, content fixes

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,5 +1,10 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
+  // Dependabot writes "chore(deps): Bump x from 1 to 2" — capital B trips
+  // subject-case and there's no upstream setting to change it. The repo
+  // squash-merges, so the human-edited PR title is what lands on main;
+  // skipping dependabot's own branch commits costs nothing.
+  ignores: [(message) => /^chore\(deps.*\): Bump /.test(message)],
   rules: {
     'type-enum': [
       2,

--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -44,25 +44,25 @@
     <loc>https://app.familygreenhouse.com/blog/how-to-remember-to-water-plants</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
-    <lastmod>2026-04-25</lastmod>
+    <lastmod>2026-05-05</lastmod>
   </url>
   <url>
     <loc>https://app.familygreenhouse.com/blog/sharing-plant-care-without-becoming-the-nag</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
-    <lastmod>2026-04-25</lastmod>
+    <lastmod>2026-05-13</lastmod>
   </url>
   <url>
     <loc>https://app.familygreenhouse.com/blog/low-maintenance-houseplants-for-forgetful-people</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
-    <lastmod>2026-04-25</lastmod>
+    <lastmod>2026-05-21</lastmod>
   </url>
   <url>
     <loc>https://app.familygreenhouse.com/blog/how-to-move-plants-without-killing-them</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
-    <lastmod>2026-04-25</lastmod>
+    <lastmod>2026-05-28</lastmod>
   </url>
   <url>
     <loc>https://app.familygreenhouse.com/care/pothos</loc>
@@ -81,5 +81,11 @@
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <lastmod>2026-06-08</lastmod>
+  </url>
+  <url>
+    <loc>https://app.familygreenhouse.com/care/spider-plant</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+    <lastmod>2026-06-12</lastmod>
   </url>
 </urlset>

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -14,7 +14,7 @@ export function Footer() {
         <p className="mt-2 text-sm italic text-gray-500">
           In loving memory of my mom, Joyce - who taught us to keep growing. 🌱
         </p>
-        <p className="mt-2 text-xs text-gray-400">
+        <p className="mt-2 text-xs text-gray-500">
           Plant data powered by{' '}
           <a
             href="https://perenual.com/"

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -157,7 +157,7 @@ export function Layout() {
         <footer className="px-4 pb-8 pt-6 sm:px-6 lg:px-8">
           <div className="flex items-center justify-center gap-4">
             <MemorialFrame className="h-8 w-32 text-primary-700/40 hidden sm:block" />
-            <p className="text-center text-xs italic text-gray-500">
+            <p className="text-center text-xs italic text-gray-600">
               In loving memory of my mom, Joyce — who taught us to keep growing.
             </p>
             <MemorialFrame className="h-8 w-32 text-primary-700/40 hidden sm:block -scale-x-100" />

--- a/frontend/src/components/icons/CalendarLeafIcon.tsx
+++ b/frontend/src/components/icons/CalendarLeafIcon.tsx
@@ -1,0 +1,41 @@
+/**
+ * Landing feature icon — the scannable week. A calendar page with its
+ * two binding posts, and a single leaf growing across the date grid:
+ * the week, but for plants. Replaces the stock Heroicons
+ * CalendarDaysIcon on the landing features grid. Same hand-drawn stroke
+ * conventions as the botanical task icons (WaterDropIcon et al.).
+ */
+interface IconProps {
+  className?: string;
+}
+
+export function CalendarLeafIcon({ className }: IconProps) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      {/* Calendar page */}
+      <rect x="3.75" y="5.25" width="16.5" height="15" rx="2" />
+      {/* Header rule, hand-drawn slightly off-straight */}
+      <path d="M 4 9.75 Q 12 9.3 20 9.75" />
+      {/* Binding posts */}
+      <path d="M 8.25 3 V 6.5" />
+      <path d="M 15.75 3 V 6.5" />
+      {/* Leaf across the date grid */}
+      <path
+        d="M 8.6 17.4 Q 8.6 12.6 15.4 12.6 Q 15.4 17.4 8.6 17.4 Z"
+        fill="currentColor"
+        fillOpacity="0.8"
+      />
+      {/* Leaf stem trailing off the blade */}
+      <path d="M 8.6 17.4 Q 7.4 18 6.8 18.6" />
+    </svg>
+  );
+}

--- a/frontend/src/components/icons/GrowthRingsIcon.tsx
+++ b/frontend/src/components/icons/GrowthRingsIcon.tsx
@@ -1,0 +1,52 @@
+/**
+ * Landing feature icon — the plant's memory. Three stems of rising
+ * height along one ground line: a bar chart, but grown. Replaces the
+ * stock Heroicons ChartBarIcon on the landing features grid. Same
+ * hand-drawn stroke conventions as the botanical task icons
+ * (WaterDropIcon et al.).
+ */
+interface IconProps {
+  className?: string;
+}
+
+export function GrowthRingsIcon({ className }: IconProps) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      {/* Ground baseline */}
+      <path d="M 3.5 20.5 Q 12 19.6 20.5 20.5" />
+      {/* Short stem — the first entry in the log */}
+      <path d="M 6.5 20 V 16.4" />
+      <circle cx="6.5" cy="15.6" r="0.95" fill="currentColor" stroke="none" />
+      {/* Middle stem with one leaf */}
+      <path d="M 12 20 V 11.6" />
+      <path
+        d="M 12 14.4 Q 9.6 13.8 8.7 15.8 Q 11 16.3 12 14.4 Z"
+        fill="currentColor"
+        fillOpacity="0.8"
+      />
+      <circle cx="12" cy="10.8" r="0.95" fill="currentColor" stroke="none" />
+      {/* Tall stem with two leaves — the full history */}
+      <path d="M 17.5 20 V 6.6" />
+      <path
+        d="M 17.5 10 Q 15.1 9.4 14.2 11.4 Q 16.5 11.9 17.5 10 Z"
+        fill="currentColor"
+        fillOpacity="0.8"
+      />
+      <path
+        d="M 17.5 13 Q 19.9 12.4 20.8 14.4 Q 18.5 14.9 17.5 13 Z"
+        fill="currentColor"
+        fillOpacity="0.8"
+      />
+      <circle cx="17.5" cy="5.8" r="0.95" fill="currentColor" stroke="none" />
+    </svg>
+  );
+}

--- a/frontend/src/components/icons/HouseholdSproutsIcon.tsx
+++ b/frontend/src/components/icons/HouseholdSproutsIcon.tsx
@@ -1,0 +1,57 @@
+/**
+ * Landing feature icon — shared household care. Three sprouts of
+ * different heights growing from the same patch of ground: everyone in
+ * the house, tending the same garden. Replaces the stock Heroicons
+ * UserGroupIcon on the landing features grid. Same hand-drawn stroke
+ * conventions as the botanical task icons (WaterDropIcon et al.).
+ */
+interface IconProps {
+  className?: string;
+}
+
+export function HouseholdSproutsIcon({ className }: IconProps) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      {/* Shared ground line */}
+      <path d="M 3.5 20.5 Q 12 19.8 20.5 20.5" />
+      {/* Tall center sprout with two leaves */}
+      <path d="M 12 20 V 9" />
+      <path
+        d="M 12 11.6 Q 9.4 10.9 8.4 12.8 Q 10.8 13.4 12 11.6 Z"
+        fill="currentColor"
+        fillOpacity="0.85"
+      />
+      <path
+        d="M 12 14.2 Q 14.6 13.5 15.6 15.4 Q 13.2 16 12 14.2 Z"
+        fill="currentColor"
+        fillOpacity="0.85"
+      />
+      <circle cx="12" cy="8.6" r="1.1" fill="currentColor" stroke="none" />
+      {/* Shorter sprout, left */}
+      <path d="M 5.6 20 Q 5.6 16.8 6.8 14.4" />
+      <path
+        d="M 6.3 16.2 Q 4.4 15.4 3.4 16.7 Q 5.3 17.5 6.4 16.4 Z"
+        fill="currentColor"
+        fillOpacity="0.7"
+      />
+      <circle cx="7" cy="14" r="0.9" fill="currentColor" stroke="none" />
+      {/* Shorter sprout, right */}
+      <path d="M 18.4 20 Q 18.4 16.8 17.2 14.4" />
+      <path
+        d="M 17.7 16.2 Q 19.6 15.4 20.6 16.7 Q 18.7 17.5 17.6 16.4 Z"
+        fill="currentColor"
+        fillOpacity="0.7"
+      />
+      <circle cx="17" cy="14" r="0.9" fill="currentColor" stroke="none" />
+    </svg>
+  );
+}

--- a/frontend/src/components/icons/PhoneLeafIcon.tsx
+++ b/frontend/src/components/icons/PhoneLeafIcon.tsx
@@ -1,0 +1,43 @@
+/**
+ * Landing feature icon — works at the sink. A phone outline with a
+ * little sprout filling the screen: the app installed where the watering
+ * happens. Replaces the stock Heroicons DevicePhoneMobileIcon on the
+ * landing features grid. Same hand-drawn stroke conventions as the
+ * botanical task icons (WaterDropIcon et al.).
+ */
+interface IconProps {
+  className?: string;
+}
+
+export function PhoneLeafIcon({ className }: IconProps) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      {/* Phone body */}
+      <rect x="7" y="2.75" width="10" height="18.5" rx="2.5" />
+      {/* Home indicator */}
+      <path d="M 10.75 18.6 H 13.25" />
+      {/* Sprout on the screen */}
+      <path d="M 12 15.8 V 8.4" />
+      <path
+        d="M 12 10.8 Q 9.4 10.1 8.6 12.1 Q 10.9 12.7 12 10.8 Z"
+        fill="currentColor"
+        fillOpacity="0.85"
+      />
+      <path
+        d="M 12 13.2 Q 14.6 12.5 15.4 14.5 Q 13.1 15.1 12 13.2 Z"
+        fill="currentColor"
+        fillOpacity="0.85"
+      />
+      <circle cx="12" cy="8" r="1" fill="currentColor" stroke="none" />
+    </svg>
+  );
+}

--- a/frontend/src/components/icons/ReminderBellbloomIcon.tsx
+++ b/frontend/src/components/icons/ReminderBellbloomIcon.tsx
@@ -1,0 +1,41 @@
+/**
+ * Landing feature icon — reminders. A bell-shaped flower (campanula)
+ * hanging from an arched stem, with two chime waves rising off the bloom:
+ * the reminder bell, grown instead of forged. Replaces the stock
+ * Heroicons BellAlertIcon on the landing features grid. Same hand-drawn
+ * stroke conventions as the botanical task icons (WaterDropIcon et al.).
+ */
+interface IconProps {
+  className?: string;
+}
+
+export function ReminderBellbloomIcon({ className }: IconProps) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      {/* Arching stem from the ground up to the bloom */}
+      <path d="M 4.5 21 C 4.5 13.5 7.5 7.5 14 6.5" />
+      {/* Leaf on the stem */}
+      <path
+        d="M 6.4 14.6 Q 3.2 14.2 2.6 16.6 Q 5.6 17 6.6 14.8 Z"
+        fill="currentColor"
+        fillOpacity="0.85"
+      />
+      {/* Hanging bell flower */}
+      <path d="M 14 6.5 c -2.4 0.5 -3.1 2.2 -3.1 4.3 0 1.5 -0.6 2.5 -1.5 3.4 h 9.2 c -0.9 -0.9 -1.5 -1.9 -1.5 -3.4 0 -2.1 -0.7 -3.8 -3.1 -4.3 z" />
+      {/* Clapper / stamen */}
+      <circle cx="14" cy="16" r="1" fill="currentColor" stroke="none" />
+      {/* Chime waves — the reminder going out */}
+      <path d="M 20.6 8.4 Q 21.8 10.4 20.8 12.4" opacity="0.6" />
+      <path d="M 22 7.2 Q 23.2 9.6 22.2 12" opacity="0.35" />
+    </svg>
+  );
+}

--- a/frontend/src/components/icons/RootLockIcon.tsx
+++ b/frontend/src/components/icons/RootLockIcon.tsx
@@ -1,0 +1,38 @@
+/**
+ * Landing feature icon — yours to keep. A padlock with roots growing
+ * out of its base: the data is locked down, and it's planted with you,
+ * not with us. Replaces the stock Heroicons ShieldCheckIcon on the
+ * landing features grid. Same hand-drawn stroke conventions as the
+ * botanical task icons (WaterDropIcon et al.).
+ */
+interface IconProps {
+  className?: string;
+}
+
+export function RootLockIcon({ className }: IconProps) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      {/* Shackle */}
+      <path d="M 8.75 9.5 V 7.5 a 3.25 3.25 0 0 1 6.5 0 v 2" />
+      {/* Lock body */}
+      <rect x="5.75" y="9.5" width="12.5" height="7.5" rx="1.5" />
+      {/* Keyhole */}
+      <circle cx="12" cy="12.6" r="1" fill="currentColor" stroke="none" />
+      <path d="M 12 13.6 V 14.9" />
+      {/* Roots growing from the base — wavy, not straight legs */}
+      <path d="M 8.6 17 C 8.8 18.6 8 19.8 6.8 20.7" />
+      <path d="M 12 17 C 11.6 18.4 12.4 19.6 12 21" />
+      <path d="M 12.1 19 Q 13.3 19.3 13.9 20.4" opacity="0.7" />
+      <path d="M 15.4 17 C 15.2 18.6 16 19.8 17.2 20.7" />
+    </svg>
+  );
+}

--- a/frontend/src/features/analytics/AnalyticsPage.tsx
+++ b/frontend/src/features/analytics/AnalyticsPage.tsx
@@ -333,7 +333,7 @@ function DailyTrend({ series }: DailyTrendProps) {
           />
         </svg>
       </div>
-      <p className="text-xs text-gray-500">
+      <p className="text-xs text-gray-600">
         Bars: tasks completed per day. Line: 7-day moving average.
       </p>
     </div>
@@ -348,7 +348,7 @@ function KpiTile({ label, value, tone }: { label: string; value: number; tone?: 
         tone === 'warning' ? 'border-amber-300 bg-amber-50' : 'border-gray-200 bg-white'
       )}
     >
-      <p className="text-xs font-medium text-gray-500">{label}</p>
+      <p className="text-xs font-medium text-gray-600">{label}</p>
       <p
         className={clsx(
           'mt-1 text-2xl font-semibold tabular-nums',

--- a/frontend/src/features/blog/posts/index.ts
+++ b/frontend/src/features/blog/posts/index.ts
@@ -34,7 +34,7 @@ export const POSTS: BlogPost[] = [
     title: 'How to actually remember to water your plants',
     description:
       'Why most people forget to water their plants — and the three systems that actually work, ranked from worst to best.',
-    date: '2026-04-25',
+    date: '2026-05-05',
     readingMinutes: 5,
     Component: RememberingToWater,
   },
@@ -43,7 +43,7 @@ export const POSTS: BlogPost[] = [
     title: 'Sharing plant care without becoming the household nag',
     description:
       "Almost every couple I've talked to has the same plant-care argument. Here's the structural fix that doesn't require either of you to remember more.",
-    date: '2026-04-25',
+    date: '2026-05-13',
     readingMinutes: 6,
     Component: SharingPlantCare,
   },
@@ -52,7 +52,7 @@ export const POSTS: BlogPost[] = [
     title: 'Seven houseplants that survive being forgotten',
     description:
       "Most 'low maintenance plant' lists are repeats of each other. Here are seven that genuinely fail in recoverable ways — ranked by how forgiving they are when life gets busy.",
-    date: '2026-04-25',
+    date: '2026-05-21',
     readingMinutes: 5,
     Component: LowWaterPlants,
   },
@@ -61,7 +61,7 @@ export const POSTS: BlogPost[] = [
     title: 'How to move with houseplants without killing them',
     description:
       "I've moved with thirty-seven plants three times. Here's what changed between losing eight, losing three, and losing none — plus the long-distance freeze problem nobody warns you about.",
-    date: '2026-04-25',
+    date: '2026-05-28',
     readingMinutes: 6,
     Component: MovingWithPlants,
   },

--- a/frontend/src/features/care/careGuides.ts
+++ b/frontend/src/features/care/careGuides.ts
@@ -226,6 +226,66 @@ export const CARE_GUIDES: CareGuide[] = [
       },
     ],
   },
+  {
+    slug: 'spider-plant',
+    commonName: 'Spider Plant',
+    scientificName: 'Chlorophytum comosum',
+    alsoKnownAs: ['Airplane Plant', 'Ribbon Plant', 'Spider Ivy'],
+    metaTitle: 'Spider Plant Care: How Often to Water + Why Brown Tips',
+    metaDescription:
+      'How often to water a spider plant, the light it likes, why the leaf tips go brown, and what to do with all the babies it keeps making.',
+    reviewed: '2026-06-12',
+    summary:
+      'The spider plant forgives missed waterings, shrugs off ordinary light, and hands you free copies of itself. Its one famous complaint, brown leaf tips, is usually about what’s in your tap water, not about your skill.',
+    quickFacts: {
+      water: 'About once a week, when the top inch of soil is dry; less in winter',
+      light: 'Bright, indirect light is ideal; tolerates moderate light',
+      difficulty: 'Very easy',
+      toxicity: 'Non-toxic to cats and dogs (per the ASPCA), though cats love chewing it',
+      humidity: 'Average household humidity is fine; very dry air browns the tips',
+    },
+    sections: {
+      watering: [
+        'Water a spider plant about once a week, when the top inch of soil has dried out. It stores water in thick, tuberous roots, so a missed week is a non-event: the leaves go a little flat and pale, then stand back up within hours of a drink, no grudge held. When you do water, do it properly, until it runs from the drainage holes.',
+        'In winter, stretch the interval to every 10–14 days. The real danger runs the other way: those water-storing roots rot in soil that never dries, and a rotted spider plant is much harder to save than a thirsty one. If you’re not sure it needs water, wait a day or two.',
+      ],
+      light: [
+        'Bright, indirect light keeps a spider plant full, crisply striped, and making babies. It also copes fine with a moderately lit room a few feet from the window; it just grows slower there, and the variegated kinds lose some of their cream stripe.',
+        'What it can’t take is harsh direct sun through glass, which bleaches the leaves and scorches the tips. An east window, or anywhere bright without a direct beam, is the sweet spot. There’s a reason this is the classic hanging-basket plant.',
+      ],
+      problems: [
+        'Brown leaf tips are the spider plant complaint, and the usual culprits are the fluoride and chlorine in tap water, or very dry air. Switching to distilled, filtered, or rain water fixes it for most people. Existing brown tips never turn green again; snip them off at an angle and the plant looks fine.',
+        'Yellow, limp leaves and mush at the base mean overwatering. The tuberous roots are a built-in water tank, and topping up a full tank rots it. Let the soil dry out fully and make sure the pot actually drains.',
+        'No babies? A spider plant only sends out runners when it’s mature, slightly root-bound, and getting decent light. A young plant in a dim corner and a roomy pot has no reason to reproduce. Snug pot, brighter spot, patience.',
+      ],
+      sharedCare: [
+        'The spider plant is unusually good at shared care because it asks out loud: when it’s thirsty, the leaves visibly droop and dull, and they perk up within hours of watering. That makes “does it need water?” a question anyone in the house can answer at a glance, which is more than you can say for almost any other plant on this list.',
+        'The babies are the other superpower. Each plantlet roots in a glass of water in a week or two, so one healthy plant becomes a windowsill of starter plants for kids, housemates, and the friend who swears they kill everything. (Family Greenhouse can track whose plant each one becomes once it’s potted up, but a labelled jam jar does the job too.)',
+      ],
+      honestBit: [
+        'My take: this is the best first plant for a household with kids or cats, full stop. It’s non-toxic, it bounces back from neglect, and a child who rooted their own spiderette in a jam jar will water it without being asked. That’s not true of a single other beginner plant I can name.',
+        'And ignore anyone who calls it dated. The spider plant got filed under “grandma plant” because it’s been quietly surviving in kitchens since the seventies — that’s not a fashion problem, that’s a track record.',
+      ],
+    },
+    faqs: [
+      {
+        q: 'How often should I water a spider plant?',
+        a: 'About once a week, when the top inch of soil is dry, stretching to every 10–14 days in winter. Its tuberous roots store water, so it forgives a late watering far better than a constantly wet pot.',
+      },
+      {
+        q: 'Why are my spider plant’s leaf tips turning brown?',
+        a: 'Usually fluoride and chlorine in tap water, or very dry air. Switch to distilled, filtered, or rain water and new growth comes in clean. Snip existing brown tips off at an angle; they don’t recover.',
+      },
+      {
+        q: 'Are spider plants safe for cats and dogs?',
+        a: 'Yes. The ASPCA lists spider plants as non-toxic to both cats and dogs. Cats do love chewing the dangling leaves, which hurts the plant more than the cat, so hang it up if yours won’t leave it alone.',
+      },
+      {
+        q: 'How do I propagate spider plant babies (spiderettes)?',
+        a: 'Snip a plantlet off the runner and sit its base in a glass of water; roots show within a week or two. Or pin it into a pot of soil while still attached and cut the runner once it takes. Either way works almost every time.',
+      },
+    ],
+  },
 ];
 
 export function findCareGuide(slug: string): CareGuide | undefined {

--- a/frontend/src/features/chat/ChatPage.tsx
+++ b/frontend/src/features/chat/ChatPage.tsx
@@ -175,7 +175,7 @@ export function ChatPage() {
           </div>
           {budget && (
             <div
-              className="text-right text-xs text-gray-500"
+              className="text-right text-xs text-gray-600"
               title={`${budgetPct}% of monthly chat budget used`}
             >
               {budgetPct}% used this month
@@ -280,7 +280,7 @@ export function ChatPage() {
             <PaperAirplaneIcon className="h-5 w-5" />
           </button>
         </div>
-        <p className="text-xs text-gray-400 mt-1">
+        <p className="text-xs text-gray-500 mt-1">
           AI-generated — verify before acting. Refuses pesticide / dosage advice. Reminder
           suggestions wait for your confirm before being created.
         </p>

--- a/frontend/src/features/dashboard/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/DashboardPage.tsx
@@ -337,7 +337,7 @@ export function DashboardPage() {
                 </div>
                 <p className="text-sm font-medium text-ink truncate">{plant.name}</p>
                 {plant.location && (
-                  <p className="text-xs text-gray-500 truncate">{plant.location}</p>
+                  <p className="text-xs text-gray-600 truncate">{plant.location}</p>
                 )}
               </Link>
             ))}
@@ -412,7 +412,7 @@ interface MetricProps {
 function Metric({ label, value, emphasis }: MetricProps) {
   return (
     <div className="flex items-baseline gap-2">
-      <dt className="text-xs uppercase tracking-[0.14em] text-gray-500">{label}</dt>
+      <dt className="text-xs uppercase tracking-[0.14em] text-gray-600">{label}</dt>
       <dd
         className={clsx(
           'font-serif text-xl text-ink leading-none',

--- a/frontend/src/features/household/HouseholdPage.tsx
+++ b/frontend/src/features/household/HouseholdPage.tsx
@@ -145,7 +145,7 @@ export function HouseholdPage() {
                   {copied ? 'Copied!' : 'Copy'}
                 </Button>
               </div>
-              <p className="text-xs text-gray-500">This link will expire in 7 days.</p>
+              <p className="text-xs text-gray-600">This link will expire in 7 days.</p>
             </div>
           ) : (
             <Button

--- a/frontend/src/features/household/MemberVacation.tsx
+++ b/frontend/src/features/household/MemberVacation.tsx
@@ -124,7 +124,7 @@ export function MemberVacation({
   }
 
   if (coverOptions.length === 0) {
-    return <p className="mt-1 text-xs text-gray-500">{t('household.vacation.noCoverOptions')}</p>;
+    return <p className="mt-1 text-xs text-gray-600">{t('household.vacation.noCoverOptions')}</p>;
   }
 
   return (

--- a/frontend/src/features/landing/LandingPage.tsx
+++ b/frontend/src/features/landing/LandingPage.tsx
@@ -1,11 +1,9 @@
 import { Link } from 'react-router-dom';
 import {
-  CalendarDaysIcon,
+  // Remaining Heroicons serve the AppMockup chrome only — the marketing
+  // feature grid uses the custom botanical icons below.
   UserGroupIcon,
-  BellAlertIcon,
-  DevicePhoneMobileIcon,
   ChartBarIcon,
-  ShieldCheckIcon,
   CheckIcon,
   HomeIcon,
   ClipboardDocumentListIcon,
@@ -22,6 +20,12 @@ import { DashboardHeaderArt } from '@/components/headers/DashboardHeaderArt';
 import { WaterDropIcon } from '@/components/icons/WaterDropIcon';
 import { FertilizeIcon } from '@/components/icons/FertilizeIcon';
 import { PruneIcon } from '@/components/icons/PruneIcon';
+import { ReminderBellbloomIcon } from '@/components/icons/ReminderBellbloomIcon';
+import { HouseholdSproutsIcon } from '@/components/icons/HouseholdSproutsIcon';
+import { CalendarLeafIcon } from '@/components/icons/CalendarLeafIcon';
+import { PhoneLeafIcon } from '@/components/icons/PhoneLeafIcon';
+import { GrowthRingsIcon } from '@/components/icons/GrowthRingsIcon';
+import { RootLockIcon } from '@/components/icons/RootLockIcon';
 import clsx from 'clsx';
 
 const features = [
@@ -29,37 +33,76 @@ const features = [
     name: 'Reminders per plant',
     description:
       "Each plant gets its own schedule, and the nudge goes to whoever the task belongs to. The cactus stops getting watered on the fern's timetable.",
-    icon: BellAlertIcon,
+    icon: ReminderBellbloomIcon,
   },
   {
     name: 'Shared, with names attached',
     description:
       "Everyone in the household sees what's due and what's done. The log shows who did what, which settles the watering arguments quickly.",
-    icon: UserGroupIcon,
+    icon: HouseholdSproutsIcon,
   },
   {
     name: 'A week you can scan',
     description:
       'Every upcoming task on one calendar. A look on Sunday night tells you whether the week ahead is heavy or quiet.',
-    icon: CalendarDaysIcon,
+    icon: CalendarLeafIcon,
   },
   {
     name: 'Works at the sink',
     description:
       'Installs to your phone like any app. Mark a task done with one thumb, add a note, get back to the watering can.',
-    icon: DevicePhoneMobileIcon,
+    icon: PhoneLeafIcon,
   },
   {
     name: 'A memory for each plant',
     description:
       'Notes, photos, and the full care log live with the plant. When leaves yellow, you check what happened instead of guessing.',
-    icon: ChartBarIcon,
+    icon: GrowthRingsIcon,
   },
   {
     name: 'Yours to keep',
     description:
       "Your household's data is encrypted in transit and at rest, and you can export all of it whenever you like.",
-    icon: ShieldCheckIcon,
+    icon: RootLockIcon,
+  },
+];
+
+// Per-card surface/border/layout variation for the features grid, keyed
+// by index. Breaks the six-identical-cards template read: backgrounds
+// rotate through paper / parchment / white, border tints alternate
+// green and terracotta, and two cards (2nd and 6th) go horizontal at
+// lg. The `chip` class also carries the icon's text color so terracotta
+// cards get a terracotta icon without touching the icon components.
+const featureCardVariants = [
+  {
+    surface: 'bg-paper border-primary-100/60',
+    chip: 'bg-primary-100 ring-primary-200/60 text-primary-700',
+    horizontal: false,
+  },
+  {
+    surface: 'bg-parchment border-primary-200/60',
+    chip: 'bg-primary-100 ring-primary-200/60 text-primary-700',
+    horizontal: true,
+  },
+  {
+    surface: 'bg-white border-accent-200/50',
+    chip: 'bg-accent-50 ring-accent-200/60 text-accent-700',
+    horizontal: false,
+  },
+  {
+    surface: 'bg-white border-primary-200/60',
+    chip: 'bg-primary-100 ring-primary-200/60 text-primary-700',
+    horizontal: false,
+  },
+  {
+    surface: 'bg-paper border-accent-200/50',
+    chip: 'bg-accent-50 ring-accent-200/60 text-accent-700',
+    horizontal: false,
+  },
+  {
+    surface: 'bg-parchment border-primary-100/60',
+    chip: 'bg-primary-100 ring-primary-200/60 text-primary-700',
+    horizontal: true,
   },
 ];
 
@@ -99,7 +142,7 @@ const productFacts = [
  * this is a marketing mock, not a live screenshot. Names and counts
  * aren't claims — they're representative content.
  */
-function AppMockup() {
+function AppMockup({ className }: { className?: string }) {
   const navItems = [
     { name: 'Dashboard', icon: HomeIcon, active: true },
     { name: 'Plants', icon: SidebarLeafIcon, active: false },
@@ -133,7 +176,7 @@ function AppMockup() {
   };
 
   return (
-    <div className="mt-16 sm:mt-24">
+    <div className={className}>
       <div className="relative -m-2 rounded-xl bg-primary-900/10 p-2 ring-1 ring-inset ring-primary-900/15 lg:-m-4 lg:rounded-2xl lg:p-4">
         <div className="rounded-lg bg-paper shadow-2xl ring-1 ring-primary-900/10 overflow-hidden">
           {/* Browser chrome */}
@@ -311,9 +354,10 @@ function Metric({ label, value }: MetricProps) {
 }
 
 /**
- * Decorative cluster of botanical sprigs that flank the hero. Used twice
- * (mirrored) to flank the headline at low opacity so the hero reads as
- * a hand-illustrated garden page rather than a default-Tailwind landing.
+ * Decorative cluster of botanical sprigs behind the hero copy, at low
+ * opacity so the hero reads as a hand-illustrated garden page rather
+ * than a default-Tailwind landing. (Formerly mirrored on the right too;
+ * the asymmetric hero's bleeding app mockup now owns that side.)
  * Stroke is `currentColor` so opacity tints come from the caller.
  */
 function HeroSprigs({
@@ -418,57 +462,60 @@ export function LandingPage() {
         </nav>
       </header>
 
-      {/* Hero Section — botanical wash on paper, no clip-path blurs. The
-          two flanking sprig clusters give the page a hand-drawn feel
-          without the cookie-cutter "abstract gradient blob" pattern. */}
+      {/* Hero Section — botanical wash on paper, no clip-path blurs. At
+          lg the hero goes asymmetric: copy left-aligned in the left
+          column, the app mockup bleeding off the right edge (the
+          overflow-hidden wrapper crops it). Below lg it stays the
+          stacked, centered layout. */}
       <div className="relative isolate pt-14 overflow-hidden">
-        {/* Left botanical wash */}
+        {/* Botanical wash behind the hero copy. `origin-bottom
+            animate-sway` rocks the sprigs from the soil line; the
+            global prefers-reduced-motion rule freezes it. */}
         <HeroSprigs
-          className="pointer-events-none absolute left-0 top-24 -z-10 hidden md:block w-64 h-auto text-primary-300/40"
-          aria-hidden="true"
-        />
-        {/* Right botanical wash, mirrored */}
-        <HeroSprigs
-          className="pointer-events-none absolute right-0 top-32 -z-10 hidden md:block w-72 h-auto text-primary-300/40 -scale-x-100"
+          className="pointer-events-none absolute left-0 top-24 -z-10 hidden md:block w-64 h-auto text-primary-300/25 origin-bottom animate-sway"
           aria-hidden="true"
         />
 
-        <div className="py-24 sm:py-32 lg:py-40">
+        <div className="py-24 sm:py-32 lg:py-36">
           <div className="mx-auto max-w-7xl px-6 lg:px-8">
-            <div className="mx-auto max-w-2xl text-center">
-              <p className="text-xs uppercase tracking-[0.22em] text-primary-700 font-semibold mb-6">
-                A garden journal for the whole house
-              </p>
-              <h1 className="font-serif text-5xl tracking-tight text-ink sm:text-7xl leading-[1.05]">
-                &ldquo;I thought <span className="italic text-primary-700">you</span> watered
-                it.&rdquo;
-              </h1>
-              <div className="mt-4 flex justify-center">
-                <TitleUnderline className="h-4 w-56 text-primary-600" />
+            <div className="grid grid-cols-1 items-center lg:grid-cols-2 lg:gap-x-16">
+              <div className="mx-auto max-w-2xl text-center lg:mx-0 lg:max-w-xl lg:text-left">
+                <p className="text-xs uppercase tracking-[0.22em] text-primary-700 font-semibold mb-6">
+                  A garden journal for the whole house
+                </p>
+                <h1 className="font-serif text-5xl tracking-tight text-ink sm:text-7xl lg:text-6xl xl:text-7xl leading-[1.05]">
+                  &ldquo;I thought <span className="italic text-primary-700">you</span> watered
+                  it.&rdquo;
+                </h1>
+                <div className="mt-4 flex justify-center lg:justify-start">
+                  <TitleUnderline className="h-4 w-56 text-primary-600" />
+                </div>
+                <p className="mt-6 text-lg leading-8 text-gray-700">
+                  Family Greenhouse is a shared care journal for the plants in your house. Everyone
+                  sees what&rsquo;s due and what&rsquo;s already done, so the fern doesn&rsquo;t get
+                  watered twice on Tuesday and then forgotten for two weeks.
+                </p>
+                <div className="mt-10 flex items-center justify-center gap-x-6 lg:justify-start">
+                  <Link to="/register">
+                    <Button size="lg">Sign up free</Button>
+                  </Link>
+                  <a
+                    href="#features"
+                    className="text-sm font-semibold leading-6 text-ink flex items-center gap-1 hover:text-primary-700 transition-colors"
+                  >
+                    See how it works <span aria-hidden="true">→</span>
+                  </a>
+                </div>
               </div>
-              <p className="mt-6 text-lg leading-8 text-gray-700">
-                Family Greenhouse is a shared care journal for the plants in your house. Everyone
-                sees what&rsquo;s due and what&rsquo;s already done, so the fern doesn&rsquo;t get
-                watered twice on Tuesday and then forgotten for two weeks.
-              </p>
-              <div className="mt-10 flex items-center justify-center gap-x-6">
-                <Link to="/register">
-                  <Button size="lg">Sign up free</Button>
-                </Link>
-                <a
-                  href="#features"
-                  className="text-sm font-semibold leading-6 text-ink flex items-center gap-1 hover:text-primary-700 transition-colors"
-                >
-                  See how it works <span aria-hidden="true">→</span>
-                </a>
-              </div>
-            </div>
 
-            {/* App Preview — a faithful mock of the real product chrome
-                styled to match the redesigned dashboard (paper bg,
-                botanical task icons, inline metadata row, Gloock serif
-                welcome). The visual is the product. */}
-            <AppMockup />
+              {/* App Preview — a faithful mock of the real product chrome
+                  styled to match the redesigned dashboard (paper bg,
+                  botanical task icons, inline metadata row, Gloock serif
+                  welcome). The visual is the product. At lg it renders at
+                  a readable fixed width and bleeds off the right edge of
+                  the viewport rather than squeezing into the column. */}
+              <AppMockup className="mt-16 sm:mt-24 lg:mt-0 lg:w-[56rem] lg:max-w-none" />
+            </div>
           </div>
         </div>
       </div>
@@ -509,27 +556,58 @@ export function LandingPage() {
           />
           <div className="mx-auto mt-12 max-w-2xl sm:mt-16 lg:mt-20 lg:max-w-none">
             <dl className="mx-auto grid max-w-xl grid-cols-1 gap-x-8 gap-y-10 md:max-w-none md:grid-cols-2 lg:grid-cols-3">
-              {features.map((feature) => (
-                <div
-                  key={feature.name}
-                  className="relative bg-paper rounded-2xl p-8 shadow-journal hover:shadow-journal-hover transition-shadow border border-primary-100/60"
-                >
-                  <dt className="flex flex-col items-start gap-4">
-                    <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-primary-100 ring-1 ring-primary-200/60">
-                      <feature.icon className="h-6 w-6 text-primary-700" aria-hidden="true" />
-                    </div>
-                    <span className="text-lg font-semibold leading-7 text-ink">{feature.name}</span>
-                  </dt>
-                  <dd className="mt-2 text-base leading-7 text-gray-700">{feature.description}</dd>
-                </div>
-              ))}
+              {features.map((feature, index) => {
+                const variant = featureCardVariants[index % featureCardVariants.length];
+                return (
+                  <div
+                    key={feature.name}
+                    className={clsx(
+                      'relative rounded-2xl p-8 shadow-journal hover:shadow-journal-hover transition-shadow border',
+                      variant.surface
+                    )}
+                  >
+                    <dt
+                      className={clsx(
+                        'flex flex-col items-start gap-4',
+                        variant.horizontal && 'lg:flex-row lg:items-center'
+                      )}
+                    >
+                      <div
+                        className={clsx(
+                          'flex h-12 w-12 shrink-0 items-center justify-center rounded-xl ring-1',
+                          variant.chip
+                        )}
+                      >
+                        <feature.icon className="h-6 w-6" aria-hidden="true" />
+                      </div>
+                      <span className="text-lg font-semibold leading-7 text-ink">
+                        {feature.name}
+                      </span>
+                    </dt>
+                    <dd
+                      className={clsx(
+                        'mt-2 text-base leading-7 text-gray-700',
+                        variant.horizontal && 'lg:ml-16'
+                      )}
+                    >
+                      {feature.description}
+                    </dd>
+                  </div>
+                );
+              })}
             </dl>
           </div>
         </div>
       </div>
 
-      {/* How It Works Section */}
-      <div className="py-20 sm:py-28 bg-parchment">
+      {/* How It Works Section — a sprig straddles the paper → parchment
+          seam, same pattern as the facts band but ink-tinted since both
+          surfaces are light. */}
+      <div className="py-20 sm:py-28 bg-parchment relative">
+        <SprigDivider
+          className="absolute left-1/2 -top-3 h-6 w-40 -translate-x-1/2 text-primary-600/80"
+          aria-hidden="true"
+        />
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
           <SectionHeading eyebrow="Setup" title="Three steps, about five minutes" />
           <div className="mx-auto mt-12 sm:mt-16 max-w-5xl">
@@ -570,8 +648,13 @@ export function LandingPage() {
         </div>
       </div>
 
-      {/* Pricing Section */}
-      <div id="pricing" className="py-20 sm:py-28 bg-parchment">
+      {/* Pricing Section — both sections sit on parchment, so the sprig
+          marks the transition the background no longer can. */}
+      <div id="pricing" className="py-20 sm:py-28 bg-parchment relative">
+        <SprigDivider
+          className="absolute left-1/2 -top-3 h-6 w-40 -translate-x-1/2 text-primary-600/80"
+          aria-hidden="true"
+        />
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
           <SectionHeading
             eyebrow="Pricing"

--- a/frontend/src/features/onboarding/WelcomeFlow.tsx
+++ b/frontend/src/features/onboarding/WelcomeFlow.tsx
@@ -121,7 +121,7 @@ export function WelcomeFlow() {
         </div>
       </Card>
 
-      <p className="mt-6 text-center text-xs text-gray-500">
+      <p className="mt-6 text-center text-xs text-gray-600">
         You can revisit any of this from <span className="font-medium">Help</span> in the sidebar.
       </p>
     </div>

--- a/frontend/src/features/plants/AddPlantPage.tsx
+++ b/frontend/src/features/plants/AddPlantPage.tsx
@@ -344,7 +344,7 @@ export function AddPlantPage() {
                       <p className="text-sm font-medium text-gray-900">
                         {s.commonName ?? s.scientificName}
                       </p>
-                      <p className="text-xs italic text-gray-500">
+                      <p className="text-xs italic text-gray-600">
                         {s.scientificName} • {(s.probability * 100).toFixed(0)}% confidence
                       </p>
                     </div>

--- a/frontend/src/features/plants/BulkApplyTemplateDialog.tsx
+++ b/frontend/src/features/plants/BulkApplyTemplateDialog.tsx
@@ -164,7 +164,7 @@ export function BulkApplyTemplateDialog({ isOpen, onClose }: BulkApplyTemplateDi
                                 {p.name}
                               </span>
                               {p.species && (
-                                <span className="text-xs italic text-gray-500 truncate">
+                                <span className="text-xs italic text-gray-600 truncate">
                                   {p.species}
                                 </span>
                               )}

--- a/frontend/src/features/plants/CareReportCard.tsx
+++ b/frontend/src/features/plants/CareReportCard.tsx
@@ -47,7 +47,7 @@ export function CareReportCard({ plant }: CareReportCardProps) {
 
       {plant.upcomingTasks.length > 0 && (
         <div>
-          <h4 className="text-xs font-semibold uppercase tracking-wide text-gray-500 mb-2">
+          <h4 className="text-xs font-semibold uppercase tracking-wide text-gray-600 mb-2">
             By task
           </h4>
           <ul className="divide-y divide-gray-200 text-sm">
@@ -64,7 +64,7 @@ export function CareReportCard({ plant }: CareReportCardProps) {
 function Stat({ label, value }: { label: string; value: string }) {
   return (
     <div>
-      <dt className="text-xs font-medium text-gray-500">{label}</dt>
+      <dt className="text-xs font-medium text-gray-600">{label}</dt>
       <dd className="mt-1 text-lg font-semibold text-gray-900">{value}</dd>
     </div>
   );

--- a/frontend/src/features/plants/ImportPlantsPage.tsx
+++ b/frontend/src/features/plants/ImportPlantsPage.tsx
@@ -193,9 +193,9 @@ export function ImportPlantsPage() {
               if (file) void handleFile(file);
             }}
           />
-          {fileName && <p className="text-xs text-gray-500">{fileName}</p>}
+          {fileName && <p className="text-xs text-gray-600">{fileName}</p>}
         </div>
-        <p className="mt-3 text-xs text-gray-500">{t('importPlants.formatHelp')}</p>
+        <p className="mt-3 text-xs text-gray-600">{t('importPlants.formatHelp')}</p>
       </Card>
 
       {rows && (
@@ -215,7 +215,7 @@ export function ImportPlantsPage() {
           <div className="max-h-96 overflow-auto">
             <table className="min-w-full divide-y divide-gray-200 text-sm">
               <thead>
-                <tr className="text-left text-xs font-medium uppercase tracking-wide text-gray-500">
+                <tr className="text-left text-xs font-medium uppercase tracking-wide text-gray-600">
                   <th className="px-3 py-2">{t('importPlants.preview.colRow')}</th>
                   <th className="px-3 py-2">{t('importPlants.preview.colStatus')}</th>
                   <th className="px-3 py-2">{t('importPlants.preview.colName')}</th>
@@ -260,7 +260,7 @@ export function ImportPlantsPage() {
             </table>
           </div>
           {validRows.length < rows.length && (
-            <p className="mt-3 text-xs text-gray-500">
+            <p className="mt-3 text-xs text-gray-600">
               {t('importPlants.preview.invalidRowsSkipped')}
             </p>
           )}

--- a/frontend/src/features/plants/LeafHealthCard.tsx
+++ b/frontend/src/features/plants/LeafHealthCard.tsx
@@ -105,7 +105,7 @@ export function LeafHealthResults({ result }: { result: LeafHealthResult }) {
 
       {result.demo && <p className="text-xs text-amber-700">{t('plants.leafHealth.demoNotice')}</p>}
 
-      <p className="text-xs text-gray-400">{result.disclaimer}</p>
+      <p className="text-xs text-gray-500">{result.disclaimer}</p>
     </div>
   );
 }

--- a/frontend/src/features/plants/PlantDetailPage.tsx
+++ b/frontend/src/features/plants/PlantDetailPage.tsx
@@ -481,7 +481,7 @@ function TaskRow({
         </span>
         <div>
           <p className="text-sm text-gray-900">Every {task.frequency} days</p>
-          <p className={clsx('text-xs', isOverdue ? 'text-red-600 font-medium' : 'text-gray-500')}>
+          <p className={clsx('text-xs', isOverdue ? 'text-red-600 font-medium' : 'text-gray-600')}>
             Due: {formatDate(task.nextDue)}
             {task.lastCompleted && ` • Last: ${formatDate(task.lastCompleted)}`}
           </p>

--- a/frontend/src/features/plants/PlantLineageCard.tsx
+++ b/frontend/src/features/plants/PlantLineageCard.tsx
@@ -101,7 +101,7 @@ export function PlantLineageCard({ lineage }: PlantLineageCardProps) {
                     </Link>
                     <PlantStatusBadge status={child.status} />
                   </span>
-                  <span className="flex-shrink-0 text-xs text-gray-500">
+                  <span className="flex-shrink-0 text-xs text-gray-600">
                     {formatDate(child.createdAt)}
                   </span>
                 </li>

--- a/frontend/src/features/plants/PlantsPage.tsx
+++ b/frontend/src/features/plants/PlantsPage.tsx
@@ -224,10 +224,10 @@ export function PlantsPage() {
                   )}
                 </p>
                 {plant.species && (
-                  <p className="text-xs text-gray-500 truncate italic">{plant.species}</p>
+                  <p className="text-xs text-gray-600 truncate italic">{plant.species}</p>
                 )}
                 {plant.location && (
-                  <p className="text-xs text-gray-500 truncate mt-1">{plant.location}</p>
+                  <p className="text-xs text-gray-600 truncate mt-1">{plant.location}</p>
                 )}
               </div>
             </Link>

--- a/frontend/src/features/settings/AccountSettings.tsx
+++ b/frontend/src/features/settings/AccountSettings.tsx
@@ -263,7 +263,7 @@ export function AccountSettings() {
             Download CSV
           </Button>
         </div>
-        <p className="mt-3 text-xs text-gray-500">
+        <p className="mt-3 text-xs text-gray-600">
           Moving in the other direction?{' '}
           <RouterLink to="/plants/import" className="font-medium text-primary-700 underline">
             Import plants from a CSV or JSON file
@@ -341,7 +341,7 @@ function CalendarFeedRow() {
           {copied ? 'Copied!' : 'Copy'}
         </Button>
       </div>
-      <p className="text-xs text-gray-500">
+      <p className="text-xs text-gray-600">
         Paste this URL into your calendar app&rsquo;s &ldquo;subscribe to calendar&rdquo; option.
         The feed shows tasks for your active household; switching households updates what you see
         automatically.

--- a/frontend/src/features/settings/ApiKeysSettings.tsx
+++ b/frontend/src/features/settings/ApiKeysSettings.tsx
@@ -150,7 +150,7 @@ export function ApiKeysSettings() {
             </div>
             <fieldset>
               <legend className="label">Scopes</legend>
-              <p className="mb-2 text-xs text-gray-500">
+              <p className="mb-2 text-xs text-gray-600">
                 Grant only what the key needs. A request to an endpoint outside the key&rsquo;s
                 scopes is refused with a 403.
               </p>

--- a/frontend/src/features/settings/PreferencesSettings.tsx
+++ b/frontend/src/features/settings/PreferencesSettings.tsx
@@ -1,18 +1,10 @@
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Card, CardHeader } from '@/components/Card';
-import {
-  applyDensity,
-  applyTheme,
-  Density,
-  LangCode,
-  Theme,
-  usePrefsStore,
-} from '@/store/prefsStore';
+import { applyDensity, Density, LangCode, usePrefsStore } from '@/store/prefsStore';
 import { isRTL, SUPPORTED_LANGS } from '@/i18n';
 import clsx from 'clsx';
 
-const THEME_OPTIONS: Theme[] = ['light', 'dark', 'system'];
 const DENSITY_OPTIONS: Density[] = ['cozy', 'compact'];
 const LANGUAGE_LABELS: Record<LangCode, string> = {
   en: 'English',
@@ -25,15 +17,12 @@ const LANGUAGES: { code: LangCode; label: string }[] = SUPPORTED_LANGS.map((code
 
 export function PreferencesSettings() {
   const { t } = useTranslation();
-  const theme = usePrefsStore((s) => s.theme);
   const density = usePrefsStore((s) => s.density);
   const language = usePrefsStore((s) => s.language);
-  const setTheme = usePrefsStore((s) => s.setTheme);
   const setDensity = usePrefsStore((s) => s.setDensity);
   const setLanguage = usePrefsStore((s) => s.setLanguage);
 
   // Mirror prefs to the DOM whenever they change in this tab.
-  useEffect(() => applyTheme(theme), [theme]);
   useEffect(() => applyDensity(density), [density]);
   useEffect(() => {
     document.documentElement.lang = language;
@@ -47,29 +36,10 @@ export function PreferencesSettings() {
         description={t('settings.preferences.description')}
       />
       <div className="space-y-6">
-        {/* Theme */}
-        <fieldset>
-          <legend className="label">{t('settings.preferences.theme')}</legend>
-          <div className="flex gap-2" role="radiogroup">
-            {THEME_OPTIONS.map((value) => (
-              <button
-                key={value}
-                type="button"
-                role="radio"
-                aria-checked={theme === value}
-                onClick={() => setTheme(value)}
-                className={clsx(
-                  'rounded-md border px-4 py-2 text-sm font-medium min-h-touch',
-                  theme === value
-                    ? 'border-primary-700 bg-primary-50 text-primary-800'
-                    : 'border-gray-300 bg-white text-gray-700 hover:bg-gray-50'
-                )}
-              >
-                {t(`settings.preferences.theme${value[0].toUpperCase() + value.slice(1)}`)}
-              </button>
-            ))}
-          </div>
-        </fieldset>
+        {/* Theme toggle removed: dark mode shipped half-baked (only the body
+            surface inverted, components stayed light and unreadable). Restore
+            it here once components have real dark variants.
+            See docs/reviews/frontend-audit-2026-06-12.md, item 6. */}
 
         {/* Density */}
         <fieldset>

--- a/frontend/src/features/status/StatusPage.tsx
+++ b/frontend/src/features/status/StatusPage.tsx
@@ -1,6 +1,12 @@
 import { Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
-import { CheckCircleIcon, ExclamationTriangleIcon, XCircleIcon } from '@heroicons/react/24/outline';
+import { isAxiosError } from 'axios';
+import {
+  CheckCircleIcon,
+  ExclamationTriangleIcon,
+  QuestionMarkCircleIcon,
+  XCircleIcon,
+} from '@heroicons/react/24/outline';
 import { BrandMark } from '@/components/BrandMark';
 import { Footer } from '@/components/Footer';
 import { useMetaTags } from '@/hooks/useMetaTags';
@@ -64,14 +70,21 @@ export function StatusPage() {
     description: 'Current operational status of Family Greenhouse and recent incidents.',
   });
 
-  const { data, isLoading, isError } = useQuery({
+  const { data, isLoading, isError, error } = useQuery({
     queryKey: ['status', 'health'],
     queryFn: healthService.check,
     refetchInterval: 60_000,
     retry: 1,
   });
 
-  const overallStatus: ComponentStatus = isError ? 'down' : (data?.status ?? 'ok');
+  // Two very different failures share `isError`. If /health answered with an
+  // HTTP error, the API is genuinely unhealthy — show red. If the request
+  // never got a response (offline, VPN, ad blocker, DNS), that says nothing
+  // about the API, only that this browser couldn't reach it — so don't claim
+  // an outage we have no evidence for.
+  const serverErrored = isError && isAxiosError(error) && error.response != null;
+  const unreachable = isError && !serverErrored;
+  const overallStatus: ComponentStatus = serverErrored ? 'down' : (data?.status ?? 'ok');
 
   return (
     <div className="min-h-screen bg-white flex flex-col">
@@ -95,45 +108,66 @@ export function StatusPage() {
         </p>
 
         {/* Overall banner */}
-        <div
-          className={`mt-8 rounded-lg border p-5 ${
-            overallStatus === 'ok'
-              ? 'border-green-200 bg-green-50'
-              : overallStatus === 'degraded'
-                ? 'border-amber-200 bg-amber-50'
-                : 'border-red-200 bg-red-50'
-          }`}
-        >
-          <div className="flex items-center gap-3">
-            {overallStatus === 'ok' && (
-              <CheckCircleIcon className="h-6 w-6 text-green-600" aria-hidden="true" />
-            )}
-            {overallStatus === 'degraded' && (
-              <ExclamationTriangleIcon className="h-6 w-6 text-amber-600" aria-hidden="true" />
-            )}
-            {overallStatus === 'down' && (
-              <XCircleIcon className="h-6 w-6 text-red-600" aria-hidden="true" />
-            )}
-            <p
-              className={`font-display text-xl font-semibold ${
-                overallStatus === 'ok'
-                  ? 'text-green-900'
-                  : overallStatus === 'degraded'
-                    ? 'text-amber-900'
-                    : 'text-red-900'
-              }`}
-            >
-              {overallStatus === 'ok' && 'All systems operational'}
-              {overallStatus === 'degraded' && 'Some systems degraded'}
-              {overallStatus === 'down' && 'We are investigating an issue'}
+        {unreachable ? (
+          <div className="mt-8 rounded-lg border border-amber-200 bg-amber-50 p-5">
+            <div className="flex items-center gap-3">
+              <QuestionMarkCircleIcon className="h-6 w-6 text-amber-600" aria-hidden="true" />
+              <p className="font-display text-xl font-semibold text-amber-900">
+                Can&rsquo;t reach the status API from your network
+              </p>
+            </div>
+            <p className="mt-2 text-sm text-amber-900">
+              This page checks <code>GET /health</code> from your browser, and that request got no
+              response. That can mean our API is down, but it can also be your connection, a VPN, or
+              an ad blocker. Try reloading, or check from another network.
             </p>
+            {data?.checkedAt && (
+              <p className="mt-2 text-xs text-gray-600">
+                Last successful check {new Date(data.checkedAt).toLocaleString()}.
+              </p>
+            )}
           </div>
-          {data?.checkedAt && (
-            <p className="mt-2 text-xs text-gray-600">
-              Last checked {new Date(data.checkedAt).toLocaleString()}.
-            </p>
-          )}
-        </div>
+        ) : (
+          <div
+            className={`mt-8 rounded-lg border p-5 ${
+              overallStatus === 'ok'
+                ? 'border-green-200 bg-green-50'
+                : overallStatus === 'degraded'
+                  ? 'border-amber-200 bg-amber-50'
+                  : 'border-red-200 bg-red-50'
+            }`}
+          >
+            <div className="flex items-center gap-3">
+              {overallStatus === 'ok' && (
+                <CheckCircleIcon className="h-6 w-6 text-green-600" aria-hidden="true" />
+              )}
+              {overallStatus === 'degraded' && (
+                <ExclamationTriangleIcon className="h-6 w-6 text-amber-600" aria-hidden="true" />
+              )}
+              {overallStatus === 'down' && (
+                <XCircleIcon className="h-6 w-6 text-red-600" aria-hidden="true" />
+              )}
+              <p
+                className={`font-display text-xl font-semibold ${
+                  overallStatus === 'ok'
+                    ? 'text-green-900'
+                    : overallStatus === 'degraded'
+                      ? 'text-amber-900'
+                      : 'text-red-900'
+                }`}
+              >
+                {overallStatus === 'ok' && 'All systems operational'}
+                {overallStatus === 'degraded' && 'Some systems degraded'}
+                {overallStatus === 'down' && 'We are investigating an issue'}
+              </p>
+            </div>
+            {data?.checkedAt && (
+              <p className="mt-2 text-xs text-gray-600">
+                Last checked {new Date(data.checkedAt).toLocaleString()}.
+              </p>
+            )}
+          </div>
+        )}
 
         {/* Component breakdown */}
         <section className="mt-10">
@@ -156,7 +190,14 @@ export function StatusPage() {
               {!data && (
                 <li className="flex items-center justify-between gap-4 px-5 py-4">
                   <span className="text-sm font-medium text-gray-900">API</span>
-                  <StatusPill status="down" />
+                  {unreachable ? (
+                    <span className="inline-flex items-center gap-1.5 rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-700">
+                      <QuestionMarkCircleIcon className="h-3.5 w-3.5" aria-hidden="true" />
+                      No response
+                    </span>
+                  ) : (
+                    <StatusPill status="down" />
+                  )}
                 </li>
               )}
             </ul>
@@ -169,7 +210,11 @@ export function StatusPage() {
             Recent incidents
           </h2>
           {INCIDENTS.length === 0 ? (
-            <p className="mt-4 text-sm text-gray-600">No incidents in the last 90 days.</p>
+            <p className="mt-4 text-sm text-gray-600">
+              {unreachable
+                ? 'Incident history unavailable right now.'
+                : 'No incidents in the last 90 days.'}
+            </p>
           ) : (
             <ul className="mt-4 space-y-6">
               {INCIDENTS.map((inc, i) => (

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -227,10 +227,6 @@ export const en = {
     preferences: {
       title: 'Preferences',
       description: 'Customize how the app looks and feels.',
-      theme: 'Theme',
-      themeLight: 'Light',
-      themeDark: 'Dark',
-      themeSystem: 'System',
       density: 'Density',
       densityCozy: 'Cozy',
       densityCompact: 'Compact',

--- a/frontend/src/i18n/locales/es.ts
+++ b/frontend/src/i18n/locales/es.ts
@@ -231,10 +231,6 @@ export const es: Translation = {
     preferences: {
       title: 'Preferencias',
       description: 'Personaliza la apariencia de la app.',
-      theme: 'Tema',
-      themeLight: 'Claro',
-      themeDark: 'Oscuro',
-      themeSystem: 'Sistema',
       density: 'Densidad',
       densityCozy: 'Cómoda',
       densityCompact: 'Compacta',

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -9,15 +9,9 @@
     --color-secondary: 234 179 8;
   }
 
-  /* Dark theme set by prefsStore.applyTheme(). Inverts only the surface +
-     body text tokens; component-level classes (bg-white etc.) keep their
-     light values unless they explicitly opt into a dark variant. */
-  html[data-theme='dark'] {
-    color-scheme: dark;
-  }
-  html[data-theme='dark'] body {
-    @apply bg-gray-900 text-gray-100;
-  }
+  /* Dark mode removed until components get real dark variants — the old
+     html[data-theme='dark'] block only inverted the body surface, leaving
+     cards/inputs unreadable (frontend-audit 2026-06-12, item 6). */
 
   html[data-density='compact'] .card {
     @apply p-4;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,7 +6,7 @@ import App from './App';
 import { initSentry } from './sentry';
 import './i18n';
 import { isRTL } from './i18n';
-import { applyDensity, applyTheme, usePrefsStore } from './store/prefsStore';
+import { applyDensity, usePrefsStore } from './store/prefsStore';
 // Self-hosted brand fonts. Gloock is the display face used in the wordmark
 // and major headlines; Instrument Sans is the body face. Both are loaded
 // at app boot from /node_modules so the page renders in-brand on first
@@ -19,22 +19,15 @@ import './index.css';
 // after mount; errors before it loads are caught by the route error boundary.
 void initSentry();
 
-// Apply persisted preferences before React mounts so we don't get a flash of
-// light theme on dark-mode users / wrong density on first paint.
+// Apply persisted preferences before React mounts so we don't get the wrong
+// density / language direction on first paint.
+// Note: dark mode was removed until components get real dark variants
+// (frontend-audit 2026-06-12, item 6), so the app always renders light.
 {
   const prefs = usePrefsStore.getState();
-  applyTheme(prefs.theme);
   applyDensity(prefs.density);
   document.documentElement.lang = prefs.language;
   document.documentElement.dir = isRTL(prefs.language) ? 'rtl' : 'ltr';
-}
-
-// Re-apply theme when the OS preference flips and the user has theme=system.
-if (typeof window !== 'undefined' && window.matchMedia) {
-  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
-    const { theme } = usePrefsStore.getState();
-    if (theme === 'system') applyTheme('system');
-  });
 }
 
 const queryClient = new QueryClient({

--- a/frontend/src/store/prefsStore.ts
+++ b/frontend/src/store/prefsStore.ts
@@ -4,24 +4,23 @@ import i18n, { SUPPORTED_LANGS } from '@/i18n';
 
 /**
  * UI preferences. Persisted to localStorage so a refresh doesn't reset the
- * user's theme/density/language. Backend doesn't need to know about these
+ * user's density/language. Backend doesn't need to know about these
  * (they're per-device anyway), so we keep them client-side.
  *
- * Theme application: `theme` is the user's stated intent; the *applied* theme
- * (light vs dark) is computed via `applyTheme()` because "system" needs to
- * read `prefers-color-scheme`. The HTML root gets `data-theme="dark"` for
- * dark, no attribute for light.
+ * Theme: dark mode was removed (frontend-audit 2026-06-12, item 6) until
+ * components grow real dark variants — the old toggle only inverted the body
+ * surface, leaving every card/input unreadable. The persist `migrate` below
+ * strips any stale `theme` value ('dark'/'system'/'light') from existing
+ * users' localStorage so nothing downstream ever sees it.
  *
  * Density: drives a CSS custom property the cards/lists use to tighten
  * vertical spacing. The default ("cozy") matches the original design;
  * "compact" trims about 25% of vertical padding.
  */
-export type Theme = 'light' | 'dark' | 'system';
 export type Density = 'cozy' | 'compact';
 export type LangCode = 'en' | 'es';
 
 interface PrefsState {
-  theme: Theme;
   density: Density;
   language: LangCode;
   /** Has the user seen the post-onboarding welcome tour? Once true, the
@@ -31,7 +30,6 @@ interface PrefsState {
    *  timezone. Empty strings mean "no quiet hours." */
   dndStart: string;
   dndEnd: string;
-  setTheme: (t: Theme) => void;
   setDensity: (d: Density) => void;
   setLanguage: (l: LangCode) => void;
   setWelcomeSeen: (v: boolean) => void;
@@ -41,7 +39,6 @@ interface PrefsState {
 export const usePrefsStore = create<PrefsState>()(
   persist(
     (set) => ({
-      theme: 'system',
       density: 'cozy',
       language: SUPPORTED_LANGS.includes(i18n.language as LangCode)
         ? (i18n.language as LangCode)
@@ -49,7 +46,6 @@ export const usePrefsStore = create<PrefsState>()(
       welcomeSeen: false,
       dndStart: '',
       dndEnd: '',
-      setTheme: (theme) => set({ theme }),
       setDensity: (density) => set({ density }),
       setLanguage: (language) => {
         i18n.changeLanguage(language);
@@ -58,31 +54,28 @@ export const usePrefsStore = create<PrefsState>()(
       setWelcomeSeen: (welcomeSeen) => set({ welcomeSeen }),
       setDnd: (dndStart, dndEnd) => set({ dndStart, dndEnd }),
     }),
-    { name: 'fg.prefs' }
+    {
+      name: 'fg.prefs',
+      version: 1,
+      // v0 → v1: drop the removed `theme` pref. Existing users may have
+      // 'dark' persisted; coercing by deletion means everyone gets light.
+      migrate: (persisted) => {
+        if (persisted && typeof persisted === 'object' && 'theme' in persisted) {
+          const rest = { ...(persisted as Record<string, unknown>) };
+          delete rest.theme;
+          return rest as Partial<PrefsState>;
+        }
+        return persisted as Partial<PrefsState>;
+      },
+    }
   )
 );
 
 /**
- * Apply theme + density to the DOM. Call on app boot and again when prefs
- * change. We attach attributes to <html> so CSS can react via attribute
- * selectors without React re-rendering anything.
+ * Apply density to the DOM. Call on app boot and again when prefs change.
+ * We attach an attribute to <html> so CSS can react via attribute selectors
+ * without React re-rendering anything.
  */
-export function applyTheme(theme: Theme): void {
-  if (typeof document === 'undefined') return;
-  const root = document.documentElement;
-  let resolved: 'light' | 'dark';
-  if (theme === 'system') {
-    resolved =
-      typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches
-        ? 'dark'
-        : 'light';
-  } else {
-    resolved = theme;
-  }
-  if (resolved === 'dark') root.setAttribute('data-theme', 'dark');
-  else root.removeAttribute('data-theme');
-}
-
 export function applyDensity(density: Density): void {
   if (typeof document === 'undefined') return;
   document.documentElement.setAttribute('data-density', density);

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -122,9 +122,19 @@ export default {
           '0%': { opacity: '0', transform: 'translateY(4px)' },
           '100%': { opacity: '1', transform: 'translateY(0)' },
         },
+        // Gentle side-to-side rock for the decorative hero sprigs, as if
+        // a draft moved through the greenhouse. Pair with `origin-bottom`
+        // so the stems pivot from the soil line, not their center. The
+        // global prefers-reduced-motion rule in index.css zeroes
+        // animation-duration on *, so this is reduced-motion safe.
+        sway: {
+          '0%, 100%': { transform: 'rotate(-1deg)' },
+          '50%': { transform: 'rotate(1deg)' },
+        },
       },
       animation: {
         'fade-in': 'fade-in 200ms ease-out both',
+        sway: 'sway 6s ease-in-out infinite',
       },
     },
   },


### PR DESCRIPTION
## What this does

Completes the ranked backlog from `docs/reviews/frontend-audit-2026-06-12.md` (items 1–9, 11), plus the commitlint fix for dependabot PRs.

- **Asymmetric hero**: text left, app mockup bleeding off the right edge at `lg`; centered stack preserved below
- **Six hand-drawn botanical feature icons** replace the stock Heroicons in the landing feature grid
- **Feature-card variation**: rotating surfaces (paper/parchment/white), green/terracotta border tints, two horizontal cards at `lg`
- **Motion**: `sway` animation on the hero sprig, verified inert under `prefers-reduced-motion`
- **SprigDividers** at the features→how→pricing seams
- **Dark mode removed** (was body-only inversion, unreadable elsewhere); persisted `dark` prefs migrate to light; restore criteria documented in the audit doc
- **Contrast sweep**: 27 small-text bumps (gray-400/500 → 500/600) across app pages
- **Blog dates staggered** (all four posts showed the same day; git history confirms the uniform date had no basis) + sitemap
- **Status page**: distinct amber "can't reach the status API from your network" state — a client-side network failure no longer renders as a red outage next to "No incidents"
- **Fourth care guide (spider plant)** in the house voice; fixes the orphan card on /care
- **commitlint** now ignores dependabot branch commits (capital "Bump" tripped subject-case and failed Lint on #61/#62)

Deferred deliberately: audit item 10 (i18n-keying ~42k words of hardcoded marketing copy) — pointless until the language picker un-gates Spanish.

### Verification
- 260/260 vitest, tsc + vite build green, size budgets pass (entry 57.3/62 kB, total JS 291/312 kB, CSS 13.7/15 kB)
- Live screenshots at 390/820/1024/1440 reviewed; zero horizontal overflow; reduced-motion verified in-browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)