### PR TITLE
fix(backend): code-review remediations (DND reminders, activity pagination, assignee validation, +)

### DIFF
--- a/backend/src/handlers/households/handler.ts
+++ b/backend/src/handlers/households/handler.ts
@@ -363,7 +363,20 @@ export const updateMemberRole = createHandler(
       throw createHttpError(404, 'Member not found');
     }
 
-    const updated = await householdService.setMemberRole(householdId, userId, validatedBody.role);
+    let updated;
+    try {
+      updated = await householdService.setMemberRole(householdId, userId, validatedBody.role);
+    } catch (err) {
+      // Service-layer last-admin guard (L1). Maps to the same 400 the handler
+      // already returns for self-demotion.
+      if (err instanceof Error && err.name === 'LastAdminError') {
+        throw createHttpError(
+          400,
+          'Promote another member to admin before demoting the last admin'
+        );
+      }
+      throw err;
+    }
     if (!updated) {
       throw createHttpError(404, 'Member not found');
     }
@@ -420,7 +433,18 @@ export const removeMember = createHandler(
       throw createHttpError(404, 'Member not found');
     }
 
-    await householdService.removeMember(householdId, userId);
+    try {
+      await householdService.removeMember(householdId, userId);
+    } catch (err) {
+      // Service-layer last-admin guard (L1).
+      if (err instanceof Error && err.name === 'LastAdminError') {
+        throw createHttpError(
+          400,
+          'Promote another member to admin before removing the last admin'
+        );
+      }
+      throw err;
+    }
 
     // Claims hygiene. Removal from a SECONDARY household must not touch the
     // user's Cognito claims at all (the old unconditional clear logged users

--- a/backend/src/handlers/notifications/handler.ts
+++ b/backend/src/handlers/notifications/handler.ts
@@ -3,7 +3,12 @@ import createHttpError from 'http-errors';
 import { z } from 'zod';
 import { createHandler } from '../../middleware/handler.js';
 import { createRouter } from '../../middleware/router.js';
-import { authMiddleware, AuthenticatedEvent, requireHousehold } from '../../middleware/auth.js';
+import {
+  authMiddleware,
+  AuthenticatedEvent,
+  requireHousehold,
+  rejectApiKeyPrincipal,
+} from '../../middleware/auth.js';
 import { validateBody, ValidatedEvent } from '../../middleware/validation.js';
 import { authRateLimit, userRateLimit } from '../../middleware/rateLimit.js';
 import * as pushSubscriptions from '../../services/pushSubscriptions.js';
@@ -168,6 +173,9 @@ export const runReminders = createHandler(
 )
   .use(authMiddleware())
   .use(requireHousehold())
+  // Internal cron / break-glass route: never a machine key (defense-in-depth
+  // even though API keys don't reach this handler today). See M2.
+  .use(rejectApiKeyPrincipal())
   // Fans out push/email/SMS to the whole household — each call costs real
   // money on the paid notification channels. "Send reminders now" is a
   // break-glass button, not a polling target: 2/hour per admin.
@@ -195,6 +203,7 @@ export const runDigests = createHandler(
 )
   .use(authMiddleware())
   .use(requireHousehold())
+  .use(rejectApiKeyPrincipal())
   // Same budget rationale as run-reminders: email costs money per send.
   .use(userRateLimit({ perWindowMs: 60 * 60 * 1000, max: 2 }));
 
@@ -221,6 +230,7 @@ export const runYearRecap = createHandler(
 )
   .use(authMiddleware())
   .use(requireHousehold())
+  .use(rejectApiKeyPrincipal())
   .use(validateBody(recapSchema))
   .use(userRateLimit({ perWindowMs: 60 * 60 * 1000, max: 2 }));
 

--- a/backend/src/handlers/plants/health.ts
+++ b/backend/src/handlers/plants/health.ts
@@ -7,6 +7,7 @@ import { validateBody, ValidatedEvent } from '../../middleware/validation.js';
 import { userRateLimit } from '../../middleware/rateLimit.js';
 import * as plantService from '../../services/plantService.js';
 import * as leafHealth from '../../services/leafHealth.js';
+import * as leafHealthBudget from '../../services/leafHealthBudget.js';
 import * as activity from '../../services/activity.js';
 import * as householdService from '../../services/householdService.js';
 import { successResponse } from '../../utils/response.js';
@@ -27,10 +28,11 @@ type HealthCheckInput = z.infer<typeof healthCheckSchema>;
 // Metering decision: leaf-health checks are NOT counted against the identify
 // monthly bucket. Identify metering exists because every Plant.id call burns
 // a paid per-call credit; a leaf-health call is one Bedrock Haiku invocation
-// (fractions of a cent) already bounded by the 5/min per-user rate limit
-// below, and silently spending the user's identification allowance on a
-// different feature would be surprising. If Bedrock spend ever needs a
-// monthly cap, clone the identifyBudget partition shape with its own PK.
+// (fractions of a cent). It is, however, real Bedrock spend, and the 5/min
+// per-user rate limiter is in-memory per warm container (ceiling = N
+// containers × max), so we add a durable monthly per-household spend cap
+// (services/leafHealthBudget.ts, its own PK — cloned from the identifyBudget
+// shape) mirroring the chat token-budget gate. Over-cap → 429.
 export const checkPlantHealth = createHandler(
   async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
     const { user } = event as AuthenticatedEvent;
@@ -47,6 +49,15 @@ export const checkPlantHealth = createHandler(
     const plant = await plantService.getPlant(user.householdId!, plantId);
     if (!plant) {
       throw createHttpError(404, 'Plant not found');
+    }
+
+    // Monthly Bedrock spend cap (M1). Gate BEFORE the model call — cheaper to
+    // bail than to invoke. Mirrors the chat budget's 429 contract.
+    if (await leafHealthBudget.isOverCap(user.householdId!)) {
+      throw createHttpError(
+        429,
+        "You've used this month's leaf-health check allowance. It resets on the 1st of next month."
+      );
     }
 
     let assessment: leafHealth.LeafHealthAssessment;
@@ -66,6 +77,13 @@ export const checkPlantHealth = createHandler(
       throw createHttpError(502, `Leaf health check failed: ${(err as Error).message}`, {
         expose: true,
       });
+    }
+
+    // Count real Bedrock invocations against the monthly cap. The demo
+    // fallback never reached Bedrock (no spend), so it isn't metered. Soft:
+    // a failed increment doesn't fail the request the user already got.
+    if (!assessment.demo) {
+      await leafHealthBudget.incrementUsage(user.householdId!);
     }
 
     // Best-effort activity row, only on success — same fire-and-forget

--- a/backend/src/handlers/plants/import.ts
+++ b/backend/src/handlers/plants/import.ts
@@ -110,7 +110,12 @@ export const importPlants = createHandler(
             );
           } catch (err) {
             logger.warn({ err, plantId: plant.id }, 'import_task_create_failed');
-            taskError = 'Plant created, but one or more tasks could not be created';
+            // Surface a dangling-assignee row error specifically (M4); other
+            // task failures keep the generic note.
+            taskError =
+              err instanceof Error && err.name === 'AssigneeNotMemberError'
+                ? 'Plant created, but a task assignee was not a current household member'
+                : 'Plant created, but one or more tasks could not be created';
           }
         }
 

--- a/backend/src/handlers/tasks/handler.ts
+++ b/backend/src/handlers/tasks/handler.ts
@@ -32,6 +32,30 @@ import {
   noContentResponse,
   cacheableResponse,
 } from '../../utils/response.js';
+import { logger } from '../../utils/logger.js';
+
+/**
+ * Resolve a member's display name from the denormalized household member row
+ * (single GetItem) — the same pattern as the plants handler's resolveActorName.
+ * Persisted as `completedByName` on completion records, which drive the
+ * activity feed, year-in-review byMember, and recap emails, so it must be the
+ * real name ("Jane Smith"), not the email local-part ("jsmith"). Best-effort:
+ * a lookup miss/failure falls back to the email local-part rather than failing
+ * the completion.
+ */
+async function resolveCompleterName(
+  householdId: string,
+  userId: string,
+  email: string
+): Promise<string> {
+  try {
+    const member = await householdService.getMemberByUserId(householdId, userId);
+    if (member?.name) return member.name;
+  } catch (err) {
+    logger.warn({ err }, 'completer_name_lookup_failed');
+  }
+  return email.split('@')[0];
+}
 
 // GET /tasks
 export const listTasks = createHandler(
@@ -93,12 +117,20 @@ export const createTask = createHandler(
       throw createHttpError(404, 'Plant not found');
     }
 
-    const task = await taskService.createTask(
-      validatedBody,
-      user.householdId!,
-      user.userId,
-      plant.name
-    );
+    let task;
+    try {
+      task = await taskService.createTask(
+        validatedBody,
+        user.householdId!,
+        user.userId,
+        plant.name
+      );
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AssigneeNotMemberError') {
+        throw createHttpError(400, 'assignedTo must be a current household member');
+      }
+      throw err;
+    }
 
     return createdResponse(task);
   }
