### PR TITLE
feat(web): free pet-safe plant checker page

### DIFF
--- a/backend/src/handlers/species/handler.ts
+++ b/backend/src/handlers/species/handler.ts
@@ -16,6 +16,7 @@ import { successResponse, cacheableResponse } from '../../utils/response.js';
 import * as enrichment from '../../services/enrichment.js';
 import { isConfigured } from '../../services/perenual.js';
 import { deriveCareSuggestion } from '../../services/careRecommendations.js';
+import { lookupToxicity } from '../../models/petToxicity.js';
 
 // GET /species/search?q=...
 // Public catalog: same query → same answer for every user. 5-minute
@@ -203,9 +204,46 @@ export const careSuggestions = createHandler(
   // AI/enrichment-backed; tighter cap than search/detail.
   .use(userRateLimit({ perWindowMs: 60_000, max: 10 }));
 
+// GET /species/toxicity?q=...
+//
+// PUBLIC ROUTE (auth=none at the gateway): powers the free, no-signup
+// "is this plant safe for pets?" checker page, which answers high-intent
+// "is X toxic to cats/dogs" searches for logged-out visitors. Like the
+// public thumbnail route, it must stay safe for anonymous callers and never
+// touch the metered Perenual API — it resolves against a hand-curated,
+// ASPCA-grounded static table (models/petToxicity.ts), so it does no I/O,
+// reads no household data, and echoes no PII.
+//
+// Read-only and deterministic (same query → same answer for everyone), so we
+// cache it publicly at the edge for an hour. IP-scoped rate limit since there
+// is no user to key on.
+export const toxicity = createHandler(
+  // Resolves a static in-memory table, so there's nothing to await — return
+  // the response wrapped in a Promise to satisfy the Handler signature.
+  (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+    const q = (event.queryStringParameters?.q ?? '').trim();
+    // Cap the query length so a giant string can't blow up the matcher; the
+    // table is tiny, so this is belt-and-braces.
+    const matches = q.length >= 2 ? lookupToxicity(q.slice(0, 80)) : [];
+    return Promise.resolve(
+      cacheableResponse(
+        { query: q, results: matches },
+        { maxAgeSeconds: 3600, visibility: 'public' }
+      )
+    );
+  }
+  // No authMiddleware: served to anonymous visitors on the marketing page.
+  // 60/min per IP comfortably covers search-as-you-type while blunting abuse.
+).use(rateLimit({ perWindowMs: 60_000, max: 60 }));
+
 // Lambda entrypoint: dispatch this group's routes (see middleware/router.ts).
+//
+// `GET /species/toxicity` is an exact-segment key, so API Gateway's HTTP API
+// route selection prefers it over the `GET /species/{id}` parameter route —
+// the two never collide.
 export const handler = createRouter({
   'GET /species/search': search,
+  'GET /species/toxicity': toxicity,
   'GET /species/{id}': detail,
   'GET /species/{id}/thumbnail': thumbnail,
   'GET /species/{id}/guide': guide,

--- a/backend/src/local-server.ts
+++ b/backend/src/local-server.ts
@@ -39,6 +39,7 @@ import {
 } from './models/schemas.js';
 import { TEMPLATES } from './models/taskTemplates.js';
 import { PLANS } from './models/plans.js';
+import { lookupToxicity } from './models/petToxicity.js';
 
 // Hard refusal to boot in production — this server has no real auth, no
 // persistence, and a well-known seed account. Mirrors the resolveCorsOrigin
@@ -2529,6 +2530,19 @@ app.get('/plants/:plantId/history', authMiddleware, requireHousehold, (req, res)
 // to its static catalog. This keeps local dev offline-friendly.
 app.get('/species/search', authMiddleware, (req, res) => {
   res.json({ source: 'disabled', results: [] });
+});
+
+// PUBLIC route (no auth) — the free "is this plant safe for pets?" lookup.
+// Mirrors handlers/species/handler.ts:toxicity exactly: resolves the typed
+// name against the same hand-curated static table (no Perenual, no DB), so
+// the mock returns real answers and the integration tests exercise the live
+// matcher. Registered BEFORE `/species/:id` so Express matches the exact
+// segment first (API Gateway does this automatically in production).
+app.get('/species/toxicity', (req, res) => {
+  const q = (typeof req.query.q === 'string' ? req.query.q : '').trim();
+  const results = q.length >= 2 ? lookupToxicity(q.slice(0, 80)) : [];
+  res.set('Cache-Control', 'public, max-age=3600');
+  res.json({ query: q, results });
 });
 
 app.get('/species/:id', authMiddleware, (req, res) => {

--- a/backend/src/models/petToxicity.ts
+++ b/backend/src/models/petToxicity.ts
@@ -1,0 +1,292 @@
+/**
+ * Curated pet-toxicity catalog for the public "is this plant safe for pets?"
+ * lookup (GET /species/toxicity).
+ *
+ * Why a hand-curated table rather than the Perenual enrichment cache: the
+ * lookup is PUBLIC and unauthenticated, so it must never hit the metered
+ * Perenual API on an anonymous request (cost + abuse surface). Perenual also
+ * only exposes a coarse `poisonous_to_pets` boolean, which can't distinguish
+ * "toxic to cats but not dogs" or carry the plain-language caveat a worried
+ * pet owner actually needs. These entries are GROUNDED in the ASPCA toxic /
+ * non-toxic plant database (the reference vets point people to); the prose is
+ * original.
+ *
+ * ⚠️ The `cats`/`dogs` verdicts are the field a wrong answer does real harm
+ * on — a pet owner trusts this line. Verify every entry against the ASPCA
+ * listing before adding or editing it, and keep `note` honest about
+ * uncertainty rather than guessing.
+ */
+
+export type ToxicityVerdict = 'toxic' | 'non-toxic';
+
+export interface PetToxicityEntry {
+  /** Stable lookup slug (kebab-case, unique). */
+  slug: string;
+  commonName: string;
+  scientificName: string;
+  /** Other names people search by — folded into the match index. */
+  aliases: string[];
+  cats: ToxicityVerdict;
+  dogs: ToxicityVerdict;
+  /** One plain, warm sentence: what happens, and the honest caveat. */
+  note: string;
+}
+
+export const PET_TOXICITY: PetToxicityEntry[] = [
+  {
+    slug: 'pothos',
+    commonName: 'Pothos',
+    scientificName: 'Epipremnum aureum',
+    aliases: ['devil’s ivy', 'devils ivy', 'golden pothos', 'money plant', 'epipremnum'],
+    cats: 'toxic',
+    dogs: 'toxic',
+    note: 'The sap carries insoluble calcium oxalate crystals, so a chewed leaf causes mouth pain, drooling and vomiting. Rarely life-threatening, but unpleasant — keep it up high or out of a determined pet’s reach.',
+  },
+  {
+    slug: 'monstera',
+    commonName: 'Monstera',
+    scientificName: 'Monstera deliciosa',
+    aliases: ['swiss cheese plant', 'split-leaf philodendron', 'split leaf philodendron'],
+    cats: 'toxic',
+    dogs: 'toxic',
+    note: 'Same calcium oxalate crystals as pothos — chewing irritates the mouth and stomach. Mild for a nibble, but worth keeping out of reach of a cat that likes to taste-test.',
+  },
+  {
+    slug: 'snake-plant',
+    commonName: 'Snake plant',
+    scientificName: 'Dracaena trifasciata',
+    aliases: ['mother-in-law’s tongue', 'mother in laws tongue', 'sansevieria', 'dracaena'],
+    cats: 'toxic',
+    dogs: 'toxic',
+    note: 'Contains saponins, which cause drooling, vomiting and the odd bout of diarrhoea if eaten. Mildly toxic rather than dangerous — most pets feel rotten for a while and recover.',
+  },
+  {
+    slug: 'spider-plant',
+    commonName: 'Spider plant',
+    scientificName: 'Chlorophytum comosum',
+    aliases: ['airplane plant', 'ribbon plant', 'chlorophytum'],
+    cats: 'non-toxic',
+    dogs: 'non-toxic',
+    note: 'Non-toxic to cats and dogs per the ASPCA — one of the safest leafy plants you can own. Cats are oddly drawn to chewing it; a big mouthful can still cause a mild tummy upset, but there’s nothing poisonous in it.',
+  },
+  {
+    slug: 'peace-lily',
+    commonName: 'Peace lily',
+    scientificName: 'Spathiphyllum',
+    aliases: ['spathiphyllum', 'closet plant'],
+    cats: 'toxic',
+    dogs: 'toxic',
+    note: 'Calcium oxalate crystals cause intense mouth and throat irritation, drooling and trouble swallowing. Despite the name it is NOT a true lily, so it won’t cause the kidney failure true lilies do — but it’s still one to keep away from pets.',
+  },
+  {
+    slug: 'aloe-vera',
+    commonName: 'Aloe vera',
+    scientificName: 'Aloe vera',
+    aliases: ['aloe', 'medicine plant', 'burn plant'],
+    cats: 'toxic',
+    dogs: 'toxic',
+    note: 'The gel inside is fine, but the leaf’s outer layer contains saponins and anthraquinones that cause vomiting, lethargy and diarrhoea if eaten. Keep the plant out of reach even though aloe gel is a human first-aid staple.',
+  },
+  {
+    slug: 'jade-plant',
+    commonName: 'Jade plant',
+    scientificName: 'Crassula ovata',
+    aliases: ['lucky plant', 'crassula', 'friendship tree'],
+    cats: 'toxic',
+    dogs: 'toxic',
+    note: 'Toxic to both, though exactly why isn’t fully understood — eating it causes vomiting, a wobbly unsteady gait and a slowed heart rate. Worth a vet call if a pet has had a real mouthful.',
+  },
+  {
+    slug: 'philodendron',
+    commonName: 'Philodendron',
+    scientificName: 'Philodendron',
+    aliases: ['heartleaf philodendron', 'philodendron hederaceum'],
+    cats: 'toxic',
+    dogs: 'toxic',
+    note: 'The whole genus carries calcium oxalate crystals — chewing burns the mouth and causes drooling and vomiting. A common, easy houseplant, so a popular one to site well out of reach.',
+  },
+  {
+    slug: 'zz-plant',
+    commonName: 'ZZ plant',
+    scientificName: 'Zamioculcas zamiifolia',
+    aliases: ['zanzibar gem', 'zamioculcas', 'zz'],
+    cats: 'toxic',
+    dogs: 'toxic',
+    note: 'Calcium oxalate crystals again — chewing irritates the mouth and stomach. Its reputation as “toxic” overstates it; a nibble means an unhappy pet, not an emergency, but the sap can also irritate skin so wash hands after handling.',
+  },
+  {
+    slug: 'fiddle-leaf-fig',
+    commonName: 'Fiddle-leaf fig',
+    scientificName: 'Ficus lyrata',
+    aliases: ['fiddle leaf fig', 'ficus', 'fig'],
+    cats: 'toxic',
+    dogs: 'toxic',
+    note: 'The sap contains crystals that irritate the mouth and skin, causing drooling and vomiting if leaves are eaten. More of a nuisance than a danger, but the milky sap can also cause a skin rash.',
+  },
+  {
+    slug: 'rubber-plant',
+    commonName: 'Rubber plant',
+    scientificName: 'Ficus elastica',
+    aliases: ['rubber tree', 'rubber fig', 'ficus elastica'],
+    cats: 'toxic',
+    dogs: 'toxic',
+    note: 'The milky sap irritates the mouth and gut and can cause drooling, vomiting and a skin reaction. Mildly toxic — keep curious chewers away and wipe up any sap from broken leaves.',
+  },
+  {
+    slug: 'dieffenbachia',
+    commonName: 'Dieffenbachia',
+    scientificName: 'Dieffenbachia',
+    aliases: ['dumb cane', 'dumbcane', 'leopard lily'],
+    cats: 'toxic',
+    dogs: 'toxic',
+    note: 'Among the harsher of the calcium-oxalate plants — chewing causes intense oral pain, drooling and, in bad cases, enough swelling to make breathing difficult. One to keep firmly out of reach of pets and children.',
+  },
+  {
+    slug: 'calathea',
+    commonName: 'Calathea',
+    scientificName: 'Calathea',
+    aliases: ['prayer plant', 'goeppertia', 'maranta', 'rattlesnake plant'],
+    cats: 'non-toxic',
+    dogs: 'non-toxic',
+    note: 'Non-toxic to cats and dogs per the ASPCA — a genuinely pet-safe choice if you want something showy. A big mouthful might cause a mild upset like any plant, but nothing poisonous.',
+  },
+  {
+    slug: 'boston-fern',
+    commonName: 'Boston fern',
+    scientificName: 'Nephrolepis exaltata',
+    aliases: ['sword fern', 'nephrolepis', 'fern'],
+    cats: 'non-toxic',
+    dogs: 'non-toxic',
+    note: 'Non-toxic to cats and dogs per the ASPCA — true ferns are a reliably safe group. Pets sometimes bat at the fronds; no harm done beyond a bit of mess.',
+  },
+  {
+    slug: 'african-violet',
+    commonName: 'African violet',
+    scientificName: 'Saintpaulia',
+    aliases: ['saintpaulia', 'violet'],
+    cats: 'non-toxic',
+    dogs: 'non-toxic',
+    note: 'Non-toxic to cats and dogs per the ASPCA — safe to keep on a windowsill within reach. (Don’t confuse it with true violets or other flowering “violets”, which differ.)',
+  },
+  {
+    slug: 'orchid',
+    commonName: 'Orchid (Phalaenopsis)',
+    scientificName: 'Phalaenopsis',
+    aliases: ['phalaenopsis', 'moth orchid', 'orchids'],
+    cats: 'non-toxic',
+    dogs: 'non-toxic',
+    note: 'The common moth orchid is non-toxic to cats and dogs per the ASPCA. Eating a flower or leaf might cause a mild stomach upset, but there’s nothing poisonous in it.',
+  },
+  {
+    slug: 'lily',
+    commonName: 'True lily',
+    scientificName: 'Lilium',
+    aliases: [
+      'lilium',
+      'easter lily',
+      'tiger lily',
+      'stargazer lily',
+      'asiatic lily',
+      'daylily',
+      'hemerocallis',
+    ],
+    cats: 'toxic',
+    dogs: 'toxic',
+    note: 'This is the dangerous one. True lilies (Lilium) and daylilies (Hemerocallis) cause sudden kidney failure in cats — even pollen, vase water or a single leaf can be fatal. If a cat has had ANY contact, treat it as an emergency and call a vet immediately. Less severe in dogs, but still keep them away.',
+  },
+  {
+    slug: 'sago-palm',
+    commonName: 'Sago palm',
+    scientificName: 'Cycas revoluta',
+    aliases: ['cycad', 'cycas', 'king sago'],
+    cats: 'toxic',
+    dogs: 'toxic',
+    note: 'Severely toxic — every part, especially the seeds, can cause liver failure and is often fatal even with treatment. If a pet has eaten any of it, this is a vet emergency, not a wait-and-see.',
+  },
+  {
+    slug: 'poinsettia',
+    commonName: 'Poinsettia',
+    scientificName: 'Euphorbia pulcherrima',
+    aliases: ['euphorbia', 'christmas flower', 'christmas star'],
+    cats: 'toxic',
+    dogs: 'toxic',
+    note: 'Its reputation is far worse than the reality — the milky sap irritates the mouth and stomach, causing drooling and mild vomiting, but it is rarely serious. Keep it out of reach, but don’t panic over a stray nibble.',
+  },
+];
+
+/** Normalize a query/name for fuzzy matching: lowercase, strip punctuation,
+ *  collapse whitespace. Keeps the matcher forgiving of "snake plant" vs
+ *  "snake-plant" vs "Snake Plant!". */
+export function normalizeName(raw: string): string {
+  return raw
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[’']/g, '')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
+export interface PetToxicityMatch {
+  slug: string;
+  commonName: string;
+  scientificName: string;
+  cats: ToxicityVerdict;
+  dogs: ToxicityVerdict;
+  note: string;
+}
+
+function toMatch(entry: PetToxicityEntry): PetToxicityMatch {
+  return {
+    slug: entry.slug,
+    commonName: entry.commonName,
+    scientificName: entry.scientificName,
+    cats: entry.cats,
+    dogs: entry.dogs,
+    note: entry.note,
+  };
+}
+
+/**
+ * Resolve a free-text plant name to at most `limit` toxicity entries, best
+ * match first. Pure + deterministic (no I/O), so it's safe to call from the
+ * public, cache-friendly handler. Matching tiers, in priority order:
+ *   1. exact name/alias hit
+ *   2. query is a prefix of a name/alias (typeahead)
+ *   3. any name/alias contains the query (substring)
+ *   4. any query word appears in a name/alias (loose word overlap)
+ */
+export function lookupToxicity(query: string, limit = 5): PetToxicityMatch[] {
+  const q = normalizeName(query);
+  if (q.length < 2) return [];
+
+  const indexed = PET_TOXICITY.map((entry) => ({
+    entry,
+    names: [entry.commonName, entry.scientificName, ...entry.aliases].map(normalizeName),
+  }));
+
+  const exact: PetToxicityEntry[] = [];
+  const prefix: PetToxicityEntry[] = [];
+  const substring: PetToxicityEntry[] = [];
+  const word: PetToxicityEntry[] = [];
+  const qWords = q.split(' ').filter((w) => w.length >= 3);
+
+  for (const { entry, names } of indexed) {
+    if (names.some((n) => n === q)) {
+      exact.push(entry);
+    } else if (names.some((n) => n.startsWith(q))) {
+      prefix.push(entry);
+    } else if (names.some((n) => n.includes(q))) {
+      substring.push(entry);
+    } else if (qWords.length > 0 && names.some((n) => qWords.some((w) => n.includes(w)))) {
+      word.push(entry);
+    }
+  }
+
+  const ordered: PetToxicityEntry[] = [];
+  for (const bucket of [exact, prefix, substring, word]) {
+    for (const e of bucket) {
+      if (!ordered.includes(e)) ordered.push(e);
+    }
+  }
+  return ordered.slice(0, limit).map(toMatch);
+}

--- a/backend/tests/unit/handlers/species.test.ts
+++ b/backend/tests/unit/handlers/species.test.ts
@@ -232,6 +232,86 @@ describe('species handler', () => {
     });
   });
 
+  describe('toxicity (public pet-safety lookup)', () => {
+    it('answers an anonymous query with cat/dog verdicts and a public cache header', async () => {
+      const { toxicity } = await import('../../../src/handlers/species/handler.js');
+      const res = (await toxicity(
+        buildAnonymousEvent({
+          path: '/species/toxicity',
+          pathParameters: null,
+          queryStringParameters: { q: 'snake plant' },
+        }),
+        ctx,
+        () => {}
+      )) as APIGatewayProxyResult;
+
+      expect(res.statusCode).toBe(200);
+      expect(res.headers?.['Cache-Control']).toMatch(/public/);
+      const body = JSON.parse(res.body);
+      expect(body.results[0]).toMatchObject({
+        slug: 'snake-plant',
+        cats: 'toxic',
+        dogs: 'toxic',
+      });
+      expect(typeof body.results[0].note).toBe('string');
+    });
+
+    it('matches by scientific name and alias, not just common name', async () => {
+      const { toxicity } = await import('../../../src/handlers/species/handler.js');
+      const call = async (q: string) => {
+        const res = (await toxicity(
+          buildAnonymousEvent({ path: '/species/toxicity', queryStringParameters: { q } }),
+          ctx,
+          () => {}
+        )) as APIGatewayProxyResult;
+        return JSON.parse(res.body).results;
+      };
+      expect((await call('chlorophytum comosum'))[0].slug).toBe('spider-plant');
+      expect((await call('devils ivy'))[0].slug).toBe('pothos');
+    });
+
+    it('surfaces the safe verdict for a non-toxic plant', async () => {
+      const { toxicity } = await import('../../../src/handlers/species/handler.js');
+      const res = (await toxicity(
+        buildAnonymousEvent({
+          path: '/species/toxicity',
+          queryStringParameters: { q: 'spider plant' },
+        }),
+        ctx,
+        () => {}
+      )) as APIGatewayProxyResult;
+      const body = JSON.parse(res.body);
+      expect(body.results[0]).toMatchObject({ cats: 'non-toxic', dogs: 'non-toxic' });
+    });
+
+    it('returns an empty result set (not an error) for a too-short or unknown query', async () => {
+      const { toxicity } = await import('../../../src/handlers/species/handler.js');
+      const call = async (q: string) => {
+        const res = (await toxicity(
+          buildAnonymousEvent({ path: '/species/toxicity', queryStringParameters: { q } }),
+          ctx,
+          () => {}
+        )) as APIGatewayProxyResult;
+        expect(res.statusCode).toBe(200);
+        return JSON.parse(res.body).results;
+      };
+      expect(await call('a')).toEqual([]);
+      expect(await call('zzzznotaplant')).toEqual([]);
+    });
+
+    it('applies an IP rate limit (429 after 60 requests/min)', async () => {
+      const { toxicity } = await import('../../../src/handlers/species/handler.js');
+      const event = () =>
+        buildAnonymousEvent({ path: '/species/toxicity', queryStringParameters: { q: 'pothos' } });
+      for (let i = 0; i < 60; i++) {
+        const res = (await toxicity(event(), ctx, () => {})) as APIGatewayProxyResult;
+        expect(res.statusCode).toBe(200);
+      }
+      const res = (await toxicity(event(), ctx, () => {})) as APIGatewayProxyResult;
+      expect(res.statusCode).toBe(429);
+    });
+  });
+
   describe('rate limits on metered routes', () => {
     it('guide is capped at 10/min per user', async () => {
       const enrichment = await import('../../../src/services/enrichment.js');

--- a/docs/api-spec.yaml
+++ b/docs/api-spec.yaml
@@ -724,6 +724,17 @@ paths:
           schema: { type: string, minLength: 2 }
       responses:
         '200': { $ref: '#/components/responses/Ok' }
+  /species/toxicity:
+    get:
+      summary: Public pet-toxicity lookup (cat/dog safety) for a plant name. No auth; curated static data, cached publicly.
+      tags: [Species]
+      parameters:
+        - name: q
+          in: query
+          required: true
+          schema: { type: string, minLength: 2 }
+      responses:
+        '200': { $ref: '#/components/responses/Ok' }
   /species/{id}:
     get:
       summary: Species detail

--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -21,6 +21,11 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://app.familygreenhouse.com/pet-safe</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://app.familygreenhouse.com/changelog</loc>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>

--- a/frontend/scripts/build-sitemap.mjs
+++ b/frontend/scripts/build-sitemap.mjs
@@ -32,6 +32,7 @@ const STATIC_ROUTES = [
   { path: '/pricing', priority: 0.9, changefreq: 'monthly' },
   { path: '/blog', priority: 0.8, changefreq: 'weekly' },
   { path: '/care', priority: 0.8, changefreq: 'weekly' },
+  { path: '/pet-safe', priority: 0.8, changefreq: 'monthly' },
   { path: '/changelog', priority: 0.5, changefreq: 'weekly' },
   { path: '/status', priority: 0.3, changefreq: 'daily' },
   { path: '/legal/privacy', priority: 0.3, changefreq: 'yearly' },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -75,6 +75,7 @@ const BlogIndex = lazyNamed(() => import('@/features/blog/BlogIndex'), 'BlogInde
 const BlogPost = lazyNamed(() => import('@/features/blog/BlogPost'), 'BlogPost');
 const CareIndex = lazyNamed(() => import('@/features/care/CareIndex'), 'CareIndex');
 const CareGuidePage = lazyNamed(() => import('@/features/care/CareGuidePage'), 'CareGuidePage');
+const PetSafePage = lazyNamed(() => import('@/features/petsafe/PetSafePage'), 'PetSafePage');
 const ChangelogPage = lazyNamed(
   () => import('@/features/changelog/ChangelogPage'),
   'ChangelogPage'
@@ -150,6 +151,7 @@ function App() {
               <Route path="/blog" element={<BlogIndex />} />
               <Route path="/care" element={<CareIndex />} />
               <Route path="/care/:slug" element={<CareGuidePage />} />
+              <Route path="/pet-safe" element={<PetSafePage />} />
               <Route path="/blog/:slug" element={<BlogPost />} />
               <Route path="/changelog" element={<ChangelogPage />} />
               <Route path="/legal/privacy" element={<PrivacyPage />} />

--- a/frontend/src/features/petsafe/PetSafePage.tsx
+++ b/frontend/src/features/petsafe/PetSafePage.tsx
@@ -1,0 +1,207 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { BrandMark } from '@/components/BrandMark';
+import { Footer } from '@/components/Footer';
+import { Alert } from '@/components/Alert';
+import { Input } from '@/components/Input';
+import { useMetaTags } from '@/hooks/useMetaTags';
+import { useDebounce } from '@/hooks/useDebounce';
+import { petToxicityService, type ToxicityMatch } from '@/services/petToxicityService';
+
+/**
+ * Free, no-signup "Is this plant safe for pets?" checker. A top-of-funnel
+ * marketing page (public, no auth — like /care and /blog) that answers
+ * high-intent "is X toxic to cats/dogs" searches and gently funnels visitors
+ * into the app.
+ *
+ * Toxicity comes from the public, cache-friendly GET /species/toxicity
+ * endpoint, which resolves a hand-curated, ASPCA-grounded table server-side.
+ * No PII, no auth, read-only.
+ */
+export function PetSafePage() {
+  useMetaTags({
+    title: 'Is This Plant Safe for Pets? — Cat & Dog Toxicity Checker',
+    description:
+      'Free, no-signup checker: type a houseplant name and see whether it’s toxic to cats and dogs, in plain language. Based on the ASPCA’s plant safety data.',
+  });
+
+  const [query, setQuery] = useState('');
+  const debouncedQuery = useDebounce(query.trim(), 300);
+  const [results, setResults] = useState<ToxicityMatch[]>([]);
+  const [status, setStatus] = useState<'idle' | 'loading' | 'done' | 'error'>('idle');
+  // Remember the query the current results belong to, so the "no matches"
+  // message only shows once a real lookup has settled (not mid-type).
+  const [resolvedQuery, setResolvedQuery] = useState('');
+
+  useEffect(() => {
+    if (debouncedQuery.length < 2) {
+      setResults([]);
+      setStatus('idle');
+      setResolvedQuery('');
+      return;
+    }
+    const controller = new AbortController();
+    setStatus('loading');
+    petToxicityService
+      .lookup(debouncedQuery, controller.signal)
+      .then((matches) => {
+        setResults(matches);
+        setResolvedQuery(debouncedQuery);
+        setStatus('done');
+      })
+      .catch((err: unknown) => {
+        if (err instanceof DOMException && err.name === 'AbortError') return;
+        setStatus('error');
+      });
+    return () => controller.abort();
+  }, [debouncedQuery]);
+
+  const showEmpty = status === 'done' && results.length === 0 && resolvedQuery.length >= 2;
+
+  return (
+    <div className="min-h-screen bg-white flex flex-col">
+      <header className="border-b border-gray-200">
+        <nav className="mx-auto max-w-3xl flex items-center justify-between p-6">
+          <Link to="/" aria-label="Family Greenhouse home">
+            <BrandMark variant="wordmark" size="sm" />
+          </Link>
+          <Link to="/" className="text-sm font-medium text-primary-700 hover:underline">
+            Try the app →
+          </Link>
+        </nav>
+      </header>
+
+      <main className="flex-1 mx-auto max-w-3xl w-full px-6 py-16">
+        <h1 className="font-serif text-4xl font-semibold tracking-tight text-gray-900 sm:text-5xl">
+          Is this plant safe for pets?
+        </h1>
+        <p className="mt-3 text-lg text-gray-600">
+          Type a houseplant name and we’ll tell you, plainly, whether it’s toxic to cats and dogs.
+          No sign-up, no fuss. Based on the{' '}
+          <a
+            href="https://www.aspca.org/pet-care/animal-poison-control/toxic-and-non-toxic-plants"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary-700 underline hover:text-primary-800"
+          >
+            ASPCA’s plant safety data
+          </a>
+          .
+        </p>
+
+        <form
+          className="mt-10"
+          role="search"
+          aria-label="Search plant pet-toxicity"
+          onSubmit={(e) => e.preventDefault()}
+        >
+          <Input
+            type="search"
+            label="Plant or species name"
+            placeholder="e.g. snake plant, pothos, lily…"
+            autoComplete="off"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            helperText="Try a common name or a scientific name."
+          />
+        </form>
+
+        {/* Live region so screen readers hear the result as it loads. */}
+        <div className="mt-8 space-y-4" aria-live="polite" aria-busy={status === 'loading'}>
+          {status === 'error' && (
+            <Alert variant="error" title="Something went wrong">
+              We couldn’t check that just now. Give it another moment and try again.
+            </Alert>
+          )}
+
+          {results.map((match) => (
+            <ToxicityCard key={match.slug} match={match} />
+          ))}
+
+          {showEmpty && (
+            <Alert variant="info" title="No match yet">
+              We don’t have that one in our checker yet. Double-check the spelling, or try the
+              plant’s common name. When in doubt, assume it’s unsafe and keep it out of reach until
+              you can confirm with your vet or the ASPCA.
+            </Alert>
+          )}
+        </div>
+
+        {/* General, always-visible caveat for kids and pets. */}
+        <aside className="mt-12 rounded-lg border border-primary-200 bg-primary-50/60 p-5">
+          <h2 className="font-serif text-lg font-semibold text-gray-900">
+            A note on kids and pets
+          </h2>
+          <p className="mt-2 text-sm text-gray-700">
+            Even “non-toxic” plants can cause a mild upset stomach if a curious pet or toddler eats
+            a big mouthful — non-toxic means not poisonous, not that it’s food. With anything truly
+            toxic, the safest move is height: put it where paws and little hands can’t reach. If you
+            think a pet has eaten something harmful, call your vet or the{' '}
+            <a
+              href="https://www.aspca.org/pet-care/animal-poison-control"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary-700 underline hover:text-primary-800"
+            >
+              ASPCA Animal Poison Control
+            </a>{' '}
+            line right away.
+          </p>
+        </aside>
+
+        <section className="mt-16 rounded-lg border border-primary-200 bg-primary-50 p-6 text-center">
+          <h2 className="font-serif text-xl font-semibold text-gray-900">
+            Keeping a pet-safe home is easier when everyone’s on the same page
+          </h2>
+          <p className="mt-2 text-sm text-gray-600">
+            Family Greenhouse keeps your plants, their care, and who’s looking after what in one
+            shared place — so the whole household knows which plants to keep out of reach. Free to
+            start, no card needed.
+          </p>
+          <div className="mt-4">
+            <Link
+              to="/register"
+              className="inline-flex items-center rounded-md bg-primary-700 px-4 py-2 text-sm font-medium text-white hover:bg-primary-800 min-h-touch"
+            >
+              Get started
+            </Link>
+            <p className="mt-3 text-xs text-gray-500">
+              Just browsing? Read our{' '}
+              <Link to="/care" className="text-primary-700 underline hover:text-primary-800">
+                plant care guides
+              </Link>
+              .
+            </p>
+          </div>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}
+
+function ToxicityCard({ match }: { match: ToxicityMatch }) {
+  const safeForBoth = match.cats === 'non-toxic' && match.dogs === 'non-toxic';
+  const variant = safeForBoth ? 'success' : 'warning';
+  const title = safeForBoth
+    ? `${match.commonName} is pet-safe`
+    : `${match.commonName} can be harmful to pets`;
+
+  return (
+    <Alert variant={variant} title={title}>
+      <p className="italic">{match.scientificName}</p>
+      <ul className="mt-2 space-y-1">
+        <li>
+          <span className="font-medium">Cats:</span>{' '}
+          {match.cats === 'toxic' ? 'Toxic' : 'Non-toxic'}
+        </li>
+        <li>
+          <span className="font-medium">Dogs:</span>{' '}
+          {match.dogs === 'toxic' ? 'Toxic' : 'Non-toxic'}
+        </li>
+      </ul>
+      <p className="mt-2">{match.note}</p>
+    </Alert>
+  );
+}

--- a/frontend/src/services/petToxicityService.ts
+++ b/frontend/src/services/petToxicityService.ts
@@ -1,0 +1,42 @@
+/**
+ * Client for the public pet-toxicity lookup (GET /species/toxicity).
+ *
+ * This endpoint is unauthenticated by design — it powers the logged-out
+ * "is this plant safe for pets?" page — so we call it with a bare `fetch`
+ * against the same API base the axios client uses, rather than the shared
+ * `api` instance. That deliberately skips the auth-header + 401-refresh
+ * interceptors, which would otherwise try to refresh a (non-existent) session
+ * for an anonymous visitor.
+ */
+
+export type ToxicityVerdict = 'toxic' | 'non-toxic';
+
+export interface ToxicityMatch {
+  slug: string;
+  commonName: string;
+  scientificName: string;
+  cats: ToxicityVerdict;
+  dogs: ToxicityVerdict;
+  note: string;
+}
+
+interface ToxicityResponse {
+  query: string;
+  results: ToxicityMatch[];
+}
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:4000';
+
+export const petToxicityService = {
+  async lookup(query: string, signal?: AbortSignal): Promise<ToxicityMatch[]> {
+    const q = query.trim();
+    if (q.length < 2) return [];
+    const url = `${API_URL}/species/toxicity?q=${encodeURIComponent(q)}`;
+    const response = await fetch(url, { signal, headers: { Accept: 'application/json' } });
+    if (!response.ok) {
+      throw new Error(`Toxicity lookup failed (${response.status})`);
+    }
+    const data = (await response.json()) as ToxicityResponse;
+    return Array.isArray(data.results) ? data.results : [];
+  },
+};

--- a/frontend/tests/e2e/a11y.spec.ts
+++ b/frontend/tests/e2e/a11y.spec.ts
@@ -83,4 +83,10 @@ test.describe('A11y — public routes (WCAG 2.0/2.1/2.2 AA)', () => {
     await page.waitForLoadState('networkidle');
     await expectNoA11yViolations(page, 'forgot-password');
   });
+
+  test('pet-safe checker page', async ({ page }) => {
+    await page.goto('/pet-safe');
+    await page.waitForLoadState('networkidle');
+    await expectNoA11yViolations(page, 'pet-safe');
+  });
 });

--- a/frontend/tests/unit/features/PetSafePage.test.tsx
+++ b/frontend/tests/unit/features/PetSafePage.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { PetSafePage } from '@/features/petsafe/PetSafePage';
+import { petToxicityService, type ToxicityMatch } from '@/services/petToxicityService';
+
+vi.mock('@/services/petToxicityService', () => ({
+  petToxicityService: { lookup: vi.fn() },
+}));
+
+const lookup = vi.mocked(petToxicityService.lookup);
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/pet-safe']}>
+      <Routes>
+        <Route path="/pet-safe" element={<PetSafePage />} />
+        <Route path="/register" element={<div>Register Page</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+const snakePlant: ToxicityMatch = {
+  slug: 'snake-plant',
+  commonName: 'Snake plant',
+  scientificName: 'Dracaena trifasciata',
+  cats: 'toxic',
+  dogs: 'toxic',
+  note: 'Contains saponins; mildly toxic if eaten.',
+};
+
+const spiderPlant: ToxicityMatch = {
+  slug: 'spider-plant',
+  commonName: 'Spider plant',
+  scientificName: 'Chlorophytum comosum',
+  cats: 'non-toxic',
+  dogs: 'non-toxic',
+  note: 'Non-toxic to cats and dogs per the ASPCA.',
+};
+
+describe('PetSafePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders an accessible search input and a single h1', () => {
+    renderPage();
+    expect(
+      screen.getByRole('heading', { level: 1, name: /is this plant safe for pets/i })
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/plant or species name/i)).toBeInTheDocument();
+  });
+
+  it('shows a toxic verdict for cats and dogs after searching', async () => {
+    lookup.mockResolvedValue([snakePlant]);
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(screen.getByLabelText(/plant or species name/i), 'snake plant');
+
+    expect(await screen.findByText(/can be harmful to pets/i)).toBeInTheDocument();
+    expect(screen.getByText(/Dracaena trifasciata/)).toBeInTheDocument();
+    // Verdict lines for both species are present.
+    expect(screen.getByText(/Cats:/)).toBeInTheDocument();
+    expect(screen.getByText(/Dogs:/)).toBeInTheDocument();
+    await waitFor(() => expect(lookup).toHaveBeenCalledWith('snake plant', expect.anything()));
+  });
+
+  it('shows a pet-safe verdict for a non-toxic plant', async () => {
+    lookup.mockResolvedValue([spiderPlant]);
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(screen.getByLabelText(/plant or species name/i), 'spider plant');
+
+    expect(await screen.findByText(/is pet-safe/i)).toBeInTheDocument();
+  });
+
+  it('tells the user when nothing matches', async () => {
+    lookup.mockResolvedValue([]);
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(screen.getByLabelText(/plant or species name/i), 'notaplant');
+
+    expect(await screen.findByText(/no match yet/i)).toBeInTheDocument();
+  });
+
+  it('does not query for inputs shorter than two characters', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(screen.getByLabelText(/plant or species name/i), 'a');
+    // Give the debounce time to (not) fire.
+    await new Promise((r) => setTimeout(r, 400));
+    expect(lookup).not.toHaveBeenCalled();
+  });
+
+  it('links to sign-up via the call to action', () => {
+    renderPage();
+    const cta = screen.getByRole('link', { name: /get started/i });
+    expect(cta).toHaveAttribute('href', '/register');
+  });
+});

--- a/infrastructure/modules/api/main.tf
+++ b/infrastructure/modules/api/main.tf
@@ -619,7 +619,12 @@ locals {
 
     # --- species ---
     "GET /species/search" = { group = "species", auth = "jwt" }
-    "GET /species/{id}"   = { group = "species", auth = "jwt" }
+    # Public, no-auth pet-toxicity lookup behind the free "is this plant safe
+    # for pets?" page. Resolves a hand-curated static table (no Perenual call),
+    # serves no household data, and is cached publicly at the edge. Exact
+    # segment, so it wins over the {id} route below in HTTP API selection.
+    "GET /species/toxicity" = { group = "species", auth = "none" }
+    "GET /species/{id}"     = { group = "species", auth = "jwt" }
     # Thumbnail is fetched by <img> tags, which cannot attach an
     # Authorization header — behind the JWT authorizer every species image
     # 401s. Public by design: the handler only 302-redirects to an


### PR DESCRIPTION
## What

A free, no-signup **"Is this plant safe for pets?"** checker at `/pet-safe` — a top-of-funnel marketing page that answers high-intent *"is X toxic to cats/dogs"* searches and funnels visitors to sign up.

## Routes & files added

**Frontend**
- `frontend/src/features/petsafe/PetSafePage.tsx` — public `/pet-safe` page (search box → cat/dog verdict cards, a kids-and-pets caveat, sign-up CTA). Reuses `Alert`, `Input`, `BrandMark`, `Footer`; mobile-first; semantic single `<h1>`, labeled search input, `aria-live` polite results region.
- `frontend/src/services/petToxicityService.ts` — bare-`fetch` client for the public endpoint (skips the auth/refresh interceptors).
- `frontend/src/App.tsx` — adds the public `<Route path="/pet-safe">` next to `/care` and `/blog`.
- SEO: `<title>`/meta via `useMetaTags`; `/pet-safe` added to the sitemap generator (`scripts/build-sitemap.mjs`, regenerates `public/sitemap.xml`).

**Backend**
- `backend/src/models/petToxicity.ts` — hand-curated, ASPCA-grounded toxicity table (19 common houseplants incl. the dangerous lily/sago-palm cases) + a pure, deterministic `lookupToxicity()` matcher (name / scientific name / alias, exact→prefix→substring→word tiers).
- `GET /species/toxicity?q=` — new **public** (auth=none), rate-limited (60/min per IP), publicly-cacheable (`max-age=3600`) handler in `backend/src/handlers/species/handler.ts`. No auth, no Perenual call, no PII, read-only — mirrors the existing public `thumbnail` / `shared-plant` patterns.
- Wired into the species `createRouter`, the dev `local-server.ts` (registered before `/species/:id` so the exact segment wins), the Terraform route table (`infrastructure/modules/api/main.tf`, `auth = "none"`), and the OpenAPI spec (`docs/api-spec.yaml`).

## How toxicity is sourced

The public lookup resolves against the curated static table in `models/petToxicity.ts` — grounded in the ASPCA toxic/non-toxic plant database (the reference vets point owners to). This keeps the anonymous endpoint off the metered Perenual API entirely (cost + abuse surface) and lets each entry carry per-species cat/dog verdicts plus a plain-language caveat, which Perenual's coarse `poisonous_to_pets` boolean can't.

## Tests

- Frontend: full `npx vitest run` — **291 passed**. New `PetSafePage.test.tsx` covers toxic vs. pet-safe rendering, no-match copy, the <2-char debounce guard, and the CTA link.
- Backend: `npm test --prefix backend` — **866 passed**. New `species.test.ts` cases cover verdicts, alias/scientific-name matching, empty/short queries, and the IP rate limit. Route-parity + route-terraform-parity green; `scripts/check-api-spec.mjs` OK (91 routes).
- `npm run build --prefix frontend` green; size budgets within limits (initial JS 56.05 kB / 62 kB; page is a lazy 6 kB chunk). Lint + prettier clean (frontend & backend).
- Added a `/pet-safe` case to the axe a11y e2e suite (`tests/e2e/a11y.spec.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)