### PR TITLE
feat(landing): A/B test the hero (household vs solo framing)

### DIFF
--- a/frontend/src/features/landing/LandingPage.tsx
+++ b/frontend/src/features/landing/LandingPage.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import {
   // The marketing feature grid uses the custom botanical icons below.
@@ -34,7 +35,56 @@ import { CalendarLeafIcon } from '@/components/icons/CalendarLeafIcon';
 import { PhoneLeafIcon } from '@/components/icons/PhoneLeafIcon';
 import { GrowthRingsIcon } from '@/components/icons/GrowthRingsIcon';
 import { RootLockIcon } from '@/components/icons/RootLockIcon';
+import { useHeroVariant, HERO_EXPERIMENT, type Variant } from '@/lib/experiment';
+import { track, registerSuperProperties } from '@/services/analytics';
 import clsx from 'clsx';
+
+// Hero copy for the two framings under test. Variant A (control) is the
+// existing household / shared-care-journal hero. Variant B leads with
+// keeping your own plants alive and names the solo case first, mentioning
+// sharing second — same voice, same layout, same CTAs. The headline is
+// split into an optional pre-quote / emphasized / post-quote so A can keep
+// its italic "you" without giving B fake quotation marks.
+//
+// Removing the experiment: delete variant B below, inline variant A's copy
+// back into the hero, and drop the variant plumbing in LandingPage.
+const heroCopy: Record<
+  Variant,
+  {
+    eyebrow: string;
+    headlinePre: string;
+    headlineEmphasis: string;
+    headlinePost: string;
+    subhead: React.ReactNode;
+  }
+> = {
+  A: {
+    eyebrow: 'A garden journal for the whole house',
+    headlinePre: '“I thought ',
+    headlineEmphasis: 'you',
+    headlinePost: ' watered it.”',
+    subhead: (
+      <>
+        Family Greenhouse is a shared care journal for the plants in your house. Everyone sees
+        what&rsquo;s due and what&rsquo;s already done, so the fern doesn&rsquo;t get watered twice
+        on Tuesday and then forgotten for two weeks.
+      </>
+    ),
+  },
+  B: {
+    eyebrow: 'A care journal for your plants',
+    headlinePre: 'Keep ',
+    headlineEmphasis: 'every',
+    headlinePost: ' plant alive.',
+    subhead: (
+      <>
+        Family Greenhouse keeps a watering and care schedule for every plant you own, so nothing
+        gets missed or drowned. It works just as well for one person and a windowsill as it does for
+        a whole household sharing the watering can.
+      </>
+    ),
+  },
+};
 
 const features = [
   {
@@ -508,6 +558,18 @@ function SidebarLeafIcon({ className }: { className?: string }) {
 }
 
 export function LandingPage() {
+  // A/B test of the hero framing (control vs solo-first). Bucketing is
+  // stable per browser; see lib/experiment.ts.
+  const variant = useHeroVariant();
+
+  useEffect(() => {
+    // Fire once per landing-page mount: records the impression and pins the
+    // assignment as a super-property so the later signup_completed event (on
+    // ConfirmEmailPage) is attributable to the variant this visitor saw.
+    registerSuperProperties({ [HERO_EXPERIMENT]: variant });
+    track('experiment_viewed', { experiment: HERO_EXPERIMENT, variant });
+  }, [variant]);
+
   return (
     <div className="bg-paper">
       {/* Navigation */}
@@ -570,20 +632,19 @@ export function LandingPage() {
             <div className="grid grid-cols-1 items-center lg:grid-cols-2 lg:gap-x-16">
               <div className="mx-auto max-w-2xl text-center lg:mx-0 lg:max-w-xl lg:text-left">
                 <p className="text-xs uppercase tracking-[0.22em] text-primary-700 font-semibold mb-6">
-                  A garden journal for the whole house
+                  {heroCopy[variant].eyebrow}
                 </p>
                 <h1 className="font-serif text-5xl tracking-tight text-ink sm:text-7xl lg:text-6xl xl:text-7xl leading-[1.05]">
-                  &ldquo;I thought <span className="italic text-primary-700">you</span> watered
-                  it.&rdquo;
+                  {heroCopy[variant].headlinePre}
+                  <span className="italic text-primary-700">
+                    {heroCopy[variant].headlineEmphasis}
+                  </span>
+                  {heroCopy[variant].headlinePost}
                 </h1>
                 <div className="mt-4 flex justify-center lg:justify-start">
                   <TitleUnderline className="h-4 w-56 text-primary-600" />
                 </div>
-                <p className="mt-6 text-lg leading-8 text-gray-700">
-                  Family Greenhouse is a shared care journal for the plants in your house. Everyone
-                  sees what&rsquo;s due and what&rsquo;s already done, so the fern doesn&rsquo;t get
-                  watered twice on Tuesday and then forgotten for two weeks.
-                </p>
+                <p className="mt-6 text-lg leading-8 text-gray-700">{heroCopy[variant].subhead}</p>
                 <div className="mt-10 flex items-center justify-center gap-x-6 lg:justify-start">
                   <Link to="/register">
                     <Button size="lg">Sign up free</Button>

--- a/frontend/src/lib/experiment.ts
+++ b/frontend/src/lib/experiment.ts
@@ -1,0 +1,97 @@
+/**
+ * Lightweight client-side A/B experiment harness.
+ *
+ * Each visitor is bucketed once, 50/50, into variant 'A' or 'B' for a
+ * named experiment. The assignment is derived from a per-experiment
+ * random value persisted in localStorage, so it is stable across reloads
+ * and navigations for the same browser. No network, no SDK, no cookies —
+ * the whole thing is a few reads/writes against localStorage.
+ *
+ * Design notes:
+ *  - The random draw happens lazily inside a function at call time, never
+ *    at module top level. `Math.random()` at import time is banned in this
+ *    codebase (it makes module evaluation non-deterministic); using it
+ *    inside a runtime function is fine.
+ *  - We persist the *draw* (a float in [0,1)), not the resolved variant.
+ *    That keeps the bucketing rule in one place: if we ever move the split
+ *    off 50/50, existing visitors keep a stable, well-distributed value
+ *    and simply re-resolve against the new threshold.
+ *  - Everything degrades to a deterministic default ('A') when storage is
+ *    unavailable (SSR, privacy mode, quota errors) so a render never throws.
+ *
+ * Removal: delete this file, the `experiment_viewed` event + super-property
+ * plumbing in services/analytics.ts, and the variant branch in
+ * features/landing/LandingPage.tsx. Nothing else depends on it.
+ */
+
+import { useSyncExternalStore } from 'react';
+
+export type Variant = 'A' | 'B';
+
+/** localStorage key prefix for the persisted random draw, per experiment. */
+const STORAGE_PREFIX = 'fg_exp_';
+
+/** The single experiment this harness currently powers. */
+export const HERO_EXPERIMENT = 'landing_hero_framing';
+
+function storageKey(experiment: string): string {
+  return `${STORAGE_PREFIX}${experiment}`;
+}
+
+function safeGet(key: string): string | null {
+  try {
+    if (typeof localStorage === 'undefined') return null;
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function safeSet(key: string, value: string): void {
+  try {
+    if (typeof localStorage === 'undefined') return;
+    localStorage.setItem(key, value);
+  } catch {
+    // Storage full or blocked — fall back to an in-memory-only assignment
+    // for this session. Bucketing simply won't persist; that's acceptable.
+  }
+}
+
+/**
+ * Read (or lazily create + persist) the stable [0,1) draw for an
+ * experiment. The draw is generated with `Math.random()` inside this
+ * function — deliberately not at module scope.
+ */
+function getDraw(experiment: string): number {
+  const key = storageKey(experiment);
+  const stored = safeGet(key);
+  if (stored !== null) {
+    const parsed = Number.parseFloat(stored);
+    if (Number.isFinite(parsed) && parsed >= 0 && parsed < 1) return parsed;
+  }
+  const draw = Math.random();
+  safeSet(key, draw.toString());
+  return draw;
+}
+
+/**
+ * Resolve the assigned variant for an experiment, bucketing the visitor
+ * on first call and persisting the assignment for stability. 50/50 split.
+ */
+export function getVariant(experiment: string): Variant {
+  return getDraw(experiment) < 0.5 ? 'A' : 'B';
+}
+
+/**
+ * React hook returning the visitor's hero variant ('A' = control, the
+ * current household hero; 'B' = the solo-first hero). Stable for the life
+ * of the browser. Uses `useSyncExternalStore` with a no-op subscriber so
+ * the value is read consistently and never tears between renders.
+ */
+export function useHeroVariant(): Variant {
+  return useSyncExternalStore(
+    () => () => {},
+    () => getVariant(HERO_EXPERIMENT),
+    () => 'A'
+  );
+}

--- a/frontend/src/services/analytics.ts
+++ b/frontend/src/services/analytics.ts
@@ -98,7 +98,8 @@ export type EventName =
   | 'plant_shared' // Cutting-share link minted for a plant card.
   | 'plant_share_accepted' // A shared cutting card was copied into a household.
   | 'household_switched' // User changed active household via the switcher.
-  | 'climate_location_set';
+  | 'climate_location_set'
+  | 'experiment_viewed'; // A bucketed A/B variant was rendered to the visitor.
 
 export interface EventProps {
   /** Plan identifier when the event is plan-relevant. */
@@ -113,10 +114,34 @@ export interface EventProps {
   upgradeTo?: 'garden' | 'greenhouse';
   /** Free-form context only when it's an enum or a count, never a name. */
   context?: string;
+  /** For `experiment_viewed` — which experiment and assigned variant. */
+  experiment?: string;
+  variant?: 'A' | 'B';
 }
 
 /** Ambient distinct id — set by `identify`, cleared by `reset`. */
 let distinctId: string | null = null;
+
+/**
+ * Super-properties: a small bag of enum-like values merged onto every
+ * captured event, and `$set` onto the person on `identify`. Used to carry
+ * an A/B experiment assignment from the anonymous landing page through to
+ * the post-signup `signup_completed` event, so conversion can be sliced by
+ * variant. Keep this to discriminators only — never user-supplied strings.
+ *
+ * Removal: drop `registerSuperProperties` + the `...superProps` merges
+ * below and this whole block goes away cleanly.
+ */
+let superProps: Record<string, string> = {};
+
+/**
+ * Register persistent super-properties merged onto all subsequent events.
+ * Shallow-merges, so callers can register one experiment without clobbering
+ * another. Values must be enum-like discriminators.
+ */
+export function registerSuperProperties(props: Record<string, string>): void {
+  superProps = { ...superProps, ...props };
+}
 
 function isEnabled(): boolean {
   if (!KEY) return false;
@@ -125,9 +150,10 @@ function isEnabled(): boolean {
 }
 
 async function send(event: EventName, properties: Record<string, unknown>): Promise<void> {
+  const withSuper = { ...superProps, ...properties };
   // GTM dataLayer push runs whether or not PostHog is configured — they're
   // independent rails. The DNT check is inside pushToDataLayer.
-  pushToDataLayer(event, properties);
+  pushToDataLayer(event, withSuper);
   if (!isEnabled() || !distinctId) return;
   try {
     await fetch(`${HOST}/capture/`, {
@@ -138,7 +164,7 @@ async function send(event: EventName, properties: Record<string, unknown>): Prom
         event,
         distinct_id: distinctId,
         properties: {
-          ...properties,
+          ...withSuper,
           $lib: 'family-greenhouse-shim',
           $lib_version: '1.0.0',
         },
@@ -160,7 +186,7 @@ export function identify(userId: string, traits?: { plan?: EventProps['plan'] })
   // Initialize GTM once we have a known user — keeps an anonymous landing-
   // page visitor from triggering the script load until they're logged in.
   ensureGtm();
-  pushToDataLayer('user_identified', { userId, ...(traits ?? {}) });
+  pushToDataLayer('user_identified', { userId, ...superProps, ...(traits ?? {}) });
   if (!isEnabled()) return;
   void fetch(`${HOST}/capture/`, {
     method: 'POST',
@@ -169,16 +195,21 @@ export function identify(userId: string, traits?: { plan?: EventProps['plan'] })
       api_key: KEY,
       event: '$identify',
       distinct_id: userId,
-      properties: { $set: traits ?? {} },
+      // Persist the experiment assignment (and any other super-props) on the
+      // person so the eventual signup is attributable to the variant seen.
+      properties: { $set: { ...superProps, ...(traits ?? {}) } },
       timestamp: new Date().toISOString(),
     }),
     keepalive: true,
   }).catch(() => {});
 }
 
-/** Drop the distinct id on logout so subsequent events don't leak across users. */
+/** Drop the distinct id (and super-properties) on logout so subsequent
+ *  events don't leak across users. The landing page re-registers the
+ *  experiment assignment from localStorage on the next visit. */
 export function reset(): void {
   distinctId = null;
+  superProps = {};
 }
 
 export function track(event: EventName, props: EventProps = {}): void {

--- a/frontend/tests/unit/lib/experiment.test.tsx
+++ b/frontend/tests/unit/lib/experiment.test.tsx
@@ -1,0 +1,83 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { getVariant, useHeroVariant, HERO_EXPERIMENT } from '@/lib/experiment';
+import { LandingPage } from '@/features/landing/LandingPage';
+
+const KEY = `fg_exp_${HERO_EXPERIMENT}`;
+
+describe('experiment bucketing', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('buckets a draw < 0.5 to A and >= 0.5 to B', () => {
+    localStorage.setItem(KEY, '0.1');
+    expect(getVariant(HERO_EXPERIMENT)).toBe('A');
+    localStorage.setItem(KEY, '0.9');
+    expect(getVariant(HERO_EXPERIMENT)).toBe('B');
+  });
+
+  it('is stable across repeated calls and persists the draw', () => {
+    // No seed: the first call draws and persists; every later call must agree.
+    const first = getVariant(HERO_EXPERIMENT);
+    const persisted = localStorage.getItem(KEY);
+    expect(persisted).not.toBeNull();
+    for (let i = 0; i < 25; i++) {
+      expect(getVariant(HERO_EXPERIMENT)).toBe(first);
+    }
+    // The persisted draw is never rewritten once set.
+    expect(localStorage.getItem(KEY)).toBe(persisted);
+  });
+
+  it('ignores a corrupt stored value and re-draws a valid one', () => {
+    localStorage.setItem(KEY, 'not-a-number');
+    const v = getVariant(HERO_EXPERIMENT);
+    expect(v === 'A' || v === 'B').toBe(true);
+    const draw = Number.parseFloat(localStorage.getItem(KEY) as string);
+    expect(Number.isFinite(draw)).toBe(true);
+    expect(draw).toBeGreaterThanOrEqual(0);
+    expect(draw).toBeLessThan(1);
+  });
+
+  it('useHeroVariant returns the persisted assignment', () => {
+    localStorage.setItem(KEY, '0.8');
+    let seen: string | undefined;
+    function Probe() {
+      seen = useHeroVariant();
+      return null;
+    }
+    render(<Probe />);
+    expect(seen).toBe('B');
+  });
+});
+
+describe('LandingPage renders both hero variants', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  function renderLanding() {
+    return render(
+      <MemoryRouter>
+        <LandingPage />
+      </MemoryRouter>
+    );
+  }
+
+  it('renders the control (A) household hero', () => {
+    localStorage.setItem(KEY, '0.2');
+    renderLanding();
+    expect(screen.getByRole('heading', { level: 1 }).textContent).toContain('I thought');
+    // CTAs survive in both variants.
+    expect(screen.getAllByRole('link', { name: /sign up free/i }).length).toBeGreaterThan(0);
+  });
+
+  it('renders the solo-first (B) hero', () => {
+    localStorage.setItem(KEY, '0.8');
+    renderLanding();
+    expect(screen.getByRole('heading', { level: 1 }).textContent).toContain('Keep');
+    expect(screen.getByRole('heading', { level: 1 }).textContent).toContain('plant alive');
+    expect(screen.getAllByRole('link', { name: /sign up free/i }).length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## What

An A/B test of two landing-page hero framings, so we can learn which converts better once traffic arrives.

- **Variant A (control)** — the current household hero: *"I thought you watered it."* / shared-care-journal framing.
- **Variant B (solo-first)** — leads with keeping your own plants alive and welcomes solo keepers: headline *"Keep every plant alive"* with a sub that names the solo case first and mentions sharing second.

Layout, components, `TitleUnderline`, and both CTAs are identical across variants — only eyebrow, headline, and subhead copy change. The beta flag and every other section of the page are untouched.

## How it works

- **Bucketing** (`frontend/src/lib/experiment.ts`): each visitor is assigned 50/50 to A or B. The assignment is derived from a per-experiment random draw persisted in `localStorage`, so it's stable across reloads and navigations. `Math.random()` is called lazily inside a function (never at module top level). Degrades to the control variant when storage is unavailable. Exposed via `useHeroVariant()`.
- **Attribution** (`frontend/src/services/analytics.ts`): the hero fires `experiment_viewed` on render and registers the variant as an analytics **super-property**, which is then merged onto every subsequent captured event and `$set` onto the person on `identify`. That carries the variant through to the existing `signup_completed` event, so conversion can be sliced by variant in PostHog. Super-properties are cleared on logout (`reset()`).

## Tests

`frontend/tests/unit/lib/experiment.test.tsx` covers stable bucketing across repeated calls, corrupt-value recovery, the hook reading the persisted assignment, and that **both** hero variants render with their CTAs intact.

Verified locally: `vitest run` (291 passed), `npm run build`, size budgets, eslint, prettier — all green.

## Note

This only produces a readable result once there's real traffic — the harness is built now. It's removable in one pass: the lib file, the super-property block in `analytics.ts`, and the variant branch in `LandingPage.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)