@@ -141,7 +173,15 @@ export const updateTask = createHandler(
       throw createHttpError(400, 'Task ID is required');
     }
 
-    const task = await taskService.updateTask(user.householdId!, taskId, validatedBody);
+    let task;
+    try {
+      task = await taskService.updateTask(user.householdId!, taskId, validatedBody);
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AssigneeNotMemberError') {
+        throw createHttpError(400, 'assignedTo must be a current household member');
+      }
+      throw err;
+    }
 
     if (!task) {
       throw createHttpError(404, 'Task not found');
@@ -187,8 +227,7 @@ export const completeTask = createHandler(
       throw createHttpError(400, 'Task ID is required');
     }
 
-    // TODO: Get actual user name from Cognito
-    const userName = user.email.split('@')[0];
+    const userName = await resolveCompleterName(user.householdId!, user.userId, user.email);
 
     const task = await taskService.completeTask(
       user.householdId!,

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -182,3 +182,28 @@ export const requireAdmin = (): middy.MiddlewareObj<AuthenticatedEvent, APIGatew
 
   return { before };
 };
+
+/**
+ * Structurally reject machine (API-key) principals with a 403, regardless of
+ * scope or role. API keys carry `householdRole: 'member'` for read-path
+ * compatibility, so a role check can't tell them apart from a human — the
+ * authoritative signal is `user.isApiKey` (set by apiKeyMiddleware).
+ *
+ * Use this as defense-in-depth on internal/operational routes that should
+ * only ever be reached by a human admin or an internal IAM-signed invocation
+ * — the reminder/digest/recap cron triggers — so a leaked key can never fan
+ * out paid notification sends even if it somehow reached the route. This also
+ * gives the otherwise-unused `isApiKey` flag a real enforcement use.
+ */
+export const rejectApiKeyPrincipal = (): middy.MiddlewareObj<
+  AuthenticatedEvent,
+  APIGatewayProxyResult
+> => {
+  const before: middy.MiddlewareFn<AuthenticatedEvent, APIGatewayProxyResult> = (request) => {
+    if (request.event.user?.isApiKey) {
+      throw createHttpError(403, 'API keys cannot access this route');
+    }
+  };
+
+  return { before };
+};

--- a/backend/src/services/householdService.ts
+++ b/backend/src/services/householdService.ts
@@ -37,6 +37,37 @@ export class PlanLimitError extends Error {
 }
 
 /**
+ * Raised when a role change or removal would leave a multi-member household
+ * with no admin (the lone admin demoting/removing themselves). The handlers
+ * already enforce this on the self-demotion / account-deletion paths, but
+ * keeping the invariant in the service layer too means a future handler that
+ * forgets the check can't lock a household out of admin. Call sites check
+ * `err.name === 'LastAdminError'` (not instanceof) — same convention as
+ * PlanLimitError.
+ */
+export class LastAdminError extends Error {
+  constructor(message = 'Cannot remove the last admin of a household with other members') {
+    super(message);
+    this.name = 'LastAdminError';
+  }
+}
+
+/**
+ * Guard: throw LastAdminError if removing `userId`'s admin rights (by demotion
+ * or removal) would leave a multi-member household with zero admins. A
+ * single-member household is exempt (a solo admin managing only themselves is
+ * fine — that's the account-deletion / leave path).
+ */
+async function assertNotLastAdmin(householdId: string, userId: string): Promise<void> {
+  const members = await getHouseholdMembers(householdId);
+  if (members.length <= 1) return;
+  const admins = members.filter((m) => m.role === 'admin');
+  if (admins.length === 1 && admins[0].userId === userId) {
+    throw new LastAdminError();
+  }
+}
+
+/**
  * Pull the per-item CancellationReasons off a TransactWriteCommand failure.
  * Returns [] for anything that isn't a TransactionCanceledException, so
  * callers can index into it safely.
@@ -107,6 +138,12 @@ export async function setMemberRole(
   userId: string,
   role: 'admin' | 'member'
 ): Promise<HouseholdMember | null> {
+  // Service-layer last-admin guard (L1): demoting the lone admin of a
+  // multi-member household would lock it out of admin entirely.
+  if (role === 'member') {
+    await assertNotLastAdmin(householdId, userId);
+  }
+
   const result = await dynamodb.send(
     new UpdateCommand({
       TableName: TABLE_NAME,
@@ -422,6 +459,11 @@ export async function addMember(
  *     is already at its floor).
  */
 export async function removeMember(householdId: string, userId: string): Promise<void> {
+  // Service-layer last-admin guard (L1): removing the lone admin of a
+  // multi-member household would lock it out of admin entirely. Solo-member
+  // households are exempt (the leave / account-deletion path).
+  await assertNotLastAdmin(householdId, userId);
+
   const memberKey = {
     PK: `HOUSEHOLD#${householdId}`,
     SK: `MEMBER#${userId}`,

--- a/backend/src/services/leafHealthBudget.ts
+++ b/backend/src/services/leafHealthBudget.ts
@@ -1,0 +1,123 @@
+/**
+ * Per-household monthly spend cap for the Bedrock leaf-health check
+ * (`POST /plants/{id}/health-check`).
+ *
+ * Each check is one Bedrock vision invocation (fractions of a cent), already
+ * bounded by the 5/min per-user rate limiter — but the rate limiter is
+ * in-memory per warm container, so the real ceiling is N containers × max.
+ * This adds a hard, durable monthly ceiling per household so concurrency can't
+ * cost-amplify Bedrock spend, mirroring the chat token-budget gate and the
+ * identify monthly meter.
+ *
+ * Storage (same single-partition shape as identifyBudget.ts):
+ *
+ *   PK: LEAFHEALTH#BUDGET
+ *   SK: MONTH#{yyyy-mm}#HH#{householdId}
+ *   used: number (atomic ADD)
+ *   ttl:  ~95 days (same retention as the chat + identify budget rows)
+ *
+ * Configurable via `LEAF_HEALTH_MONTHLY_CAP` (default 200/household/month).
+ * Unlike identify, enforcement is ALWAYS on — leaf-health is a pure Bedrock
+ * cost with no per-plan allowance to tier — but a cap of 0 or a negative value
+ * disables the gate entirely (treated as "unlimited"), which is the documented
+ * escape hatch if a household legitimately needs more.
+ */
+import { GetCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
+import { dynamodb, TABLE_NAME } from '../utils/dynamodb.js';
+import { logger } from '../utils/logger.js';
+
+const BUDGET_TTL_SECONDS = 95 * 24 * 60 * 60;
+const DEFAULT_MONTHLY_CAP = 200;
+
+/**
+ * Monthly cap on leaf-health checks per household. Reads `LEAF_HEALTH_MONTHLY_CAP`
+ * each call (cheap, and lets tests flip it). `<= 0` (or an unparseable value)
+ * means "no cap" — see module docs.
+ */
+export function monthlyCap(): number {
+  const raw = process.env.LEAF_HEALTH_MONTHLY_CAP;
+  if (raw === undefined || raw === '') return DEFAULT_MONTHLY_CAP;
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return DEFAULT_MONTHLY_CAP;
+  return n;
+}
+
+/** UTC calendar month, e.g. "2026-06". Exported for tests (rollover). */
+export function monthKey(d: Date = new Date()): string {
+  const yyyy = d.getUTCFullYear();
+  const mm = String(d.getUTCMonth() + 1).padStart(2, '0');
+  return `${yyyy}-${mm}`;
+}
+
+function budgetKey(householdId: string, now: Date): { PK: string; SK: string } {
+  return {
+    PK: 'LEAFHEALTH#BUDGET',
+    SK: `MONTH#${monthKey(now)}#HH#${householdId}`,
+  };
+}
+
+/**
+ * Leaf-health checks used this month for the household. Missing row → 0. DDB
+ * failures fail OPEN (0 + a warn log): the spend cap must never take down the
+ * feature itself.
+ */
+export async function getUsage(householdId: string, now: Date = new Date()): Promise<number> {
+  try {
+    const result = await dynamodb.send(
+      new GetCommand({ TableName: TABLE_NAME, Key: budgetKey(householdId, now) })
+    );
+    const used: unknown = result.Item?.used;
+    return typeof used === 'number' && used > 0 ? used : 0;
+  } catch (err) {
+    logger.warn({ err: (err as Error).message, householdId }, 'leaf_health.budget_read_failed');
+    return 0;
+  }
+}
+
+/**
+ * True when the household has hit its monthly cap (and a cap is in effect).
+ * Reads usage and compares; callers gate the Bedrock call on this.
+ */
+export async function isOverCap(householdId: string, now: Date = new Date()): Promise<boolean> {
+  const cap = monthlyCap();
+  if (cap <= 0) return false; // unlimited
+  const used = await getUsage(householdId, now);
+  return used >= cap;
+}
+
+/**
+ * Atomically count one leaf-health check against the household's month.
+ * Returns the new used total, or null when the write failed — callers treat a
+ * failure as soft (the user already got their result; losing one tick of
+ * metering is the better failure mode).
+ */
+export async function incrementUsage(
+  householdId: string,
+  now: Date = new Date()
+): Promise<number | null> {
+  try {
+    const result = await dynamodb.send(
+      new UpdateCommand({
+        TableName: TABLE_NAME,
+        Key: budgetKey(householdId, now),
+        UpdateExpression:
+          'ADD #used :one SET #ttl = if_not_exists(#ttl, :ttl), entityType = if_not_exists(entityType, :etype)',
+        ExpressionAttributeNames: { '#used': 'used', '#ttl': 'ttl' },
+        ExpressionAttributeValues: {
+          ':one': 1,
+          ':ttl': Math.floor(now.getTime() / 1000) + BUDGET_TTL_SECONDS,
+          ':etype': 'LeafHealthBudget',
+        },
+        ReturnValues: 'UPDATED_NEW',
+      })
+    );
+    const used: unknown = result.Attributes?.used;
+    return typeof used === 'number' ? used : null;
+  } catch (err) {
+    logger.warn(
+      { err: (err as Error).message, householdId },
+      'leaf_health.budget_increment_failed'
+    );
+    return null;
+  }
+}

--- a/backend/src/services/notifier.ts
+++ b/backend/src/services/notifier.ts
@@ -46,12 +46,20 @@ export interface NotificationRecipient {
   email: string;
 }
 
-async function sendBrowserPush(userId: string, payload: NotificationPayload): Promise<void> {
+/**
+ * Returns whether at least one browser-push delivery was actually attempted —
+ * a configured send to an existing subscription, or (in dry-run) the logged
+ * stand-in for one. `sendToUser` uses this to decide whether the user was
+ * reachable on this channel. A user with no subscriptions returns false.
+ */
+async function sendBrowserPush(userId: string, payload: NotificationPayload): Promise<boolean> {
   const subs = await pushSubscriptions.getUserSubscriptions(userId);
-  if (subs.length === 0) return;
+  if (subs.length === 0) return false;
   if (!ensureWebPushConfigured()) {
     logger.info({ userId, count: subs.length, payload, msg: 'push_dry_run' }, 'push_dry_run');
-    return;
+    // Dry-run still counts as "reachable on browser push" — in a configured
+    // environment this would have delivered.
+    return true;
   }
   await Promise.all(
     subs.map(async (sub) => {
@@ -71,6 +79,25 @@ async function sendBrowserPush(userId: string, payload: NotificationPayload): Pr
       }
     })
   );
+  return true;
+}
+
+/**
+ * Outcome of a `sendToUser` fan-out. The reminder dedupe marker (see
+ * `services/reminders.ts`) keys off this so it only "burns the day" when the
+ * user was actually reachable:
+ *
+ *   - `delivered` — at least one channel attempted a real send (browser push
+ *     to an existing subscription, email, or SMS).
+ *   - `dndSuppressedOnly` — the user has email and/or SMS enabled but NOTHING
+ *     delivered, and the only reason the loud channels were skipped is the DND
+ *     window. This is the case H1 exists for: a DND user who relies on
+ *     email/SMS (no push) is reachable again once the window lifts, so the
+ *     caller must NOT claim the daily slot and should retry on the next run.
+ */
+export interface SendResult {
+  delivered: boolean;
+  dndSuppressedOnly: boolean;
 }
 
 /**
@@ -82,20 +109,29 @@ async function sendBrowserPush(userId: string, payload: NotificationPayload): Pr
  *   - Inside DND, email + SMS are suppressed (they wake people up loudly).
  *   - Browser push is NOT suppressed — the OS already manages quiet hours
  *     better than we can, and browser push respects the OS setting.
+ *
+ * Returns a `SendResult` describing whether anything was delivered and, if
+ * not, whether the only thing standing in the way was the DND window — see
+ * `SendResult`.
  */
 export async function sendToUser(
   recipient: NotificationRecipient,
   payload: NotificationPayload
-): Promise<void> {
+): Promise<SendResult> {
   const prefs = await notificationPrefs.getPreferences(recipient.userId);
   const inDnd = notificationPrefs.isInDndWindow(prefs);
 
+  // Browser push runs first and synchronously resolves whether the user has a
+  // subscription, so we can fold its reachability into `delivered`.
+  let delivered = false;
+  if (prefs.browser) {
+    delivered = (await sendBrowserPush(recipient.userId, payload)) || delivered;
+  }
+
   const work: Promise<void>[] = [];
 
-  if (prefs.browser) {
-    work.push(sendBrowserPush(recipient.userId, payload));
-  }
   if (prefs.email && !inDnd) {
+    delivered = true;
     work.push(
       emailNotifier
         .sendEmail({
@@ -118,6 +154,7 @@ export async function sendToUser(
         'sms_skipped_unverified'
       );
     } else {
+      delivered = true;
       work.push(
         smsNotifier
           .sendSms({ to: prefs.phone, text: `${payload.title}: ${payload.body}` })
@@ -132,4 +169,10 @@ export async function sendToUser(
   }
 
   await Promise.all(work);
+
+  // DND-suppressed-only: the user wants email/SMS, nothing actually went out,
+  // and DND is the cause. (`delivered` already covers browser push delivering
+  // during DND.)
+  const dndSuppressedOnly = !delivered && inDnd && (prefs.email || prefs.sms);
+  return { delivered, dndSuppressedOnly };
 }

--- a/backend/src/services/plantIdentification.ts
+++ b/backend/src/services/plantIdentification.ts
@@ -9,6 +9,8 @@
  *   - LeafSnap (mobile-only, not ideal for our flow)
  * The interface below is small enough that swapping is trivial.
  */
+import { logger } from '../utils/logger.js';
+
 export interface IdentificationSuggestion {
   scientificName: string;
   commonName: string | null;
@@ -82,8 +84,16 @@ export async function identifyPlant(base64Image: string): Promise<IdentifyRespon
   }
 
   if (!res.ok) {
+    // Log the upstream status + body server-side for debugging, but do NOT
+    // reflect Plant.id's error body to the client — it can carry upstream
+    // detail we don't want to surface (and the identify handler exposes 5xx
+    // messages to the frontend). Return a generic, stable message instead (L2).
     const text = await res.text();
-    throw new Error(`plant.id ${res.status}: ${text.slice(0, 200)}`);
+    logger.warn(
+      { status: res.status, body: text.slice(0, 500), msg: 'plant_id_upstream_error' },
+      'plant_id_upstream_error'
+    );
+    throw new Error('plant identification service is temporarily unavailable');
   }
 
   const data = (await res.json()) as PlantIdResponse;

--- a/backend/src/services/reminders.ts
+++ b/backend/src/services/reminders.ts
@@ -13,14 +13,17 @@
  * Spam control: the scan is hourly and the due window is 24h, so the same due
  * task is eligible on every run. A per-user, per-day dedupe marker (conditional
  * Put on USER#{id} / REMINDED#{yyyy-mm-dd}) caps delivery at one reminder per
- * user per UTC day — email/SMS are billed per send, so this matters.
+ * user per UTC day — email/SMS are billed per send, so this matters. The marker
+ * is claimed AFTER a channel actually delivers (see claimDailyReminderSlot):
+ * claiming it up front silently dropped the day's reminder for DND users who
+ * rely on email/SMS, since DND suppresses those channels (H1).
  *
  * Query shape: ONE GSI1 due-window query per household (the same pattern as
  * getUpcomingTasks), grouped by assignee in memory. The old shape was one GSI2
  * query per member, which both multiplied reads and silently dropped
  * unassigned tasks (they're in nobody's GSI2 partition).
  */
-import { PutCommand } from '@aws-sdk/lib-dynamodb';
+import { GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb';
 import { dynamodb, TABLE_NAME } from '../utils/dynamodb.js';
 import { logger } from '../utils/logger.js';
 import type { Task } from '../models/types.js';
@@ -40,11 +43,33 @@ function dateKey(now: Date): string {
 }
 
 /**
+ * Has this user already been reminded today? A point read on the per-user,
+ * per-day marker, used to skip a member up front on subsequent hourly runs
+ * (before building/sending the roll-up). The authoritative dedupe is still
+ * the conditional Put in `claimDailyReminderSlot`; this is the cheap pre-check.
+ */
+async function alreadyRemindedToday(userId: string, now: Date): Promise<boolean> {
+  const result = await dynamodb.send(
+    new GetCommand({
+      TableName: TABLE_NAME,
+      Key: { PK: `USER#${userId}`, SK: `REMINDED#${dateKey(now)}` },
+    })
+  );
+  return Boolean(result.Item);
+}
+
+/**
  * Conditionally claim the user's "reminded today" slot. Returns true when the
  * marker was absent (we own today's send), false when a previous run already
- * sent today. Written BEFORE sending: if the send then fails the user misses
- * one day's reminder, which is the safer failure mode than double-billing
- * email/SMS on every hourly run.
+ * claimed it.
+ *
+ * Written AFTER a channel actually delivered (H1): the slot must reflect a
+ * real send, not merely an attempt. The old order claimed the slot BEFORE
+ * sending, which silently burned the day for DND users who rely on email/SMS —
+ * DND suppresses those channels (only browser push survives), so a push-less
+ * DND user got the marker written but no reminder, and every later hourly run
+ * skipped them. We now claim only once `notifier.sendToUser` reports a
+ * delivery, so a DND-suppressed user is retried on the next run instead.
  */
 async function claimDailyReminderSlot(userId: string, now: Date): Promise<boolean> {
   try {
@@ -136,8 +161,11 @@ export async function remindHousehold(
       const tasksForMember = [...mine, ...unassigned];
       if (tasksForMember.length === 0) continue;
 
-      // Per-user daily dedupe — see module docstring.
-      if (!(await claimDailyReminderSlot(member.userId, now))) continue;
+      // Per-user daily dedupe — see claimDailyReminderSlot. Cheap pre-check
+      // up front so an already-reminded member skips the roll-up build + send
+      // entirely on later hourly runs. The slot is only CLAIMED below, after a
+      // channel actually delivered (H1).
+      if (await alreadyRemindedToday(member.userId, now)) continue;
 
       const overdue = tasksForMember.filter((t) => t.nextDue < nowIso).length;
       let body = overdue
@@ -161,11 +189,25 @@ export async function remindHousehold(
         body += ` (covering for ${coveringNames.join(', ')})`;
       }
 
-      await notifier.sendToUser(
+      const result = await notifier.sendToUser(
         { userId: member.userId, email: member.email },
         { title: 'Plant care reminder', body, tag: 'reminder' }
       );
-      sent += 1;
+
+      if (result.delivered) {
+        // Burn the day only on a real delivery, so a transient race can't
+        // double-claim either. The conditional Put is still authoritative.
+        if (await claimDailyReminderSlot(member.userId, now)) {
+          sent += 1;
+        }
+      } else if (result.dndSuppressedOnly) {
+        // Reachable only via DND-suppressed email/SMS: don't claim the slot —
+        // the next hourly run retries once the DND window lifts (H1).
+        logger.info(
+          { householdId, userId: member.userId },
+          'reminders.dnd_suppressed_retry_next_run'
+        );
+      }
     }
   }
 

--- a/backend/src/services/taskService.ts
+++ b/backend/src/services/taskService.ts
@@ -41,6 +41,22 @@ const VACATION_TTL_BUFFER_MS = 3 * 24 * 60 * 60 * 1000;
 const MAX_QUERY_PAGES = 10;
 
 /**
+ * Raised when a task create/update/import would assign the task to a userId
+ * that is not a current member of the household. Without this guard the task
+ * wrote with a dangling assignee — invisible in every member's "assigned to
+ * me" view and rolled into the unassigned bucket by reminders. Handlers map
+ * this to a 400 (call sites check `err.name === 'AssigneeNotMemberError'`, not
+ * instanceof, so test automocks stay compatible — same convention as
+ * PlanLimitError).
+ */
+export class AssigneeNotMemberError extends Error {
+  constructor(message = 'assignedTo must be a current household member') {
+    super(message);
+    this.name = 'AssigneeNotMemberError';
+  }
+}
+
+/**
  * Run a Query and follow LastEvaluatedKey up to MAX_QUERY_PAGES pages.
  * DynamoDB applies `Limit` per page *before* filtering, so any single-page
  * query with Limit set risks silent truncation — use this for anything that
@@ -84,7 +100,9 @@ export async function createTask(
   let assignedToName: string | null = null;
   if (input.assignedTo) {
     const member = await getMemberByUserId(householdId, input.assignedTo);
-    assignedToName = member?.name ?? null;
+    // Reject a dangling assignee rather than writing a task nobody can see (M4).
+    if (!member) throw new AssigneeNotMemberError();
+    assignedToName = member.name;
   }
 
   const task: Task = {
@@ -277,9 +295,11 @@ export async function updateTask(
 
     if (input.assignedTo) {
       // Re-resolve the denormalized assignee name — without this the task
-      // keeps displaying the previous assignee after reassignment.
+      // keeps displaying the previous assignee after reassignment. Reject a
+      // reassignment to a non-member rather than persist a dangling one (M4).
       const member = await getMemberByUserId(householdId, input.assignedTo);
-      expressionAttributeValues[':assignedToName'] = member?.name ?? null;
+      if (!member) throw new AssigneeNotMemberError();
+      expressionAttributeValues[':assignedToName'] = member.name;
 
       // GSI2 keys must follow the assignment (createTask sets them; updateTask
       // historically didn't, so "tasks assigned to me" kept returning stale
@@ -565,31 +585,51 @@ export async function getHouseholdActivity(
   householdId: string,
   limit = 50
 ): Promise<TaskCompletion[]> {
-  const result = await dynamodb.send(
-    new QueryCommand({
-      TableName: TABLE_NAME,
-      IndexName: 'GSI1',
-      KeyConditionExpression: 'GSI1PK = :pk',
-      ExpressionAttributeValues: {
-        ':pk': `HOUSEHOLD#${householdId}#ACTIVITY`,
-      },
-      ScanIndexForward: false,
-      Limit: Math.min(limit, MAX_QUERY_LIMIT),
-    })
-  );
-  return (result.Items || [])
-    .filter((item) => item.entityType === 'TaskCompletion')
-    .map((item) => ({
-      id: item.id as string,
-      householdId: item.householdId as string,
-      plantId: item.plantId as string,
-      taskId: item.taskId as string,
-      taskType: item.taskType as string,
-      completedBy: item.completedBy as string,
-      completedByName: item.completedByName as string,
-      completedAt: item.completedAt as string,
-      notes: item.notes as string | null,
-    }));
+  const want = Math.min(limit, MAX_QUERY_LIMIT);
+
+  // GSI1 HOUSEHOLD#{id}#ACTIVITY now holds both TaskCompletion AND ActivityEvent
+  // rows. DynamoDB applies `Limit` per page BEFORE our entityType filter, so a
+  // single Limit-bounded page that happens to be mostly ActivityEvents returns
+  // far fewer than `want` completions (M3). Page through newest-first,
+  // accumulating only completions, until we have enough or run out of pages
+  // (bounded by MAX_QUERY_PAGES — same ceiling as queryAllPages).
+  const completions: TaskCompletion[] = [];
+  let exclusiveStartKey: Record<string, unknown> | undefined;
+  let pages = 0;
+  do {
+    const result = await dynamodb.send(
+      new QueryCommand({
+        TableName: TABLE_NAME,
+        IndexName: 'GSI1',
+        KeyConditionExpression: 'GSI1PK = :pk',
+        ExpressionAttributeValues: {
+          ':pk': `HOUSEHOLD#${householdId}#ACTIVITY`,
+        },
+        ScanIndexForward: false,
+        Limit: MAX_QUERY_LIMIT,
+        ExclusiveStartKey: exclusiveStartKey,
+      })
+    );
+    for (const item of result.Items ?? []) {
+      if (item.entityType !== 'TaskCompletion') continue;
+      completions.push({
+        id: item.id as string,
+        householdId: item.householdId as string,
+        plantId: item.plantId as string,
+        taskId: item.taskId as string,
+        taskType: item.taskType as string,
+        completedBy: item.completedBy as string,
+        completedByName: item.completedByName as string,
+        completedAt: item.completedAt as string,
+        notes: item.notes as string | null,
+      });
+      if (completions.length >= want) return completions;
+    }
+    exclusiveStartKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+    pages += 1;
+  } while (exclusiveStartKey && pages < MAX_QUERY_PAGES);
+
+  return completions;
 }
 
 export interface YearInReview {

--- a/backend/tests/integration/route-terraform-parity.test.ts
+++ b/backend/tests/integration/route-terraform-parity.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Contract regression guard: the HTTP routes API Gateway actually wires
+ * (`infrastructure/modules/api/main.tf`, the `local.routes` map driving the
+ * `aws_apigatewayv2_route` for_each) must EXACTLY match the union of every
+ * handler group's `createRouter` route keys.
+ *
+ * Why this exists: `route-parity.test.ts` keeps handlers ↔ local-server honest
+ * and `scripts/check-api-spec.mjs` keeps handlers ↔ OpenAPI honest, but nothing
+ * checked handlers ↔ Terraform. A route added to a handler but forgotten in
+ * main.tf deploys as a 404 (no integration wired); a route left in main.tf
+ * after its handler is removed wires an integration to nothing. Either way no
+ * other gate catches it — this asserts set-equality so CI does (H7).
+ *
+ * Importing the handler modules is safe under vitest (NODE_ENV=test sentinels;
+ * AWS clients are constructed-but-never-called at load) — same rationale as
+ * route-parity.test.ts.
+ *
+ * The streaming chat route (`POST /chat/messages/stream`) is intentionally
+ * NOT in `local.routes` (it's a standalone RESPONSE_STREAM Lambda with its own
+ * `aws_apigatewayv2_route` resource) and is NOT in any `createRouter` (its
+ * handler is `streamHandler`, not a router), so it sits outside both sets and
+ * doesn't break the equality.
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import * as apiH from '../../src/handlers/api/handler.js';
+import * as apiKeysH from '../../src/handlers/apiKeys/handler.js';
+import * as authH from '../../src/handlers/auth/handler.js';
+import * as billingH from '../../src/handlers/billing/handler.js';
+import * as chatH from '../../src/handlers/chat/handler.js';
+import * as climateH from '../../src/handlers/climate/handler.js';
+import * as householdsH from '../../src/handlers/households/handler.js';
+import * as meH from '../../src/handlers/me/handler.js';
+import * as notificationsH from '../../src/handlers/notifications/handler.js';
+import * as plantsH from '../../src/handlers/plants/handler.js';
+import * as speciesH from '../../src/handlers/species/handler.js';
+import * as tasksH from '../../src/handlers/tasks/handler.js';
+
+// EventBridge-invoked handlers (reminders/digests/year-recap scans) have no
+// HTTP route table, so they have nothing to mirror here.
+const GROUPS: Array<{ handler: { routes: string[] } }> = [
+  apiH,
+  apiKeysH,
+  authH,
+  billingH,
+  chatH,
+  climateH,
+  householdsH,
+  meH,
+  notificationsH,
+  plantsH,
+  speciesH,
+  tasksH,
+];
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MAIN_TF = resolve(__dirname, '../../../infrastructure/modules/api/main.tf');
+
+const ROUTE_KEY = /^"((?:GET|POST|PUT|DELETE|PATCH) \/[^"]*)"\s*=/;
+
+/**
+ * Parse the `route_key` strings out of the `local.routes` map in main.tf.
+ * Walks from `routes = {` to its matching close brace, pulling each
+ * `"METHOD /path" = { ... }` map key.
+ */
+function terraformRouteKeys(): Set<string> {
+  const src = readFileSync(MAIN_TF, 'utf8');
+  const lines = src.split('\n');
+
+  const start = lines.findIndex((l) => /^\s*routes\s*=\s*\{/.test(l));
+  if (start === -1) {
+    throw new Error('could not find the `routes = {` block in main.tf');
+  }
+
+  const keys = new Set<string>();
+  let depth = 0;
+  let started = false;
+  for (let i = start; i < lines.length; i++) {
+    const line = lines[i];
+    // Track brace depth so we stop at the map's matching close brace and don't
+    // wander into later locals.
+    for (const ch of line) {
+      if (ch === '{') depth += 1;
+      else if (ch === '}') depth -= 1;
+    }
+    started = true;
+    const m = ROUTE_KEY.exec(line.trim());
+    if (m) keys.add(m[1]);
+    if (started && depth === 0) break;
+  }
+  return keys;
+}
+
+/** Union of every handler group's createRouter keys. */
+function handlerRouteKeys(): Set<string> {
+  const out = new Set<string>();
+  for (const mod of GROUPS) {
+    for (const key of mod.handler.routes) out.add(key);
+  }
+  return out;
+}
+
+describe('handler routes ↔ Terraform route table parity', () => {
+  it('every handler route is wired in main.tf and vice-versa (set equality)', () => {
+    const tf = terraformRouteKeys();
+    const handlers = handlerRouteKeys();
+
+    // Sanity: both sides actually parsed something.
+    expect(tf.size).toBeGreaterThan(0);
+    expect(handlers.size).toBeGreaterThan(0);
+
+    const missingInTf = [...handlers].filter((r) => !tf.has(r)).sort();
+    const missingInHandlers = [...tf].filter((r) => !handlers.has(r)).sort();
+
+    expect(
+      missingInTf,
+      `Handler routes NOT wired in infrastructure/modules/api/main.tf ` +
+        `(they would deploy as 404s): ${JSON.stringify(missingInTf)}`
+    ).toEqual([]);
+    expect(
+      missingInHandlers,
+      `Routes in main.tf with no matching handler createRouter key ` +
+        `(integration wired to nothing): ${JSON.stringify(missingInHandlers)}`
+    ).toEqual([]);
+  });
+});

--- a/backend/tests/unit/handlers/plantHealthCheck.test.ts
+++ b/backend/tests/unit/handlers/plantHealthCheck.test.ts
@@ -2,11 +2,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from 'aws-lambda';
 
 vi.mock('../../../src/services/leafHealth.js');
+vi.mock('../../../src/services/leafHealthBudget.js');
 vi.mock('../../../src/services/plantService.js');
 vi.mock('../../../src/services/activity.js');
 vi.mock('../../../src/services/householdService.js');
 
 import * as leafHealth from '../../../src/services/leafHealth.js';
+import * as leafHealthBudget from '../../../src/services/leafHealthBudget.js';
 import * as plantService from '../../../src/services/plantService.js';
 import * as activity from '../../../src/services/activity.js';
 import * as householdService from '../../../src/services/householdService.js';
@@ -68,6 +70,9 @@ describe('plants health-check handler', () => {
 
     vi.mocked(plantService.getPlant).mockResolvedValue(PLANT);
     vi.mocked(leafHealth.assessLeafHealth).mockResolvedValue(ASSESSMENT);
+    // Spend cap (M1): under the cap by default; increment is a soft no-op.
+    vi.mocked(leafHealthBudget.isOverCap).mockResolvedValue(false);
+    vi.mocked(leafHealthBudget.incrementUsage).mockResolvedValue(1);
     vi.mocked(activity.recordActivity).mockResolvedValue(undefined);
     vi.mocked(householdService.getMemberByUserId).mockResolvedValue({
       name: 'Chelsea',
@@ -91,6 +96,25 @@ describe('plants health-check handler', () => {
         payload: { plantId: 'plant-1', plantName: 'Fernie', overall: 'monitor' },
       })
     );
+    // A real (non-demo) assessment is counted against the monthly cap.
+    expect(leafHealthBudget.incrementUsage).toHaveBeenCalledWith('hh-1');
+  });
+
+  it('429s and never calls Bedrock when the household is over its monthly cap (M1)', async () => {
+    vi.mocked(leafHealthBudget.isOverCap).mockResolvedValue(true);
+    const checkPlantHealth = await subject();
+    const res = (await checkPlantHealth(buildEvent(), ctx, () => {})) as APIGatewayProxyResult;
+    expect(res.statusCode).toBe(429);
+    expect(leafHealth.assessLeafHealth).not.toHaveBeenCalled();
+    expect(leafHealthBudget.incrementUsage).not.toHaveBeenCalled();
+  });
+
+  it('does NOT count the demo fallback against the cap (no Bedrock spend)', async () => {
+    vi.mocked(leafHealth.assessLeafHealth).mockResolvedValue({ ...ASSESSMENT, demo: true });
+    const checkPlantHealth = await subject();
+    const res = (await checkPlantHealth(buildEvent(), ctx, () => {})) as APIGatewayProxyResult;
+    expect(res.statusCode).toBe(200);
+    expect(leafHealthBudget.incrementUsage).not.toHaveBeenCalled();
   });
 
   it("404s when the plant is not in the caller's household (ownership)", async () => {

--- a/backend/tests/unit/handlers/tasks.test.ts
+++ b/backend/tests/unit/handlers/tasks.test.ts
@@ -199,7 +199,9 @@ describe('tasks handler', () => {
     });
     const res = (await completeTask(event, fakeContext, () => {})) as APIGatewayProxyResult;
     expect(res.statusCode).toBe(200);
-    expect(taskService.completeTask).toHaveBeenCalledWith('hh-1', 't1', 'user-1', 'a', 'done');
+    // completedByName resolves to the real member name from the household
+    // member row ('Tester'), NOT the email local-part 'a' (M5).
+    expect(taskService.completeTask).toHaveBeenCalledWith('hh-1', 't1', 'user-1', 'Tester', 'done');
   });
 
   it('completeTask returns 404 when task missing', async () => {

--- a/backend/tests/unit/middleware/auth.test.ts
+++ b/backend/tests/unit/middleware/auth.test.ts
@@ -5,6 +5,7 @@ import {
   authMiddleware,
   requireAdmin,
   requireHousehold,
+  rejectApiKeyPrincipal,
   __resetMembershipCacheForTests,
 } from '../../../src/middleware/auth.js';
 import * as householdService from '../../../src/services/householdService.js';
@@ -299,5 +300,46 @@ describe('requireAdmin', () => {
     await expect(invoke(buildEvent({ sub: 'u', email: 'e' }))).rejects.toMatchObject({
       statusCode: 403,
     });
+  });
+});
+
+describe('rejectApiKeyPrincipal (M2)', () => {
+  // Middleware that stamps event.user, standing in for authMiddleware /
+  // apiKeyMiddleware so we can exercise the guard in isolation.
+  const stampUser = (user: Record<string, unknown>): middy.MiddlewareObj => ({
+    before: (request) => {
+      (request.event as unknown as { user: unknown }).user = user;
+    },
+  });
+
+  it('403s an API-key principal even though it carries householdRole member', async () => {
+    const { invoke } = makeHandler([
+      stampUser({
+        userId: 'apikey:k1',
+        email: '',
+        householdId: 'hh',
+        householdRole: 'member',
+        isApiKey: true,
+      }),
+      rejectApiKeyPrincipal(),
+    ]);
+    await expect(invoke(buildEvent({ sub: 'k', email: 'e' }))).rejects.toMatchObject({
+      statusCode: 403,
+    });
+  });
+
+  it('lets a human (non-key) principal through', async () => {
+    const { invoke, inner } = makeHandler([
+      stampUser({
+        userId: 'user-1',
+        email: 'a@b.com',
+        householdId: 'hh',
+        householdRole: 'admin',
+      }),
+      rejectApiKeyPrincipal(),
+    ]);
+    const res = await invoke(buildEvent({ sub: 'u', email: 'e' }));
+    expect(res.statusCode).toBe(200);
+    expect(inner).toHaveBeenCalledOnce();
   });
 });

--- a/backend/tests/unit/services/householdService.test.ts
+++ b/backend/tests/unit/services/householdService.test.ts
@@ -63,6 +63,14 @@ describe('householdService', () => {
   it('setMemberRole returns null when member missing', async () => {
     const { dynamodb } = await import('../../../src/utils/dynamodb.js');
     const { setMemberRole } = await import('../../../src/services/householdService.js');
+    // Demotion to 'member' runs the last-admin guard first — mock a members
+    // list where 'u' isn't the sole admin so the guard passes.
+    vi.mocked(dynamodb.send).mockResolvedValueOnce({
+      Items: [
+        { householdId: 'hh', userId: 'u', role: 'member' },
+        { householdId: 'hh', userId: 'admin', role: 'admin' },
+      ],
+    });
     vi.mocked(dynamodb.send).mockResolvedValueOnce({ Attributes: undefined });
     expect(await setMemberRole('hh', 'u', 'member')).toBeNull();
   });
@@ -271,12 +279,23 @@ describe('householdService', () => {
     expect(vi.mocked(dynamodb.send).mock.calls).toHaveLength(2);
   });
 
+  // Members listing that passes the last-admin guard (the removed user 'u' is
+  // a plain member, and another admin remains). Prepended to removeMember /
+  // setMemberRole-demotion flows because the L1 guard reads members first.
+  const GUARD_OK_MEMBERS = {
+    Items: [
+      { householdId: 'hh', userId: 'u', role: 'member' },
+      { householdId: 'hh', userId: 'admin', role: 'admin' },
+    ],
+  };
+
   it('removeMember transacts the member delete with a floored memberCount decrement', async () => {
     const { dynamodb } = await import('../../../src/utils/dynamodb.js');
     const { removeMember } = await import('../../../src/services/householdService.js');
+    vi.mocked(dynamodb.send).mockResolvedValueOnce(GUARD_OK_MEMBERS); // last-admin guard read
     vi.mocked(dynamodb.send).mockResolvedValueOnce({});
     await removeMember('hh', 'u');
-    const cmd = vi.mocked(dynamodb.send).mock.calls[0][0] as unknown as {
+    const cmd = vi.mocked(dynamodb.send).mock.calls[1][0] as unknown as {
       kind: string;
       input: {
         TransactItems: [
@@ -304,6 +323,7 @@ describe('householdService', () => {
   it('removeMember stays idempotent when the member row is already gone (no counter touch)', async () => {
     const { dynamodb } = await import('../../../src/utils/dynamodb.js');
     const { removeMember } = await import('../../../src/services/householdService.js');
+    vi.mocked(dynamodb.send).mockResolvedValueOnce(GUARD_OK_MEMBERS); // last-admin guard read
     vi.mocked(dynamodb.send).mockRejectedValueOnce(
       Object.assign(new Error('cancelled'), {
         name: 'TransactionCanceledException',
@@ -311,8 +331,8 @@ describe('householdService', () => {
       })
     );
     await expect(removeMember('hh', 'u')).resolves.toBeUndefined();
-    // No fallback delete — the row was already gone.
-    expect(vi.mocked(dynamodb.send).mock.calls).toHaveLength(1);
+    // Guard read + TransactWrite only — no fallback delete (row already gone).
+    expect(vi.mocked(dynamodb.send).mock.calls).toHaveLength(2);
   });
 
   it('removeMember falls back to a plain delete when only the counter floor blocked the transaction', async () => {
@@ -320,6 +340,7 @@ describe('householdService', () => {
     const { removeMember } = await import('../../../src/services/householdService.js');
     // Counter already 0 (drift on a legacy row): the member row still exists
     // and must be removed even though the decrement can't go below 0.
+    vi.mocked(dynamodb.send).mockResolvedValueOnce(GUARD_OK_MEMBERS); // last-admin guard read
     vi.mocked(dynamodb.send).mockRejectedValueOnce(
       Object.assign(new Error('cancelled'), {
         name: 'TransactionCanceledException',
@@ -329,8 +350,8 @@ describe('householdService', () => {
     vi.mocked(dynamodb.send).mockResolvedValueOnce({});
     await removeMember('hh', 'u');
     const calls = vi.mocked(dynamodb.send).mock.calls;
-    expect(calls).toHaveLength(2);
-    const fallback = calls[1][0] as unknown as { kind: string; input: { Key: { SK: string } } };
+    expect(calls).toHaveLength(3);
+    const fallback = calls[2][0] as unknown as { kind: string; input: { Key: { SK: string } } };
     expect(fallback.kind).toBe('Delete');
     expect(fallback.input.Key.SK).toBe('MEMBER#u');
   });
@@ -340,5 +361,69 @@ describe('householdService', () => {
     const { getMemberByUserId } = await import('../../../src/services/householdService.js');
     vi.mocked(dynamodb.send).mockResolvedValueOnce({ Item: undefined });
     expect(await getMemberByUserId('hh', 'u')).toBeNull();
+  });
+
+  // --- Service-layer last-admin guard (L1) ---
+
+  it('removeMember throws LastAdminError when removing the lone admin of a multi-member household', async () => {
+    const { dynamodb } = await import('../../../src/utils/dynamodb.js');
+    const { removeMember } = await import('../../../src/services/householdService.js');
+    vi.mocked(dynamodb.send).mockResolvedValueOnce({
+      Items: [
+        { householdId: 'hh', userId: 'admin', role: 'admin' },
+        { householdId: 'hh', userId: 'other', role: 'member' },
+      ],
+    });
+    await expect(removeMember('hh', 'admin')).rejects.toMatchObject({ name: 'LastAdminError' });
+    // Guard fired BEFORE any destructive write — only the members read happened.
+    expect(vi.mocked(dynamodb.send).mock.calls).toHaveLength(1);
+  });
+
+  it('removeMember allows removing the sole member (single-member household is exempt)', async () => {
+    const { dynamodb } = await import('../../../src/utils/dynamodb.js');
+    const { removeMember } = await import('../../../src/services/householdService.js');
+    vi.mocked(dynamodb.send).mockResolvedValueOnce({
+      Items: [{ householdId: 'hh', userId: 'admin', role: 'admin' }],
+    });
+    vi.mocked(dynamodb.send).mockResolvedValueOnce({}); // TransactWrite
+    await expect(removeMember('hh', 'admin')).resolves.toBeUndefined();
+  });
+
+  it('setMemberRole throws LastAdminError when demoting the lone admin', async () => {
+    const { dynamodb } = await import('../../../src/utils/dynamodb.js');
+    const { setMemberRole } = await import('../../../src/services/householdService.js');
+    vi.mocked(dynamodb.send).mockResolvedValueOnce({
+      Items: [
+        { householdId: 'hh', userId: 'admin', role: 'admin' },
+        { householdId: 'hh', userId: 'other', role: 'member' },
+      ],
+    });
+    await expect(setMemberRole('hh', 'admin', 'member')).rejects.toMatchObject({
+      name: 'LastAdminError',
+    });
+    expect(vi.mocked(dynamodb.send).mock.calls).toHaveLength(1);
+  });
+
+  it('setMemberRole allows demotion when another admin remains', async () => {
+    const { dynamodb } = await import('../../../src/utils/dynamodb.js');
+    const { setMemberRole } = await import('../../../src/services/householdService.js');
+    vi.mocked(dynamodb.send).mockResolvedValueOnce({
+      Items: [
+        { householdId: 'hh', userId: 'admin', role: 'admin' },
+        { householdId: 'hh', userId: 'admin2', role: 'admin' },
+      ],
+    });
+    vi.mocked(dynamodb.send).mockResolvedValueOnce({
+      Attributes: {
+        householdId: 'hh',
+        userId: 'admin',
+        name: 'A',
+        email: 'a@b.com',
+        role: 'member',
+        joinedAt: '',
+      },
+    });
+    const result = await setMemberRole('hh', 'admin', 'member');
+    expect(result?.role).toBe('member');
   });
 });

--- a/backend/tests/unit/services/leafHealthBudget.test.ts
+++ b/backend/tests/unit/services/leafHealthBudget.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+  GetCommand: vi.fn((i) => ({ input: i, kind: 'Get' })),
+  UpdateCommand: vi.fn((i) => ({ input: i, kind: 'Update' })),
+}));
+vi.mock('../../../src/utils/dynamodb.js', () => ({
+  dynamodb: { send: vi.fn() },
+  TABLE_NAME: 'test',
+}));
+
+import { dynamodb } from '../../../src/utils/dynamodb.js';
+
+describe('leafHealthBudget service (M1 — monthly Bedrock spend cap)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.LEAF_HEALTH_MONTHLY_CAP;
+  });
+  afterEach(() => {
+    delete process.env.LEAF_HEALTH_MONTHLY_CAP;
+  });
+
+  it('defaults the cap to 200 and reads LEAF_HEALTH_MONTHLY_CAP when set', async () => {
+    const { monthlyCap } = await import('../../../src/services/leafHealthBudget.js');
+    expect(monthlyCap()).toBe(200);
+    process.env.LEAF_HEALTH_MONTHLY_CAP = '50';
+    expect(monthlyCap()).toBe(50);
+    // Unparseable falls back to the default rather than NaN-ing the gate.
+    process.env.LEAF_HEALTH_MONTHLY_CAP = 'nope';
+    expect(monthlyCap()).toBe(200);
+  });
+
+  it('isOverCap returns false (unlimited) when the cap is <= 0', async () => {
+    const { isOverCap } = await import('../../../src/services/leafHealthBudget.js');
+    process.env.LEAF_HEALTH_MONTHLY_CAP = '0';
+    // No usage read needed when unlimited.
+    expect(await isOverCap('hh')).toBe(false);
+    expect(vi.mocked(dynamodb.send)).not.toHaveBeenCalled();
+  });
+
+  it('isOverCap is true once usage reaches the cap, false below', async () => {
+    const { isOverCap } = await import('../../../src/services/leafHealthBudget.js');
+    process.env.LEAF_HEALTH_MONTHLY_CAP = '3';
+
+    vi.mocked(dynamodb.send).mockResolvedValueOnce({ Item: { used: 2 } } as never);
+    expect(await isOverCap('hh')).toBe(false);
+
+    vi.mocked(dynamodb.send).mockResolvedValueOnce({ Item: { used: 3 } } as never);
+    expect(await isOverCap('hh')).toBe(true);
+  });
+
+  it('getUsage fails OPEN (0) on a DDB error — the cap never breaks the feature', async () => {
+    const { getUsage } = await import('../../../src/services/leafHealthBudget.js');
+    vi.mocked(dynamodb.send).mockRejectedValueOnce(new Error('ddb down'));
+    expect(await getUsage('hh')).toBe(0);
+  });
+
+  it('incrementUsage atomically ADDs one against the household month partition', async () => {
+    const { incrementUsage } = await import('../../../src/services/leafHealthBudget.js');
+    vi.mocked(dynamodb.send).mockResolvedValueOnce({ Attributes: { used: 4 } } as never);
+    const used = await incrementUsage('hh', new Date('2026-06-15T00:00:00Z'));
+    expect(used).toBe(4);
+    const cmd = vi.mocked(dynamodb.send).mock.calls[0][0] as unknown as {
+      input: { Key: { PK: string; SK: string }; UpdateExpression: string };
+    };
+    expect(cmd.input.Key.PK).toBe('LEAFHEALTH#BUDGET');
+    expect(cmd.input.Key.SK).toBe('MONTH#2026-06#HH#hh');
+    expect(cmd.input.UpdateExpression).toContain('ADD #used :one');
+  });
+
+  it('incrementUsage returns null on a DDB error (soft failure)', async () => {
+    const { incrementUsage } = await import('../../../src/services/leafHealthBudget.js');
+    vi.mocked(dynamodb.send).mockRejectedValueOnce(new Error('ddb down'));
+    expect(await incrementUsage('hh')).toBeNull();
+  });
+});

--- a/backend/tests/unit/services/plantIdentification.test.ts
+++ b/backend/tests/unit/services/plantIdentification.test.ts
@@ -53,15 +53,29 @@ describe('plantIdentification', () => {
     });
   });
 
-  it('throws on non-2xx upstream', async () => {
+  it('throws a generic error on non-2xx upstream (does NOT reflect the upstream body — L2)', async () => {
     process.env = { ...ORIGINAL, PLANT_ID_API_KEY: 'k' };
     fetchMock.mockResolvedValueOnce({
       ok: false,
       status: 503,
-      text: async () => 'overloaded',
+      text: async () => 'overloaded: secret upstream detail',
     });
     const { identifyPlant } = await import('../../../src/services/plantIdentification.js');
-    await expect(identifyPlant('AAAA')).rejects.toThrow(/503/);
+    // The thrown message is generic — neither the status code nor the upstream
+    // body leaks to the client (the identify handler exposes 5xx messages).
+    await expect(identifyPlant('AAAA')).rejects.toThrow(
+      /plant identification service is temporarily unavailable/
+    );
+    await expect(
+      (async () => {
+        fetchMock.mockResolvedValueOnce({
+          ok: false,
+          status: 503,
+          text: async () => 'overloaded: secret upstream detail',
+        });
+        return identifyPlant('AAAA');
+      })()
+    ).rejects.not.toThrow(/secret upstream detail/);
   });
 
   it('passes an abort signal to fetch and aborts after the 5s timeout', async () => {

--- a/backend/tests/unit/services/reminders.test.ts
+++ b/backend/tests/unit/services/reminders.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('@aws-sdk/lib-dynamodb', () => ({
   PutCommand: vi.fn((input) => ({ input, kind: 'Put' })),
+  GetCommand: vi.fn((input) => ({ input, kind: 'Get' })),
 }));
 vi.mock('../../../src/utils/dynamodb.js', () => ({
   dynamodb: { send: vi.fn() },
@@ -28,7 +29,9 @@ vi.mock('../../../src/services/pestAlerts.js', () => ({
   markAlerted: vi.fn(),
 }));
 vi.mock('../../../src/services/notifier.js', () => ({
-  sendToUser: vi.fn(),
+  // Default: a real delivery. Tests that exercise the DND-suppressed-only
+  // path (H1) override this with mockResolvedValueOnce.
+  sendToUser: vi.fn(async () => ({ delivered: true, dndSuppressedOnly: false })),
 }));
 
 const NOW = new Date('2026-06-01T12:00:00.000Z');
@@ -71,8 +74,20 @@ async function mockConditionalMarkerStore() {
   const { dynamodb } = await import('../../../src/utils/dynamodb.js');
   const markers = new Set<string>();
   vi.mocked(dynamodb.send).mockImplementation(async (cmd: unknown) => {
-    const { input } = cmd as { input: { Item: { PK: string; SK: string } } };
-    const key = `${input.Item.PK}|${input.Item.SK}`;
+    const { input, kind } = cmd as {
+      kind?: 'Put' | 'Get';
+      input: { Item?: { PK: string; SK: string }; Key?: { PK: string; SK: string } };
+    };
+    // GetCommand → marker pre-check (alreadyRemindedToday). Return the marker
+    // row when present so the read-side dedupe sees it.
+    if (kind === 'Get' && input.Key) {
+      const key = `${input.Key.PK}|${input.Key.SK}`;
+      return (markers.has(key) ? { Item: { PK: input.Key.PK, SK: input.Key.SK } } : {}) as never;
+    }
+    // PutCommand → conditional claim. Second claim on the same key throws
+    // ConditionalCheckFailed, exactly the dedupe behavior across hourly runs.
+    const item = input.Item!;
+    const key = `${item.PK}|${item.SK}`;
     if (markers.has(key)) {
       const err = new Error('The conditional request failed');
       err.name = 'ConditionalCheckFailedException';
@@ -164,6 +179,37 @@ describe('reminders service', () => {
     // Next day: fresh marker key → reminder goes out again.
     const nextDay = new Date(NOW.getTime() + 24 * 60 * 60 * 1000);
     expect(await remindHousehold('hh', nextDay)).toBe(1);
+    expect(notifier.sendToUser).toHaveBeenCalledTimes(2);
+  });
+
+  it('does NOT claim the daily slot when delivery was DND-suppressed-only, so the next run retries (H1)', async () => {
+    const household = await import('../../../src/services/householdService.js');
+    const tasks = await import('../../../src/services/taskService.js');
+    const notifier = await import('../../../src/services/notifier.js');
+    const { remindHousehold } = await import('../../../src/services/reminders.js');
+    const markers = await mockConditionalMarkerStore();
+    await mockActivePlants(['p1']);
+    await mockNoPestOptIns();
+
+    vi.mocked(household.getHouseholdMembers).mockResolvedValue([memberA] as never);
+    vi.mocked(tasks.getTasksDueBy).mockResolvedValue([
+      { nextDue: past, plantId: 'p1', assignedTo: 'u1' },
+    ] as never);
+
+    // Hour 1: the user is in their DND window and relies on email/SMS (no
+    // push), so nothing actually delivered. The slot must stay UNclaimed.
+    vi.mocked(notifier.sendToUser).mockResolvedValueOnce({
+      delivered: false,
+      dndSuppressedOnly: true,
+    });
+    expect(await remindHousehold('hh', NOW)).toBe(0);
+    expect(markers.has('USER#u1|REMINDED#2026-06-01')).toBe(false);
+
+    // Hour 2: DND has lifted, email delivers. Because the slot was never
+    // claimed, the user still gets today's reminder (the H1 bug regressed).
+    const hourLater = new Date(NOW.getTime() + 60 * 60 * 1000);
+    expect(await remindHousehold('hh', hourLater)).toBe(1);
+    expect(markers.has('USER#u1|REMINDED#2026-06-01')).toBe(true);
     expect(notifier.sendToUser).toHaveBeenCalledTimes(2);
   });
 

--- a/backend/tests/unit/services/taskService.test.ts
+++ b/backend/tests/unit/services/taskService.test.ts
@@ -115,6 +115,34 @@ describe('taskService', () => {
     expect(sentCommand.input.Item.GSI2PK).toBe('HOUSEHOLD#hh-1#ASSIGNEE#user-2');
   });
 
+  it('createTask rejects a non-member assignee with AssigneeNotMemberError and writes nothing (M4)', async () => {
+    const { dynamodb } = await import('../../../src/utils/dynamodb.js');
+    const householdService = await import('../../../src/services/householdService.js');
+    const { createTask } = await import('../../../src/services/taskService.js');
+    vi.mocked(householdService.getMemberByUserId).mockResolvedValueOnce(null);
+    await expect(
+      createTask(
+        { plantId: 'p1', type: 'water', frequency: 7, assignedTo: 'ghost' },
+        'hh-1',
+        'user-1',
+        'Pothos'
+      )
+    ).rejects.toMatchObject({ name: 'AssigneeNotMemberError' });
+    // No Put attempted — the dangling assignee is refused before any write.
+    expect(vi.mocked(dynamodb.send)).not.toHaveBeenCalled();
+  });
+
+  it('updateTask rejects a reassignment to a non-member with AssigneeNotMemberError (M4)', async () => {
+    const { dynamodb } = await import('../../../src/utils/dynamodb.js');
+    const householdService = await import('../../../src/services/householdService.js');
+    const { updateTask } = await import('../../../src/services/taskService.js');
+    vi.mocked(householdService.getMemberByUserId).mockResolvedValueOnce(null);
+    await expect(updateTask('hh-1', 't1', { assignedTo: 'ghost' })).rejects.toMatchObject({
+      name: 'AssigneeNotMemberError',
+    });
+    expect(vi.mocked(dynamodb.send)).not.toHaveBeenCalled();
+  });
+
   it('getTask returns null when missing', async () => {
     const { dynamodb } = await import('../../../src/utils/dynamodb.js');
     const { getTask } = await import('../../../src/services/taskService.js');

--- a/docs/multi-household.md
+++ b/docs/multi-household.md
@@ -18,9 +18,13 @@ The frontend's `HouseholdSwitcher` (`components/HouseholdSwitcher.tsx`) lists ev
 
 ## Authorization across households
 
-`authMiddleware` projects Cognito claims onto `event.user`, then applies the `X-Household-Id` override. Because the middleware can't do DDB calls (it runs on every request), it conservatively downgrades `householdRole` to `member` when the override is set. Admin-only routes call `requireAdmin` which then 403s on a switched household; clients are expected to refresh their role via `/me/households` if they need accurate role state on a non-default household.
+`authMiddleware` projects the Cognito JWT's identity (`sub`, `email`) onto `event.user`, then resolves the household context — whichever comes from the `X-Household-Id` override header or, absent that, the `custom:household_id` claim. **The membership row is authoritative for BOTH membership and role.** For the resolved household, the middleware reads the caller's `MEMBER#{userId}` row and sets `user.householdRole` to the role stored there — `admin` or `member`. It does **not** downgrade to `member`, and it never trusts the `custom:household_role` claim (that claim is defense-in-depth only and lags membership changes by up to the token lifetime).
 
-The local Express server is more accurate because it has direct access to the in-memory memberships array — it sets the right role straight from the membership entry.
+So an admin keeps admin on a switched household, and a member who was removed loses access — both correctly — within the cache TTL (below). `requireAdmin` therefore reflects the caller's real role on the addressed household with no client-side `/me/households` refresh needed.
+
+The lookup goes through a small per-warm-container cache (`utils/membershipCache.ts`, 60s TTL). Mutations that change membership (`setMemberRole`, `removeMember`) invalidate the cache synchronously in the container that processed them; other warm containers honor the change within ≤60s. A non-member who sets `X-Household-Id` to a household they don't belong to gets a 403 ("Not a member of the requested household").
+
+The local Express server mirrors this by reading the role straight from its in-memory memberships array.
 
 ### Cross-household reads
 


### PR DESCRIPTION
Backend remediations from the 2026-06-17 codebase review (`docs/reviews/codebase-review-2026-06-17.md`). Backend-only; no tfvars touched.

## Findings addressed

- **H1 (live bug) — DND users silently lose their daily reminder.** The per-user daily dedupe slot was claimed *before* delivery, so a DND user who relies on email/SMS (no push) got the marker written but no reminder, and every later hourly run skipped them. `notifier.sendToUser` now returns `{ delivered, dndSuppressedOnly }`; `reminders.ts` claims the slot only on a real delivery and, when the user was reachable only via DND-suppressed channels, leaves the slot unclaimed so the next run retries once DND lifts. Pre-check via a point read avoids rebuilding/re-sending on later runs.
- **M3 — activity feed under-returns.** `taskService.getHouseholdActivity` paginated: it pages the GSI1 `ACTIVITY` partition (which now also holds `ActivityEvent` rows) and accumulates `TaskCompletion` rows until the limit is met, instead of filtering a single Limit-bounded page.
- **M4 — `assignedTo` not validated.** `createTask`/`updateTask` (and therefore `/plants/import`) now throw `AssigneeNotMemberError` when `getMemberByUserId` returns null; handlers map it to **400**. No dangling assignee is written.
- **M5 — completer attributed to email prefix.** Task completion resolves the real member name via `getMemberByUserId` (`resolveCompleterName`, mirroring the plants handler), falling back to the email local-part only on lookup miss. Drives the activity feed / year-in-review / recap emails.
- **M1 (backend half) — Bedrock spend cap.** New `services/leafHealthBudget.ts` adds a per-household monthly cap for the leaf-health check, mirroring the chat token-budget gate. Configurable via `LEAF_HEALTH_MONTHLY_CAP` (default 200; `<= 0` = unlimited). Over-cap → **429**; only real (non-demo) Bedrock invocations are metered.
- **M2 + dead `isApiKey` flag.** New `rejectApiKeyPrincipal` middleware wires the previously-unused `isApiKey` into a structural **403** on the internal cron routes `run-reminders` / `run-digests` / `run-year-recap`.
- **L1 — service-layer last-admin guard.** `householdService.setMemberRole`/`removeMember` now throw `LastAdminError` if the change would leave a multi-member household with no admin (single-member households exempt). Handlers map to 400. Tests added.
- **L2 — upstream error reflection.** `plantIdentification.ts` no longer reflects the Plant.id error body to the client; it logs the status+body server-side and throws a generic message.
- **M9 (doc).** Rewrote the "Authorization across households" section of `docs/multi-household.md` to the membership-row-authoritative model (middleware reads the authoritative role from the membership row via a cached DDB read; it does **not** downgrade to member).
- **H7 (test).** `tests/integration/route-terraform-parity.test.ts` parses `route_key` entries from `infrastructure/modules/api/main.tf` and asserts set-equality with the union of handler `createRouter` route keys, so a route missing from Terraform fails CI.

## Verification

- `npm test --prefix backend`: **861 passed** (was 843; added H1 DND, M4 ×2, L1 ×4, M1 ×6, M2 ×2, H7, plus updated M5/L2 assertions).
- `npm run typecheck --prefix backend`: clean.
- `npm run build --prefix backend`: clean.
- `npm run lint --prefix backend`: clean (eslint max-warnings 0); prettier clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)