### PR TITLE
fix(infra): code-review remediations (gate prod apply, deploy-role deny, image lifecycle, +)

### DIFF
--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -111,6 +111,11 @@ jobs:
     name: Terraform Apply
     runs-on: ubuntu-latest
     needs: [validate, build]
+    # `terraform apply -auto-approve` runs FIRST and can replace Cognito / DDB
+    # / CloudFront / IAM. Gate it behind the same `production` environment as
+    # deploy-backend so the prod infra apply requires a reviewer approval too —
+    # otherwise any `v*` tag triggers an unreviewed infrastructure mutation.
+    environment: production
     defaults:
       run:
         working-directory: infrastructure
@@ -154,6 +159,10 @@ jobs:
     name: Deploy Frontend
     runs-on: ubuntu-latest
     needs: [validate, terraform]
+    # Same `production` approval gate as the terraform + deploy-backend jobs:
+    # an S3 sync + CloudFront invalidation to the live site is a prod mutation
+    # and must not run on an untagged/unreviewed path.
+    environment: production
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -341,6 +350,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [validate, deploy-backend, smoke-tests]
     if: failure() && needs.deploy-backend.result == 'success'
+    # SCOPE: this auto-rollback reverts Lambda *code* ONLY. The `terraform
+    # apply` that ran earlier in this deploy (Cognito/DDB/CloudFront/IAM/etc.)
+    # is NOT auto-rolled-back — if a bad infra change is what broke smoke,
+    # revert the tfvars/module change and run a corrective deploy by hand.
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -363,14 +376,27 @@ jobs:
             # Restore the previous version's code from the per-version zip the
             # deploy job archived to S3 (keyed by published version number).
             # `update-alias` would be cleaner once aliases exist; until then we
-            # re-publish the previous version's code to $LATEST. The fallback
-            # only fires for versions deployed before artifact archival existed.
-            aws lambda update-function-code \
+            # re-publish the previous version's code to $LATEST.
+            #
+            # A missing artifact means rollback CANNOT restore this function —
+            # fail loudly instead of swallowing it. Silently no-oping here
+            # leaves a broken deploy live while the workflow looks "rolled
+            # back". Track every failure and exit non-zero at the end so the
+            # operator is paged to finish the rollback by hand.
+            if ! aws lambda update-function-code \
               --function-name "$FUNCTION_NAME" \
               --s3-bucket "$ARTIFACT_BUCKET" \
               --s3-key "lambda-versions/${handler}-v${ver}.zip" \
-              --publish > /dev/null 2>&1 || echo "  ! ${FUNCTION_NAME}: no prior-version artifact found"
+              --publish > /dev/null 2>&1; then
+              echo "::error::${FUNCTION_NAME}: no prior-version artifact (lambda-versions/${handler}-v${ver}.zip) — NOT rolled back, manual intervention required"
+              rollback_failed=1
+            fi
           done < prev-versions.txt
+
+          if [ "${rollback_failed:-0}" = "1" ]; then
+            echo "::error::One or more functions could not be rolled back (missing artifact). Production may be running broken code — investigate immediately."
+            exit 1
+          fi
 
       - name: Notify (rollback)
         run: |

--- a/infrastructure/environments/production/terraform.tfvars
+++ b/infrastructure/environments/production/terraform.tfvars
@@ -21,3 +21,8 @@ github_repo = "family-greenhouse"
 # Cost guardrail. The running app is ~$2-3/mo; this catches a runaway. Cost
 # Anomaly Detection (monitoring module) handles spend *spikes* separately.
 monthly_budget_usd = "30"
+
+# Enforce the Plant.id identify monthly meter in production (block once a
+# household exceeds its cap) so the real per-call Plant.id credit can't be
+# cost-amplified by concurrency. Beta default is tracking-only ("").
+identify_metering_enabled = "1"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -105,6 +105,7 @@ module "api" {
   openweather_api_key        = var.openweather_api_key
   openweather_daily_budget   = var.openweather_daily_budget
   bedrock_embed_model_id     = var.bedrock_embed_model_id
+  identify_metering_enabled  = var.identify_metering_enabled
 }
 
 # Frontend module (S3 + CloudFront)

