### PR TITLE
feat(plants): heads-up when adding a plant that's toxic to pets

### DIFF
--- a/frontend/src/features/plants/AddPlantPage.tsx
+++ b/frontend/src/features/plants/AddPlantPage.tsx
@@ -18,6 +18,7 @@ import { Card } from '@/components/Card';
 import { Alert } from '@/components/Alert';
 import { SpeciesCombobox } from '@/components/SpeciesCombobox';
 import { SuggestedCareCard } from './SuggestedCareCard';
+import { PetToxicityNote } from './PetToxicityNote';
 import { generatePlantName } from '@/utils/plantNameGenerator';
 import { downscaleImage } from '@/utils/image';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
@@ -391,6 +392,8 @@ export function AddPlantPage() {
             error={errors.species?.message}
             helperText="Type to search common names; pick a suggestion to autofill the scientific name."
           />
+
+          <PetToxicityNote perenualSpeciesId={perenualSpeciesId} />
 
           <SuggestedCareCard perenualSpeciesId={perenualSpeciesId} />
 

--- a/frontend/src/features/plants/PetToxicityNote.tsx
+++ b/frontend/src/features/plants/PetToxicityNote.tsx
@@ -1,0 +1,36 @@
+import { useQuery } from '@tanstack/react-query';
+import { speciesService } from '@/services/speciesService';
+import { Alert } from '@/components/Alert';
+
+interface PetToxicityNoteProps {
+  perenualSpeciesId: number | null;
+}
+
+/**
+ * Inline heads-up shown on the AddPlant form once the user picks a Perenual-
+ * backed species that's flagged toxic to pets. Sourced from the same species
+ * detail the form already keys on (`perenualSpeciesId`) — no extra backend
+ * surface, just the existing `/species/:id` lookup. If the detail fails or
+ * the species isn't flagged toxic, we render nothing.
+ *
+ * This is informational only: it never blocks saving. Plenty of people keep
+ * toxic plants on purpose and just place them out of reach — the note is a
+ * gentle heads-up, not a gate.
+ */
+export function PetToxicityNote({ perenualSpeciesId }: PetToxicityNoteProps) {
+  const { data } = useQuery({
+    queryKey: ['species', 'detail', perenualSpeciesId],
+    queryFn: () => speciesService.detail(perenualSpeciesId!),
+    enabled: !!perenualSpeciesId,
+    staleTime: 60 * 60 * 1000,
+  });
+
+  if (!data?.poisonousToPets) return null;
+
+  return (
+    <Alert variant="warning" title="Toxic to pets">
+      Toxic to cats and dogs if chewed — keep it out of reach. You can still add it; this is just a
+      heads-up.
+    </Alert>
+  );
+}

--- a/frontend/tests/unit/features/PetToxicityNote.test.tsx
+++ b/frontend/tests/unit/features/PetToxicityNote.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { PetToxicityNote } from '@/features/plants/PetToxicityNote';
+import { speciesService, type PerenualSpeciesDetail } from '@/services/speciesService';
+
+vi.mock('@/services/speciesService', () => ({
+  speciesService: {
+    detail: vi.fn(),
+  },
+}));
+
+const detail = vi.mocked(speciesService.detail);
+
+function makeDetail(overrides: Partial<PerenualSpeciesDetail>): PerenualSpeciesDetail {
+  return {
+    id: 1,
+    commonName: 'Test Plant',
+    scientificName: 'Testus plantus',
+    thumbnailUrl: null,
+    family: null,
+    cycle: null,
+    watering: null,
+    sunlight: [],
+    hardinessZone: null,
+    indoor: true,
+    edible: false,
+    poisonousToPets: false,
+    defaultImageUrl: null,
+    ...overrides,
+  };
+}
+
+function renderNote(perenualSpeciesId: number | null) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <PetToxicityNote perenualSpeciesId={perenualSpeciesId} />
+    </QueryClientProvider>
+  );
+}
+
+describe('PetToxicityNote', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the heads-up when the selected species is toxic to pets', async () => {
+    detail.mockResolvedValue(makeDetail({ id: 42, poisonousToPets: true }));
+    renderNote(42);
+
+    expect(await screen.findByText(/keep it out of reach/i)).toBeInTheDocument();
+    expect(screen.getByText('Toxic to pets')).toBeInTheDocument();
+  });
+
+  it('renders nothing when the selected species is not toxic to pets', async () => {
+    detail.mockResolvedValue(makeDetail({ id: 7, poisonousToPets: false }));
+    renderNote(7);
+
+    // Wait for the detail fetch to settle before asserting absence.
+    await waitFor(() => expect(detail).toHaveBeenCalledWith(7));
+    expect(screen.queryByText(/keep it out of reach/i)).not.toBeInTheDocument();
+  });
+
+  it('does not fetch or render when no species is picked', () => {
+    renderNote(null);
+
+    expect(detail).not.toHaveBeenCalled();
+    expect(screen.queryByText(/keep it out of reach/i)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What

When someone selects a species in the add-plant flow that's flagged toxic to pets, the form now shows a clear but **non-blocking** inline note near the species field:

> **Toxic to pets** — Toxic to cats and dogs if chewed — keep it out of reach. You can still add it; this is just a heads-up.

## Why

People keep toxic plants on purpose and just place them out of reach. This is an informational caution, not a barrier — saving is never gated. The heads-up sits right under the species picker so it's visible at the moment of choice.

## How it's sourced

The toxicity flag comes from the species detail the form already keys on (`perenualSpeciesId`), via the existing `/species/:id` lookup — `PerenualSpeciesDetail.poisonousToPets`. No new backend surface and no extra calls beyond the detail the flow already had access to. If the species isn't flagged or the lookup fails, the note simply doesn't render.

## Changes

- `frontend/src/features/plants/PetToxicityNote.tsx` — new component; reuses the existing `Alert` (warning variant) and warm, plain voice.
- `frontend/src/features/plants/AddPlantPage.tsx` — render the note between the species picker and the suggested-care card.
- `frontend/tests/unit/features/PetToxicityNote.test.tsx` — covers: warning shows for a toxic species, renders nothing for a safe species, and no fetch/render when no species is picked.

## Verification

- `npm test` — 285 passed (incl. 3 new)
- `npm run build` — clean
- `npm run size` — all budgets green
- lint + prettier — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)