### PR TITLE
feat(copy): warmer reminders and a welcome for solo plant-keepers

### DIFF
--- a/backend/src/services/digest.ts
+++ b/backend/src/services/digest.ts
@@ -92,27 +92,27 @@ export async function computePlantsAtRisk(
 }
 
 function overduePhrase(days: number): string {
-  if (days <= 0) return 'overdue today';
-  return days === 1 ? '1 day overdue' : `${days} days overdue`;
+  if (days <= 0) return 'ready for a little care today';
+  return days === 1 ? 'waiting a day for some care' : `waiting ${days} days for some care`;
 }
 
 /** Plain-text weekly digest email body + subject. */
 export function composeDigestEmail(atRisk: PlantAtRisk[]): { subject: string; text: string } {
   const subject =
     atRisk.length === 1
-      ? 'Weekly digest: 1 plant needs attention'
-      : `Weekly digest: ${atRisk.length} plants need attention`;
+      ? 'Weekly digest: 1 plant could use some care'
+      : `Weekly digest: ${atRisk.length} plants could use some care`;
   const lines = atRisk.map(
     (p, i) => `${i + 1}. ${p.plantName} — ${p.taskType} ${overduePhrase(p.daysOverdue)}`
   );
   const text = [
     'Your weekly Family Greenhouse check-in.',
     '',
-    'These plants are most at risk (most overdue first):',
+    'A few plants could use some catch-up care (the ones waiting longest first):',
     '',
     ...lines,
     '',
-    'A few minutes of catch-up care goes a long way. Your plants thank you!',
+    'A few minutes of care goes a long way. Your plants thank you!',
   ].join('\n');
   return { subject, text };
 }

--- a/backend/src/services/reminders.ts
+++ b/backend/src/services/reminders.ts
@@ -169,8 +169,8 @@ export async function remindHousehold(
 
       const overdue = tasksForMember.filter((t) => t.nextDue < nowIso).length;
       let body = overdue
-        ? `${overdue} overdue, ${tasksForMember.length - overdue} due soon`
-        : `${tasksForMember.length} task${tasksForMember.length === 1 ? '' : 's'} due in the next 24h`;
+        ? `${overdue} ready for some catch-up care, ${tasksForMember.length - overdue} coming up soon`
+        : `${tasksForMember.length} task${tasksForMember.length === 1 ? '' : 's'} coming up in the next 24h`;
 
       // Tell the cover whose tasks they're picking up.
       const coveringNames = [

--- a/backend/tests/unit/services/digest.test.ts
+++ b/backend/tests/unit/services/digest.test.ts
@@ -156,10 +156,10 @@ describe('digest service', () => {
         { plantId: 'p1', plantName: 'Monstera', taskType: 'water', daysOverdue: 1 },
         { plantId: 'p3', plantName: 'Cactus', taskType: 'repot', daysOverdue: 0 },
       ]);
-      expect(subject).toBe('Weekly digest: 3 plants need attention');
-      expect(text).toContain('1. Fern — mist 10 days overdue');
-      expect(text).toContain('2. Monstera — water 1 day overdue');
-      expect(text).toContain('3. Cactus — repot overdue today');
+      expect(subject).toBe('Weekly digest: 3 plants could use some care');
+      expect(text).toContain('1. Fern — mist waiting 10 days for some care');
+      expect(text).toContain('2. Monstera — water waiting a day for some care');
+      expect(text).toContain('3. Cactus — repot ready for a little care today');
     });
   });
 

