### PR TITLE
feat(billing): free plan now covers the whole household (up to 6 members)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 node_modules/
 .pnpm-store/
 
+# Local research / scratch notes (not part of the published source)
+docs/research/
+
 # Build outputs
 frontend/vite.config.js
 frontend/vite.config.d.ts

--- a/backend/src/models/plans.ts
+++ b/backend/src/models/plans.ts
@@ -24,7 +24,7 @@ export const PLANS: Record<PlanId, Plan> = {
     description: 'Free, perfect for getting started',
     monthlyPrice: 0,
     maxPlants: 10,
-    maxMembers: 1,
+    maxMembers: 6,
   },
   garden: {
     id: 'garden',

--- a/backend/tests/integration/local-server.test.ts
+++ b/backend/tests/integration/local-server.test.ts
@@ -745,7 +745,8 @@ describe('invite + join flow', () => {
 
   it('POST /households/join/:inviteCode joins via a valid invite and returns the household', async () => {
     const adminToken = await loginAsSeed();
-    await upgradeSeedHousehold(adminToken); // seedling caps members at 1
+    // Seedling now welcomes the whole household (up to 6), so a join into a
+    // one-member household succeeds on the free plan — no upgrade required.
     const invite = await request(app)
       .post(`/households/${seedHouseholdId}/invites`)
       .set('Authorization', `Bearer ${adminToken}`);
@@ -789,20 +790,22 @@ describe('invite + join flow', () => {
   });
 
   it('402s a join that would exceed the plan member cap', async () => {
-    // Seed household stays on seedling (maxMembers: 1, already full).
+    // Seed household stays on seedling (maxMembers: 6). It starts with the
+    // seed admin; fill it to the cap so the next join trips the limit.
     const adminToken = await loginAsSeed();
-    await upgradeSeedHousehold(adminToken, 'garden');
-    // Downgrade back so the cap check trips with an existing valid invite.
     const invite = await request(app)
       .post(`/households/${seedHouseholdId}/invites`)
       .set('Authorization', `Bearer ${adminToken}`);
+    for (let i = 0; i < 5; i++) {
+      seedMember(`cap-fill-${i}`, `cap-fill-${i}@example.com`, 'member');
+    }
     db.households.get(seedHouseholdId)!.planId = 'seedling';
     const joinerToken = await createConfirmedUser('capped@example.com');
     const join = await request(app)
       .post(`/households/join/${invite.body.code}`)
       .set('Authorization', `Bearer ${joinerToken}`);
     expect(join.status).toBe(402);
-    expect(join.body.message).toMatch(/limited to 1 members/);
+    expect(join.body.message).toMatch(/limited to 6 members/);
   });
 
   it('400s a double-join into the same household', async () => {

--- a/backend/tests/unit/handlers/billing.test.ts
+++ b/backend/tests/unit/handlers/billing.test.ts
@@ -142,9 +142,9 @@ describe('billing handler', () => {
     it('reports over-limit usage verbatim after a downgrade (caps come from the NEW plan)', async () => {
       const billing = await import('../../../src/services/billing.js');
       const { getCurrentSubscription } = await import('../../../src/handlers/billing/handler.js');
-      // Household downgraded to seedling while holding 25 plants / 4 members.
+      // Household downgraded to seedling while holding 25 plants / 8 members.
       vi.mocked(billing.getHouseholdSubscription).mockResolvedValueOnce({ planId: 'seedling' });
-      vi.mocked(getHouseholdCounters).mockResolvedValueOnce({ plantCount: 25, memberCount: 4 });
+      vi.mocked(getHouseholdCounters).mockResolvedValueOnce({ plantCount: 25, memberCount: 8 });
 
       const res = (await getCurrentSubscription(
         buildEvent({ httpMethod: 'GET' }),
@@ -153,8 +153,9 @@ describe('billing handler', () => {
       )) as APIGatewayProxyResult;
 
       const usage = JSON.parse(res.body).usage;
-      expect(usage).toEqual({ plantCount: 25, maxPlants: 10, memberCount: 4, maxMembers: 1 });
+      expect(usage).toEqual({ plantCount: 25, maxPlants: 10, memberCount: 8, maxMembers: 6 });
       expect(usage.plantCount).toBeGreaterThan(usage.maxPlants);
+      expect(usage.memberCount).toBeGreaterThan(usage.maxMembers);
     });
 
     it('tolerates missing counters (legacy households) as zero usage', async () => {

--- a/backend/tests/unit/models/plans.test.ts
+++ b/backend/tests/unit/models/plans.test.ts
@@ -7,7 +7,7 @@ describe('plan catalog', () => {
   });
 
   it('pins the per-tier caps the handlers enforce', () => {
-    expect(PLANS.seedling).toMatchObject({ monthlyPrice: 0, maxPlants: 10, maxMembers: 1 });
+    expect(PLANS.seedling).toMatchObject({ monthlyPrice: 0, maxPlants: 10, maxMembers: 6 });
     expect(PLANS.garden).toMatchObject({ monthlyPrice: 4.99, maxPlants: 500, maxMembers: 6 });
     expect(PLANS.greenhouse).toMatchObject({ monthlyPrice: 9.99, maxPlants: 5000, maxMembers: 50 });
   });

--- a/frontend/src/features/landing/LandingPage.tsx
+++ b/frontend/src/features/landing/LandingPage.tsx
@@ -860,9 +860,9 @@ export function LandingPage() {
 
       {/* Pricing Section — now on paper after the parchment "before you
           buy" band; the sprig marks the seam. The description frames the
-          tiers as a path (free → household → unlimited + API) so
-          collectors and power users see themselves, not just abstract
-          plan names. */}
+          tiers as a path (free household → unlimited plants → unlimited +
+          API) so collectors and power users see themselves, not just
+          abstract plan names. */}
       <div id="pricing" className="py-20 sm:py-28 bg-paper relative">
         <SprigDivider
           className="absolute left-1/2 -top-3 h-6 w-40 -translate-x-1/2 text-primary-600/80"
@@ -872,7 +872,7 @@ export function LandingPage() {
           <SectionHeading
             eyebrow="Pricing"
             title="Plans for every greenhouse"
-            description="Start free with ten plants and one keeper. Add the household on Garden, then go unlimited and open up the API on Greenhouse."
+            description="Start free with ten plants and your whole household — up to six people. Go unlimited on Garden, then open up the API on Greenhouse."
           />
           <PricingGrid />
           <p className="mt-12 text-center text-sm text-gray-700">

--- a/frontend/src/features/pricing/PricingPage.tsx
+++ b/frontend/src/features/pricing/PricingPage.tsx
@@ -54,8 +54,8 @@ export function PricingPage() {
                 Do I need a credit card to try the free plan?
               </dt>
               <dd className="mt-1 text-sm text-gray-600">
-                No. The Seedling plan is fully free, no card required. Add up to 10 plants and one
-                household member.
+                No. The Seedling plan is fully free, no card required. Add up to 10 plants and bring
+                in up to 6 household members.
               </dd>
             </div>
             <div>

--- a/frontend/src/features/pricing/plans.ts
+++ b/frontend/src/features/pricing/plans.ts
@@ -22,7 +22,12 @@ export const PRICING_PLANS: PricingPlan[] = [
     name: 'Seedling',
     price: 'Free',
     description: 'Start on the windowsill',
-    features: ['Up to 10 plants', '1 household member', 'Care reminders', 'Works on your phone'],
+    features: [
+      'Up to 10 plants',
+      'Up to 6 household members',
+      'Care reminders',
+      'Works on your phone',
+    ],
     cta: 'Get started',
     highlighted: false,
   },

--- a/frontend/src/features/settings/BillingSettings.tsx
+++ b/frontend/src/features/settings/BillingSettings.tsx
@@ -224,9 +224,7 @@ function PlanCard({ plan, current, isAdmin, beta, onSelect, isLoading }: PlanCar
         </li>
         <li className="flex gap-2">
           <CheckIcon className="h-5 w-5 text-primary-700" aria-hidden="true" />
-          {plan.maxMembers === 1
-            ? '1 household member'
-            : `Up to ${plan.maxMembers} household members`}
+          {`Up to ${plan.maxMembers} household members`}
         </li>
       </ul>
       <div className="mt-6">


### PR DESCRIPTION
## What & why

The free **Seedling** plan capped membership at a single person. For an app built around shared, household plant care, that's an odd fit — the second person living in a home couldn't join without paying. This raises Seedling's member cap from **1 to 6** so a whole household can collaborate on the free plan.

The paid differentiation shifts from *people* to *plants + features*: the free plan keeps its **10-plant cap unchanged**, while the paid tiers unlock unlimited plants, analytics, custom schedules, and API access.

## New free / Garden / Greenhouse member ladder

| Plan | Price | Members (before → after) | Plants |
| --- | --- | --- | --- |
| Seedling | Free | **1 → 6** | 10 (unchanged) |
| Garden | $4.99/mo | 6 (unchanged) | Unlimited |
| Greenhouse | $9.99/mo | Unlimited (unchanged) | Unlimited |

## Changes

- **`backend/src/models/plans.ts`** — Seedling `maxMembers: 1 → 6`. This is the single source of truth; server-side enforcement in `householdService.addMember` and the join handler reads the cap from the catalog, so the new limit applies with no other server changes. The `"limited to N members"` 402 copy is interpolated from the plan, so it updates automatically.
- **Frontend copy** — pricing cards (`features/pricing/plans.ts`), landing pricing section (`features/landing/LandingPage.tsx`), the `/pricing` FAQ (`features/pricing/PricingPage.tsx`), and `features/settings/BillingSettings.tsx`, all updated from "1 household member" to "up to 6 household members" in the existing plain, warm voice.
- **Tests** — plan-catalog, billing-usage, and integration join/cap tests updated to assert the new 6-member cap (the cap-trip integration test now fills the household to 6 before exercising the 402).
- Incidental housekeeping: ignore `docs/research/` scratch notes in `.gitignore`.

## Tests

- `npm test --prefix backend` — 861 passed
- `npm test --prefix frontend` — 282 passed
- Backend + frontend builds — green
- `npm run typecheck`, prettier, eslint — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)