### PR TITLE
fix(monitoring): notBreaching on per-function/ddb/api-5xx alarms

### DIFF
--- a/infrastructure/modules/monitoring/main.tf
+++ b/infrastructure/modules/monitoring/main.tf
@@ -316,6 +316,10 @@ resource "aws_cloudwatch_metric_alarm" "lambda_errors" {
   alarm_description   = "Lambda function ${each.value} errors exceeded threshold"
   alarm_actions       = [aws_sns_topic.alerts.arn]
   ok_actions          = [aws_sns_topic.alerts.arn]
+  # A function with no invocations in the window has no error data; treat that
+  # as healthy (OK) rather than INSUFFICIENT_DATA so a quiet low-traffic
+  # function reads green and a real error still trips the alarm.
+  treat_missing_data = "notBreaching"
 
   dimensions = {
     FunctionName = each.value
@@ -341,6 +345,8 @@ resource "aws_cloudwatch_metric_alarm" "lambda_duration" {
   threshold         = length(regexall("-chat-", each.value)) > 0 ? 60000 : 10000
   alarm_description = "Lambda function ${each.value} duration exceeded threshold"
   alarm_actions     = [aws_sns_topic.alerts.arn]
+  # No invocations = no duration data; quiet reads OK, not INSUFFICIENT_DATA.
+  treat_missing_data = "notBreaching"
 
   dimensions = {
     FunctionName = each.value
@@ -365,6 +371,8 @@ resource "aws_cloudwatch_metric_alarm" "dynamodb_throttle" {
   alarm_description   = "DynamoDB read throttling — capacity issue or hot partition"
   alarm_actions       = [aws_sns_topic.alerts.arn]
   ok_actions          = [aws_sns_topic.alerts.arn]
+  # No throttle events published = not throttling = OK, not INSUFFICIENT_DATA.
+  treat_missing_data = "notBreaching"
 
   dimensions = {
     TableName = var.dynamodb_table_name
@@ -387,6 +395,8 @@ resource "aws_cloudwatch_metric_alarm" "api_5xx" {
   alarm_description   = "API Gateway 5XX errors exceeded threshold"
   alarm_actions       = [aws_sns_topic.alerts.arn]
   ok_actions          = [aws_sns_topic.alerts.arn]
+  # No 5XX metric published in a quiet window = no server errors = OK.
+  treat_missing_data = "notBreaching"
 
   dimensions = {
     ApiId = var.api_gateway_name


### PR DESCRIPTION
Four alarm types (per-function lambda errors + duration, ddb-throttle, api-5xx) lacked `treat_missing_data`, so they defaulted to `INSUFFICIENT_DATA` when their metric was quiet — a dead-alarm state (8 alarms were sitting in it). `notBreaching` makes a quiet window read OK while a real error still trips the alarm, consistent with the aggregate/DLQ/auth alarms that already set it.

Verified: `terraform fmt` + `validate` (CI Terraform Validate gates this). No behavior change to alerting on real errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)