--- a/infrastructure/modules/api/main.tf
+++ b/infrastructure/modules/api/main.tf
@@ -288,6 +288,11 @@ locals {
     WEB_PUSH_VAPID_SUBJECT     = var.web_push_vapid_subject
     SMS_NOTIFICATIONS_ENABLED  = var.sms_notifications_enabled
     PLANT_ID_API_KEY           = var.plant_id_api_key
+    # Plant.id identify monthly meter. "1" enforces the per-household monthly
+    # cap (blocks once exceeded); unset/"" only tracks usage (beta default).
+    # Set to "1" in production so the real per-call Plant.id credit can't be
+    # cost-amplified by concurrency.
+    IDENTIFY_METERING_ENABLED = var.identify_metering_enabled
     # OpenWeather powers the climate/weather features. Without the key the
     # weather service short-circuits to null and those features silently
     # disable in prod — so it must be wired here, not left to drift.
@@ -320,6 +325,11 @@ resource "aws_lambda_function" "handlers" {
   # 90s leaves margin without unbounded; memory bump shortens cold starts.
   timeout     = each.key == "chat" ? 90 : 30
   memory_size = each.key == "chat" ? 512 : 256
+
+  # Cap chat concurrency to bound Bedrock spend + blast radius: a runaway
+  # chat loop can't drain the 1000-account concurrency pool and brown out the
+  # rest of the API. Other handlers stay unreserved (-1 = use the shared pool).
+  reserved_concurrent_executions = each.key == "chat" ? 15 : -1
 
   filename         = "${path.module}/placeholder.zip"
   source_code_hash = filebase64sha256("${path.module}/placeholder.zip")
@@ -385,6 +395,11 @@ resource "aws_lambda_function" "chat_stream" {
   # 5 Bedrock calls per turn at ~2-6s each.
   timeout     = 90
   memory_size = 512
+
+  # Same blast-radius/Bedrock-spend cap as the sync `chat` member of the fleet
+  # above: bound concurrent streaming turns so a runaway loop can't exhaust the
+  # account concurrency pool.
+  reserved_concurrent_executions = 15
 
   filename         = "${path.module}/placeholder.zip"
   source_code_hash = filebase64sha256("${path.module}/placeholder.zip")

--- a/infrastructure/modules/api/variables.tf
+++ b/infrastructure/modules/api/variables.tf
@@ -137,6 +137,12 @@ variable "plant_id_api_key" {
   sensitive   = true
 }
 
+variable "identify_metering_enabled" {
+  description = "Set to '1' to ENFORCE the Plant.id identify monthly meter (blocks once a household exceeds its cap). Empty/'' only tracks usage without blocking (beta default). Production should set '1' so the per-call Plant.id credit can't be cost-amplified."
+  type        = string
+  default     = ""
+}
+
 variable "perenual_api_key_secret_id" {
   description = "Secrets Manager secret name (e.g. 'family-greenhouse/perenual-api-key') holding the Perenual API key. The Lambda fetches the value at cold start; the secret material never lands in Terraform state. Empty disables Perenual integration."
   type        = string

--- a/infrastructure/modules/cicd/main.tf
+++ b/infrastructure/modules/cicd/main.tf
@@ -14,6 +14,11 @@
 # policy controls WHO can assume; the permission policy bounds the blast
 # radius if assumption is ever compromised.
 
+# Account id for pinning IAM resource ARNs to THIS account instead of `*`
+# (any-account). A wildcard account in an IAM resource ARN is broader than
+# the role ever needs — every project role/policy it manages lives here.
+data "aws_caller_identity" "current" {}
+
 resource "aws_iam_openid_connect_provider" "github" {
   url            = "https://token.actions.githubusercontent.com"
   client_id_list = ["sts.amazonaws.com"]
@@ -164,9 +169,39 @@ resource "aws_iam_policy" "deploy" {
           "iam:*",
         ]
         Resource = [
-          "arn:aws:iam::*:role/${var.project_name}-*",
-          "arn:aws:iam::*:policy/${var.project_name}-*",
-          "arn:aws:iam::*:oidc-provider/token.actions.githubusercontent.com",
+          "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.project_name}-*",
+          "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/${var.project_name}-*",
+          "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/token.actions.githubusercontent.com",
+        ]
+      },
+      {
+        # SELF-ESCALATION DEFENSE.
+        #
+        # The IamWriteProjectScoped grant above necessarily includes the
+        # deploy role's OWN ARN (it matches `${project_name}-*`), because the
+        # role legitimately manages the project's roles/policies — including
+        # itself. But that means an Allow of iam:AttachRolePolicy /
+        # iam:PutRolePolicy on `role/${project_name}-*` lets a compromised CI
+        # run attach AdministratorAccess (or an inline allow-*) to THIS role
+        # and bootstrap full admin from a scoped credential.
+        #
+        # An explicit Deny (which always wins over an Allow) on the
+        # permission-mutating actions, scoped to ONLY this role's exact ARN,
+        # closes that path. It deliberately does NOT name the other project
+        # roles (e.g. the lambda execution role), so the deploy role keeps its
+        # legitimate ability to attach/put/delete policies on those during a
+        # normal terraform apply. iam:PutRolePermissionsBoundary is included so
+        # the role can't widen its own boundary either.
+        Sid    = "DenySelfPrivilegeEscalation"
+        Effect = "Deny"
+        Action = [
+          "iam:AttachRolePolicy",
+          "iam:PutRolePolicy",
+          "iam:DeleteRolePolicy",
+          "iam:PutRolePermissionsBoundary",
+        ]
+        Resource = [
+          "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.project_name}-github-deploy",
         ]
       },
       {

--- a/infrastructure/modules/frontend/main.tf
+++ b/infrastructure/modules/frontend/main.tf
@@ -99,13 +99,62 @@ resource "aws_s3_bucket_public_access_block" "images" {
   restrict_public_buckets = true
 }
 
+# Versioning enabled in production to match the frontend bucket — gives a
+# recovery window for an accidentally overwritten/deleted plant photo. Paired
+# with the lifecycle rule below so noncurrent versions don't accumulate forever.
+resource "aws_s3_bucket_versioning" "images" {
+  bucket = aws_s3_bucket.images.id
+
+  versioning_configuration {
+    status = var.environment == "production" ? "Enabled" : "Suspended"
+  }
+}
+
+# Lifecycle for the images bucket (previously absent — deleted-plant photos and
+# abandoned presigned-PUT uploads would otherwise live forever: cost creep plus
+# a data-retention gap where user images persist after account deletion).
+#   - abort_incomplete_multipart_upload: reclaim never-finished presigned PUTs.
+#   - noncurrent_version_expiration: bound the versioning history added above.
+resource "aws_s3_bucket_lifecycle_configuration" "images" {
+  bucket = aws_s3_bucket.images.id
+
+  # Noncurrent-version rules only make sense once versioning is configured.
+  depends_on = [aws_s3_bucket_versioning.images]
+
+  rule {
+    id     = "abort-incomplete-multipart"
+    status = "Enabled"
+
+    filter {}
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+
+  rule {
+    id     = "expire-noncurrent-versions"
+    status = "Enabled"
+
+    filter {}
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+  }
+}
+
 resource "aws_s3_bucket_cors_configuration" "images" {
   bucket = aws_s3_bucket.images.id
 
   cors_rule {
     allowed_headers = ["*"]
     allowed_methods = ["PUT", "GET"]
-    allowed_origins = ["*"]
+    # Presigned-PUT uploads come from the browser on the site origin only.
+    # Pin CORS to that origin instead of "*" (which let any site script the
+    # cross-origin upload). Falls back to "*" only in the no-domain dev
+    # environment, where there is no stable site origin to pin to.
+    allowed_origins = var.domain_name == "" ? ["*"] : ["https://${var.domain_name}", "https://www.${var.domain_name}"]
     max_age_seconds = 3600
   }
 }

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -113,3 +113,12 @@ variable "bedrock_embed_model_id" {
   type        = string
   default     = ""
 }
+
+# Plant.id identify monthly meter. "1" ENFORCES the per-household monthly cap;
+# blank only tracks usage (beta default). Production sets "1" so the real
+# per-call Plant.id credit can't be cost-amplified by concurrency.
+variable "identify_metering_enabled" {
+  description = "Set to '1' to enforce the Plant.id identify monthly meter. Blank only tracks usage without blocking."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
Infrastructure/CI remediations from `docs/reviews/codebase-review-2026-06-17.md`. These apply on the **next tagged deploy**, not on merge.

## Findings addressed

**H4 — Prod `terraform apply` not behind the approval gate.** Added `environment: production` to the `terraform` and `deploy-frontend` jobs in `cd-production.yml`, so the infra apply + frontend sync sit behind the same required-reviewer gate as `deploy-backend` (previously any `v*` tag ran an unreviewed `apply -auto-approve`).

**H5 — Deploy role could self-escalate.** In `modules/cicd/main.tf`, added an explicit `Deny` on `iam:AttachRolePolicy`/`iam:PutRolePolicy`/`iam:DeleteRolePolicy`/`iam:PutRolePermissionsBoundary` scoped to **only** the deploy role's own ARN (`family-greenhouse-github-deploy`) — Deny always wins, so a compromised CI run can't attach AdministratorAccess to itself. Other project roles (e.g. the lambda exec role) are untouched, so legitimate policy management still works. Also pinned the project IAM `Resource` ARNs from `arn:aws:iam::*:...` to the concrete account id via a new `data.aws_caller_identity.current`.

**M2 — Images bucket had no lifecycle.** In `modules/frontend/main.tf`: enabled versioning (prod, matching the frontend bucket), added `abort_incomplete_multipart_upload` (7d) + `noncurrent_version_expiration` (30d), and tightened the CORS `allowed_origins` from `["*"]` to the site origin (`https://<domain>` + `www`), falling back to `*` only in the no-domain dev environment.

**M11 — No reserved concurrency; rollback silently no-ops.** Added `reserved_concurrent_executions = 15` to the `chat` (fleet) and `chat-stream` (standalone) lambdas in `modules/api/main.tf`. In `cd-production.yml`, the auto-rollback's missing-artifact case now emits a `::error::` and exits non-zero (was `|| echo`), and a comment documents that the `terraform apply` is **not** auto-rolled-back (code only).

**M1 (infra half) — Identify meter shipped disabled.** Wired `IDENTIFY_METERING_ENABLED` end-to-end: root `variables.tf` → root `module "api"` call → `modules/api/variables.tf` → the shared lambda env block → set to `"1"` in `environments/production/terraform.tfvars`, so the Plant.id identify monthly meter is enforced in prod.

## Skipped
- **arm64 lambda migration** (low) — documented-deferred per the review (awkward `ignore_changes` interaction), left untouched.

## Verification
- `terraform fmt -check -recursive` → clean
- `terraform init -backend=false` + `terraform validate` → "configuration is valid"

🤖 Generated with [Claude Code](https://claude.com/claude-code)