--- a/backend/tests/unit/services/reminders.test.ts
+++ b/backend/tests/unit/services/reminders.test.ts
@@ -125,7 +125,9 @@ describe('reminders service', () => {
     expect(notifier.sendToUser).toHaveBeenCalledOnce();
     const [recipient, payload] = vi.mocked(notifier.sendToUser).mock.calls[0];
     expect(recipient).toEqual({ userId: 'u1', email: 'a@x.com' });
-    expect((payload as { body: string }).body).toBe('1 overdue, 1 due soon');
+    expect((payload as { body: string }).body).toBe(
+      '1 ready for some catch-up care, 1 coming up soon'
+    );
   });
 
   it('includes unassigned due tasks in every member roll-up', async () => {
@@ -149,7 +151,7 @@ describe('reminders service', () => {
     const recipients = vi.mocked(notifier.sendToUser).mock.calls.map((c) => c[0].userId);
     expect(recipients.sort()).toEqual(['u1', 'u2']);
     expect((vi.mocked(notifier.sendToUser).mock.calls[0][1] as { body: string }).body).toBe(
-      '2 tasks due in the next 24h'
+      '2 tasks coming up in the next 24h'
     );
   });
 
@@ -293,7 +295,9 @@ describe('reminders service', () => {
       // Delivered to the cover, not the away member…
       expect(recipient.userId).toBe('u2');
       // …with the handoff called out in the message.
-      expect((payload as { body: string }).body).toBe('1 overdue, 0 due soon (covering for A)');
+      expect((payload as { body: string }).body).toBe(
+        '1 ready for some catch-up care, 0 coming up soon (covering for A)'
+      );
     });
 
     it('after the window expires, reminders revert to the original assignee (auto-revert)', async () => {

--- a/frontend/src/features/household/HouseholdOnboarding.tsx
+++ b/frontend/src/features/household/HouseholdOnboarding.tsx
@@ -104,8 +104,8 @@ export function HouseholdOnboarding() {
         </h2>
         {step === 'choice' && !isAddingAnother && (
           <p className="mt-2 max-w-sm text-center text-sm text-gray-600">
-            A household is a group that shares plant care. Create one to start fresh, or if someone
-            already invited you, paste their link instead.
+            A household keeps your plant care in one place — just you, or shared with others. Create
+            one to start fresh, or if someone already invited you, paste their link instead.
           </p>
         )}
       </div>
@@ -124,7 +124,7 @@ export function HouseholdOnboarding() {
                       Create a new household
                     </h3>
                     <p className="mt-1 text-sm text-gray-500">
-                      Start fresh and invite your family members to join
+                      Start fresh on your own — invite family any time you like
                     </p>
                   </div>
                 </div>
@@ -157,6 +157,13 @@ export function HouseholdOnboarding() {
               <Alert variant="error" className="mb-6">
                 {error}
               </Alert>
+            )}
+
+            {!isAddingAnother && (
+              <p className="mb-6 text-sm text-gray-600">
+                Flying solo? Name it after yourself or your home — it's just for you, and you can
+                invite people whenever you're ready.
+              </p>
             )}
 
             <form onSubmit={handleSubmit(onSubmit)} className="space-y-6" noValidate>

--- a/frontend/src/features/onboarding/WelcomeFlow.tsx
+++ b/frontend/src/features/onboarding/WelcomeFlow.tsx
@@ -28,12 +28,12 @@ const STEPS: Array<{
   {
     illustration: EmptyPlants,
     title: "You're in",
-    body: 'Your household is set up. Two things worth knowing before you add your first plant.',
+    body: "Your space is set up. Just you for now? That's perfectly fine — you can invite people any time. Two things worth knowing before you add your first plant.",
   },
   {
     illustration: EmptyMembers,
-    title: 'Plant care, shared',
-    body: "Add plants, schedule recurring tasks, and assign them. Whoever's around does the task and marks it done, and everyone in the household sees it. No more 'I thought you watered it' arguments.",
+    title: 'Plant care that fits you',
+    body: "Add plants, schedule recurring tasks, and keep everything in one calm place. Looking after your plants solo? It all just works. Sharing with others? Assign tasks — whoever's around does it and marks it done, and everyone sees it. No more 'I thought you watered it' arguments.",
   },
   {
     illustration: EmptyActivity,

--- a/frontend/src/hooks/useOverdueAlerts.ts
+++ b/frontend/src/hooks/useOverdueAlerts.ts
@@ -98,8 +98,8 @@ export function useOverdueAlerts(
       if (announced.current.has(t.id)) continue;
       announced.current.add(t.id);
       changed = true;
-      notify(`${t.plantName} needs attention`, {
-        body: `${t.customType ?? t.type} is overdue.`,
+      notify(`${t.plantName} could use a little care`, {
+        body: `${t.customType ?? t.type} is ready whenever you are.`,
         tag: `task-${t.id}`,
       });
     }


### PR DESCRIPTION
Copy/UX polish only — no behavior or logic changes.

## Warmer reminders & overdue copy
Past-due tasks now read like a gentle nudge rather than a failure, while still honestly conveying that something is waiting.

- **Reminder body** (`backend/src/services/reminders.ts`): `"N overdue, M due soon"` → `"N ready for some catch-up care, M coming up soon"`; `"N tasks due in the next 24h"` → `"N tasks coming up in the next 24h"`.
- **Weekly digest** (`backend/src/services/digest.ts`): subject `"… plants need attention"` → `"… plants could use some care"`; the "most at risk" framing becomes "a few plants could use some catch-up care"; per-plant `"X days overdue"` → `"waiting X days for some care"` / `"ready for a little care today"`.
- **Browser overdue alert** (`frontend/src/hooks/useOverdueAlerts.ts`): `"<plant> needs attention" / "<task> is overdue."` → `"<plant> could use a little care" / "<task> is ready whenever you are."`

Factual status labels (the "Overdue" filter tab, dashboard metric, and task-section heading) are left as-is.

## A welcome for solo plant-keepers
Onboarding leaned hard on "invite your household." Added brief, reassuring microcopy so starting alone feels first-class.

- `frontend/src/features/onboarding/WelcomeFlow.tsx`: acknowledges the solo case ("Just you for now? That's perfectly fine — you can invite people any time") and reframes the "shared" step to work whether you're solo or sharing.
- `frontend/src/features/household/HouseholdOnboarding.tsx`: softens the household framing toward "just you, or shared with others" and adds a solo-friendly note on the create step.

## Verification
- `npm test --prefix backend` — 861 passed
- `npm test --prefix frontend` — 282 passed
- Both builds pass; eslint + prettier clean (backend & frontend)
- Tests asserting on the changed strings were updated accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)