### PR TITLE
feat(sitter): no-account time-boxed sitter links to check off tasks

### DIFF
--- a/backend/src/handlers/households/handler.ts
+++ b/backend/src/handlers/households/handler.ts
@@ -14,9 +14,12 @@ import {
   CreateHouseholdInput,
   updateMemberRoleSchema,
   UpdateMemberRoleInput,
+  createSitterLinkSchema,
+  CreateSitterLinkInput,
 } from '../../models/schemas.js';
 import * as householdService from '../../services/householdService.js';
 import * as taskService from '../../services/taskService.js';
+import * as sitterService from '../../services/sitterService.js';
 import * as cognitoUsers from '../../services/cognitoUsers.js';
 import * as billing from '../../services/billing.js';
 import * as activity from '../../services/activity.js';
@@ -477,6 +480,124 @@ export const removeMember = createHandler(
   .use(requireHousehold())
   .use(requireAdmin());
 
+// ---------------------------------------------------------------------------
+// Plant-sitter links (authed management side)
+// ---------------------------------------------------------------------------
+//
+// A household member generates a no-account, time-boxed link before they
+// travel; a sitter opens it (the public /sitter/{token} routes live in the
+// tasks group) to see due tasks and check them off. These three routes are
+// the create / list / revoke surface, gated to household ADMINS — same posture
+// as invites, since both mint a credential that grants outside access.
+
+// POST /households/{id}/sitter-links
+//
+// Create a link and return its token/URL EXACTLY ONCE — subsequent list calls
+// never expose the token again (only the non-secret summary).
+export const createSitterLink = createHandler(
+  async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+    const { user } = event as AuthenticatedEvent;
+    const { validatedBody } = event as ValidatedEvent<CreateSitterLinkInput>;
+    const householdId = event.pathParameters?.id;
+
+    if (!householdId) {
+      throw createHttpError(400, 'Household ID is required');
+    }
+    if (user.householdId !== householdId) {
+      throw createHttpError(403, 'Access denied');
+    }
+
+    const baseUrl = process.env.FRONTEND_URL || process.env.ALLOWED_ORIGIN;
+    if (!baseUrl) {
+      throw createHttpError(
+        500,
+        'FRONTEND_URL / ALLOWED_ORIGIN must be set to generate sitter link URLs',
+        { expose: true }
+      );
+    }
+
+    const link = await sitterService.createSitterLink({
+      householdId,
+      createdBy: user.userId,
+      startsAt: validatedBody.startsAt ?? new Date().toISOString(),
+      expiresAt: validatedBody.expiresAt,
+      label: validatedBody.label ?? null,
+    });
+
+    audit('household.member_added', {
+      actorId: user.userId,
+      actorEmail: user.email,
+      householdId,
+      metadata: { stage: 'sitter_link_created', linkId: link.id, expiresAt: link.expiresAt },
+    });
+
+    // The token leaves the building exactly once, here.
+    return createdResponse({
+      ...sitterService.toSummary(link),
+      token: link.token,
+      url: `${baseUrl}/sit/${link.token}`,
+    });
+  }
+)
+  .use(authMiddleware())
+  .use(requireHousehold())
+  .use(requireAdmin())
+  .use(validateBody(createSitterLinkSchema));
+
+// GET /households/{id}/sitter-links
+//
+// List the household's links for management. NEVER returns tokens — only the
+// non-secret summary (id, window, status, label) so the UI can show + revoke.
+export const listSitterLinks = createHandler(
+  async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+    const { user } = event as AuthenticatedEvent;
+    const householdId = event.pathParameters?.id;
+    if (!householdId) {
+      throw createHttpError(400, 'Household ID is required');
+    }
+    if (user.householdId !== householdId) {
+      throw createHttpError(403, 'Access denied');
+    }
+    const links = await sitterService.listSitterLinks(householdId);
+    return successResponse(links.map(sitterService.toSummary));
+  }
+)
+  .use(authMiddleware())
+  .use(requireHousehold())
+  .use(requireAdmin());
+
+// DELETE /households/{id}/sitter-links/{linkId}
+//
+// Revoke a link by its non-secret id. Scoped to the household in the service,
+// so one household can never revoke another's link. Idempotent.
+export const revokeSitterLink = createHandler(
+  async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+    const { user } = event as AuthenticatedEvent;
+    const householdId = event.pathParameters?.id;
+    const linkId = event.pathParameters?.linkId;
+    if (!householdId || !linkId) {
+      throw createHttpError(400, 'Household ID and link ID are required');
+    }
+    if (user.householdId !== householdId) {
+      throw createHttpError(403, 'Access denied');
+    }
+    const revoked = await sitterService.revokeSitterLink(householdId, linkId);
+    if (!revoked) {
+      throw createHttpError(404, 'Sitter link not found');
+    }
+    audit('household.member_removed', {
+      actorId: user.userId,
+      actorEmail: user.email,
+      householdId,
+      metadata: { stage: 'sitter_link_revoked', linkId },
+    });
+    return noContentResponse();
+  }
+)
+  .use(authMiddleware())
+  .use(requireHousehold())
+  .use(requireAdmin());
+
 // Lambda entrypoint: dispatch this group's routes (see middleware/router.ts).
 export const handler = createRouter({
   'POST /households': createHousehold,
@@ -489,4 +610,7 @@ export const handler = createRouter({
   'GET /households/{id}/year-in-review': getYearInReview,
   'PUT /households/{householdId}/members/{userId}/role': updateMemberRole,
   'DELETE /households/{householdId}/members/{userId}': removeMember,
+  'POST /households/{id}/sitter-links': createSitterLink,
+  'GET /households/{id}/sitter-links': listSitterLinks,
+  'DELETE /households/{id}/sitter-links/{linkId}': revokeSitterLink,
 });

--- a/backend/src/handlers/tasks/handler.ts
+++ b/backend/src/handlers/tasks/handler.ts
@@ -4,7 +4,8 @@ import { createHandler } from '../../middleware/handler.js';
 import { createRouter } from '../../middleware/router.js';
 import { authMiddleware, AuthenticatedEvent, requireHousehold } from '../../middleware/auth.js';
 import { validateBody, ValidatedEvent } from '../../middleware/validation.js';
-import { userRateLimit } from '../../middleware/rateLimit.js';
+import { userRateLimit, rateLimit } from '../../middleware/rateLimit.js';
+import * as sitterService from '../../services/sitterService.js';
 import {
   createTaskSchema,
   updateTaskSchema,
@@ -523,6 +524,116 @@ export const listVacations = createHandler(
   .use(authMiddleware())
   .use(requireHousehold());
 
+// ---------------------------------------------------------------------------
+// Plant-sitter public endpoints (auth=none)
+// ---------------------------------------------------------------------------
+//
+// These two routes are reachable WITHOUT a Cognito JWT — a plant sitter opens
+// a link the household member shared and never signs in. The token in the path
+// is the only credential. Security posture:
+//   - No authMiddleware: anonymous by design.
+//   - Hard IP-scoped rate limit (token guessing / scraping brake). The token
+//     is 256-bit so it isn't guessable, but the limiter caps probe volume.
+//   - sitterService.getActiveLink enforces existence + active + within the
+//     [startsAt, expiresAt] window on EVERY call, and is generic on failure so
+//     the endpoint isn't a token-existence oracle (single 404 for any miss).
+//   - The response exposes ONLY the PII-free SitterTask projection — no member
+//     names/emails, no other households, no full plant records, no notes.
+
+// GET /sitter/{token}
+//
+// Validate the token, then return the household's due/overdue tasks in the
+// minimal sitter shape. 404 for an invalid/expired/revoked token (generic —
+// no oracle). The optional `label` is a friendly, non-PII household nickname
+// the creator chose; absent → a generic greeting on the frontend.
+export const getSitterView = createHandler(
+  async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+    const token = event.pathParameters?.token ?? '';
+    const link = await sitterService.getActiveLink(token);
+    if (!link) {
+      // Generic 404 for every failure mode (missing / expired / revoked /
+      // malformed) so a caller can't distinguish them and enumerate tokens.
+      throw createHttpError(404, 'This sitter link is invalid or has expired.');
+    }
+    const tasks = await taskService.getSitterTasks(link.householdId);
+    return successResponse({
+      label: link.label,
+      expiresAt: link.expiresAt,
+      tasks,
+    });
+  }
+  // No authMiddleware — anonymous sitter. 60/min per IP absorbs the
+  // page-load + a few completions while blunting token scraping.
+).use(rateLimit({ perWindowMs: 60_000, max: 60 }));
+
+// POST /sitter/{token}/tasks/{taskId}/complete
+//
+// Complete a single task on behalf of the sitter. We re-validate the token
+// (it may have expired/been revoked since the page loaded) AND confirm the
+// task belongs to THIS token's household before touching it — a sitter can
+// never reach across households even if they forge a taskId. Attributed as
+// "a plant sitter" (no real user). Idempotent via taskService.completeTask.
+export const completeSitterTask = createHandler(
+  async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+    const token = event.pathParameters?.token ?? '';
+    const taskId = event.pathParameters?.taskId ?? '';
+    if (!taskId) {
+      throw createHttpError(400, 'Task ID is required');
+    }
+
+    const link = await sitterService.getActiveLink(token);
+    if (!link) {
+      throw createHttpError(404, 'This sitter link is invalid or has expired.');
+    }
+
+    // Cross-household guard: the task MUST live in the token's household. We
+    // read it scoped to link.householdId, so a taskId from any other household
+    // simply isn't found here — there is no path to another partition.
+    const existing = await taskService.getTask(link.householdId, taskId);
+    if (!existing) {
+      throw createHttpError(404, 'Task not found');
+    }
+
+    // Synthetic, non-user actor. `completedByName` shows up in the activity
+    // feed / history exactly as the prompt asks ("a plant sitter"); actorId is
+    // a traceable, non-PII marker tying the action to the specific link.
+    const task = await taskService.completeTask(
+      link.householdId,
+      taskId,
+      `sitter:${link.id}`,
+      'a plant sitter'
+    );
+    if (!task) {
+      // Deleted between the read above and the write — treat as not found.
+      throw createHttpError(404, 'Task not found');
+    }
+
+    await recordActivity({
+      type: 'task.completed',
+      householdId: link.householdId,
+      actorId: `sitter:${link.id}`,
+      actorName: 'a plant sitter',
+      payload: {
+        taskId,
+        plantId: task.plantId,
+        plantName: task.plantName,
+        taskType: task.customType || task.type,
+        viaSitter: true,
+      },
+    });
+
+    // Return only the PII-free shape — the sitter never sees the full Task.
+    return successResponse({
+      taskId: task.id,
+      plantName: task.plantName,
+      taskType: task.customType || task.type,
+      dueDate: task.nextDue,
+      overdue: false,
+    });
+  }
+  // Anonymous; tighter than the read (write side). 30/min per IP.
+).use(rateLimit({ perWindowMs: 60_000, max: 30 }));
+
 // Lambda entrypoint: dispatch this group's routes (see middleware/router.ts).
 export const handler = createRouter({
   'GET /tasks': listTasks,
@@ -541,4 +652,6 @@ export const handler = createRouter({
   'PUT /tasks/vacation': setVacation,
   'DELETE /tasks/vacation/{userId}': deleteVacation,
   'GET /tasks/vacation': listVacations,
+  'GET /sitter/{token}': getSitterView,
+  'POST /sitter/{token}/tasks/{taskId}/complete': completeSitterTask,
 });

--- a/backend/src/local-server.ts
+++ b/backend/src/local-server.ts
@@ -14,6 +14,7 @@
 import express from 'express';
 import cors from 'cors';
 import { v4 as uuidv4 } from 'uuid';
+import { randomBytes } from 'node:crypto';
 import { z } from 'zod';
 import {
   signupSchema,
@@ -36,6 +37,7 @@ import {
   setVacationSchema,
   applyTemplateSchema,
   applyTemplateBulkSchema,
+  createSitterLinkSchema,
 } from './models/schemas.js';
 import { TEMPLATES } from './models/taskTemplates.js';
 import { PLANS } from './models/plans.js';
@@ -149,6 +151,20 @@ interface Task {
   notes: string | null;
   createdBy: string;
   createdAt: string;
+}
+
+/** Mirrors sitterService.SitterLink (SITTER#{token} row). The token is the
+ *  256-bit secret; id is the non-secret handle used by list/revoke. */
+interface SitterLink {
+  id: string;
+  token: string;
+  householdId: string;
+  createdBy: string;
+  createdAt: string;
+  startsAt: string;
+  expiresAt: string;
+  status: 'active' | 'revoked';
+  label: string | null;
 }
 
 interface PushSubscriptionRecord {
@@ -280,6 +296,7 @@ export const db = {
   phoneVerifications: new Map<string, PhoneVerificationRecord>(), // userId -> pending code
   recapSent: new Set<string>(), // `${householdId}|${year}` once-per-year markers
   pendingConfirmations: new Map<string, string>(), // email -> confirmation code
+  sitterLinks: new Map<string, SitterLink>(), // keyed by token (the secret)
 };
 
 export const seedHouseholdId = '550e8400-e29b-41d4-a716-446655440001';
@@ -304,6 +321,7 @@ export function resetDb(): void {
   db.phoneVerifications.clear();
   db.recapSent.clear();
   db.pendingConfirmations.clear();
+  db.sitterLinks.clear();
 
   const now = new Date().toISOString();
 
@@ -1056,6 +1074,106 @@ app.post('/households/:id/invites', authMiddleware, requireHousehold, requireAdm
 
   res.status(201).json(payload);
 });
+
+// --- Plant-sitter links (authed management) -------------------------------
+// Mirrors handlers/households/handler.ts: createSitterLink / listSitterLinks /
+// revokeSitterLink. Admin-gated, like invites.
+
+/** Non-secret view of a sitter link (no token). Mirrors toSummary. */
+function sitterSummary(link: SitterLink) {
+  const { token: _token, ...summary } = link;
+  void _token;
+  return summary;
+}
+
+// POST /households/:id/sitter-links
+app.post(
+  '/households/:id/sitter-links',
+  authMiddleware,
+  requireHousehold,
+  requireAdmin,
+  validateBody(createSitterLinkSchema),
+  (req, res) => {
+    const user = (req as any).user;
+    if (user.householdId !== req.params.id) {
+      return res.status(403).json({ message: 'Access denied' });
+    }
+    const body = (req as any).validatedBody;
+    const now = new Date();
+    const token = randomBytes(32).toString('hex'); // 256-bit, like the service
+    const link: SitterLink = {
+      id: uuidv4(),
+      token,
+      householdId: req.params.id,
+      createdBy: user.userId,
+      createdAt: now.toISOString(),
+      startsAt: body.startsAt ?? now.toISOString(),
+      expiresAt: body.expiresAt,
+      status: 'active',
+      label: body.label ?? null,
+    };
+    db.sitterLinks.set(token, link);
+
+    const baseUrl =
+      process.env.FRONTEND_URL ||
+      process.env.ALLOWED_ORIGIN ||
+      `http://localhost:${process.env.FRONTEND_PORT || 3000}`;
+
+    res.status(201).json({ ...sitterSummary(link), token, url: `${baseUrl}/sit/${token}` });
+  }
+);
+
+// GET /households/:id/sitter-links
+app.get(
+  '/households/:id/sitter-links',
+  authMiddleware,
+  requireHousehold,
+  requireAdmin,
+  (req, res) => {
+    const user = (req as any).user;
+    if (user.householdId !== req.params.id) {
+      return res.status(403).json({ message: 'Access denied' });
+    }
+    const links = [...db.sitterLinks.values()]
+      .filter((l) => l.householdId === req.params.id)
+      .sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1))
+      .map(sitterSummary);
+    res.json(links);
+  }
+);
+
+// DELETE /households/:id/sitter-links/:linkId
+app.delete(
+  '/households/:id/sitter-links/:linkId',
+  authMiddleware,
+  requireHousehold,
+  requireAdmin,
+  (req, res) => {
+    const user = (req as any).user;
+    if (user.householdId !== req.params.id) {
+      return res.status(403).json({ message: 'Access denied' });
+    }
+    const target = [...db.sitterLinks.values()].find(
+      (l) => l.householdId === req.params.id && l.id === req.params.linkId
+    );
+    if (!target) {
+      return res.status(404).json({ message: 'Sitter link not found' });
+    }
+    target.status = 'revoked';
+    res.status(204).end();
+  }
+);
+
+/** Token → link only if active and within [startsAt, expiresAt]. Generic
+ *  null on any miss, mirroring sitterService.getActiveLink. */
+function getActiveSitterLink(token: string): SitterLink | null {
+  if (!/^[0-9a-f]{64}$/.test(token)) return null;
+  const link = db.sitterLinks.get(token);
+  if (!link || link.status !== 'active') return null;
+  const nowIso = new Date().toISOString();
+  if (nowIso < link.startsAt || nowIso > link.expiresAt) return null;
+  return link;
+}
 
 /** Expiry-checked invite lookup; mirrors householdService.getInvite. */
 function getValidInvite(code: string): Invite | null {
@@ -1836,6 +1954,99 @@ app.get('/plants/shared/:code', (req, res) => {
     plant: share.plantSnapshot,
     householdName: household?.name ?? 'A Family Greenhouse household',
     expiresAt: share.expiresAt,
+  });
+});
+
+// --- Plant-sitter PUBLIC endpoints (no auth) ------------------------------
+// Mirrors handlers/tasks/handler.ts: getSitterView / completeSitterTask. The
+// 256-bit token in the path is the only credential; we validate it on every
+// call and expose ONLY the PII-free due-task projection.
+
+/** PII-free due/overdue tasks for a household. Mirrors taskService.getSitterTasks:
+ *  due within 7 days OR overdue, active plants only, minimal fields. */
+function sitterTasksFor(householdId: string) {
+  const now = new Date();
+  const cutoff = new Date(now);
+  cutoff.setDate(cutoff.getDate() + 7);
+  const cutoffIso = cutoff.toISOString();
+  const nowIso = now.toISOString();
+  return [...db.tasks.values()]
+    .filter((t) => t.householdId === householdId)
+    .filter((t) => (db.plants.get(t.plantId)?.status ?? 'active') === 'active')
+    .filter((t) => t.nextDue <= cutoffIso)
+    .sort((a, b) => new Date(a.nextDue).getTime() - new Date(b.nextDue).getTime())
+    .map((t) => ({
+      taskId: t.id,
+      plantName: t.plantName,
+      taskType: t.customType || t.type,
+      dueDate: t.nextDue,
+      overdue: t.nextDue < nowIso,
+    }));
+}
+
+// GET /sitter/:token
+app.get('/sitter/:token', (req, res) => {
+  const link = getActiveSitterLink(req.params.token);
+  if (!link) {
+    return res.status(404).json({ message: 'This sitter link is invalid or has expired.' });
+  }
+  res.json({
+    label: link.label,
+    expiresAt: link.expiresAt,
+    tasks: sitterTasksFor(link.householdId),
+  });
+});
+
+// POST /sitter/:token/tasks/:taskId/complete
+app.post('/sitter/:token/tasks/:taskId/complete', (req, res) => {
+  const link = getActiveSitterLink(req.params.token);
+  if (!link) {
+    return res.status(404).json({ message: 'This sitter link is invalid or has expired.' });
+  }
+  const task = db.tasks.get(req.params.taskId);
+  // Cross-household guard: the task must live in the token's household.
+  if (!task || task.householdId !== link.householdId) {
+    return res.status(404).json({ message: 'Task not found' });
+  }
+
+  const now = new Date();
+  const nextDue = new Date(now);
+  nextDue.setDate(nextDue.getDate() + task.frequency);
+  task.lastCompleted = now.toISOString();
+  task.nextDue = nextDue.toISOString();
+
+  const completionId = uuidv4();
+  db.completions.set(completionId, {
+    id: completionId,
+    householdId: task.householdId,
+    plantId: task.plantId,
+    taskId: task.id,
+    taskType: task.customType || task.type,
+    completedBy: `sitter:${link.id}`,
+    completedByName: 'a plant sitter',
+    completedAt: now.toISOString(),
+    notes: null,
+  });
+  recordActivity({
+    type: 'task.completed',
+    householdId: task.householdId,
+    actorId: `sitter:${link.id}`,
+    actorName: 'a plant sitter',
+    payload: {
+      taskId: task.id,
+      plantId: task.plantId,
+      plantName: task.plantName,
+      taskType: task.customType || task.type,
+      viaSitter: true,
+    },
+  });
+
+  res.json({
+    taskId: task.id,
+    plantName: task.plantName,
+    taskType: task.customType || task.type,
+    dueDate: task.nextDue,
+    overdue: false,
   });
 });
 

--- a/backend/src/models/schemas.ts
+++ b/backend/src/models/schemas.ts
@@ -168,6 +168,36 @@ export const setVacationSchema = z
     }
   });
 
+// Sitter link (no-account, time-boxed plant-sitting access). The creator sets
+// an explicit [startsAt, expiresAt] coverage window; the link is rejected
+// outside it on every public call. Window is capped so a stray click can't
+// mint a year-long public link. `label` is an optional, non-PII friendly name
+// shown to the sitter (e.g. "The Smiths' plants") — never a member name/email.
+const MAX_SITTER_DAYS = 60;
+export const createSitterLinkSchema = z
+  .object({
+    startsAt: z.string().datetime().optional(),
+    expiresAt: z.string().datetime(),
+    label: z.string().trim().max(60).optional(),
+  })
+  .superRefine((val, ctx) => {
+    const start = val.startsAt ? Date.parse(val.startsAt) : Date.now();
+    const end = Date.parse(val.expiresAt);
+    if (end <= start) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['expiresAt'],
+        message: 'expiresAt must be in the future (after startsAt)',
+      });
+    } else if (end - start > MAX_SITTER_DAYS * 24 * 60 * 60 * 1000) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['expiresAt'],
+        message: `Sitter link cannot last longer than ${MAX_SITTER_DAYS} days`,
+      });
+    }
+  });
+
 export const applyTemplateSchema = z.object({
   templateId: z.string().min(1).max(80),
 });
@@ -245,4 +275,5 @@ export type CompleteTaskInput = z.infer<typeof completeTaskSchema>;
 export type SnoozeTaskInput = z.infer<typeof snoozeTaskSchema>;
 export type SnoozeReason = z.infer<typeof snoozeReasonEnum>;
 export type SetVacationInput = z.infer<typeof setVacationSchema>;
+export type CreateSitterLinkInput = z.infer<typeof createSitterLinkSchema>;
 export type TaskFilters = z.infer<typeof taskFiltersSchema>;

--- a/backend/src/services/sitterService.ts
+++ b/backend/src/services/sitterService.ts
@@ -1,0 +1,210 @@
+/**
+ * Plant-sitter links: a no-account, time-boxed way to let a neighbour or
+ * friend see a household's due tasks and check them off while the household
+ * is away — without creating an account or joining the household.
+ *
+ * Security model (mirrors householdService invites, hardened further):
+ *   - The token is 256 bits of CSPRNG entropy (crypto.randomBytes(32), hex).
+ *     That's double the 128-bit invite code and far beyond brute-force even
+ *     from a leaked log line or DDB dump. The token is the ONLY secret — it
+ *     grants exactly one household's due-task view + completion, nothing else.
+ *   - Rows carry a DynamoDB `ttl` so expired links are swept automatically;
+ *     `getActiveLink` ALSO re-checks `expiresAt` and `status` on every read so
+ *     a not-yet-swept row can never be honoured past its window (defence in
+ *     depth — never rely on the TTL sweeper for correctness).
+ *   - Links are revocable: `status: 'revoked'` short-circuits validation
+ *     immediately, before the TTL would otherwise expire the row.
+ *   - Validation is generic: any failure (missing / expired / revoked) returns
+ *     null and the handler answers a single 404/410, so the public endpoint
+ *     can't be used as a token-existence oracle.
+ *
+ * Row shape: PK = `SITTER#{token}`, SK = 'METADATA'. The token is the
+ * partition key directly (same as INVITE#{code}) — a sitter request is a
+ * single GetItem, no scan, no enumeration surface.
+ */
+import { PutCommand, GetCommand, QueryCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
+import { randomBytes } from 'node:crypto';
+import { v4 as uuid } from 'uuid';
+import { dynamodb, TABLE_NAME } from '../utils/dynamodb.js';
+import { DynamoDBItem } from '../models/types.js';
+
+export type SitterLinkStatus = 'active' | 'revoked';
+
+export interface SitterLink {
+  /** Opaque id used in the management API (list/revoke). NOT the secret. */
+  id: string;
+  /** The 256-bit secret token. Returned to the creator exactly once. */
+  token: string;
+  householdId: string;
+  createdBy: string;
+  createdAt: string;
+  /** Start of the creator-set coverage window (ISO). */
+  startsAt: string;
+  /** End of the coverage window (ISO). Enforced on every public call. */
+  expiresAt: string;
+  status: SitterLinkStatus;
+  /** Friendly, non-PII label the sitter sees (e.g. "The Smiths' plants"). */
+  label: string | null;
+}
+
+/** A sitter link as exposed to the CREATING household member (never the token
+ *  after creation — only `create` returns it). */
+export interface SitterLinkSummary {
+  id: string;
+  householdId: string;
+  createdBy: string;
+  createdAt: string;
+  startsAt: string;
+  expiresAt: string;
+  status: SitterLinkStatus;
+  label: string | null;
+}
+
+// A buffer past expiresAt before the TTL sweeper may delete the row, so a
+// clock-skewed sweep can't drop a link that reads still-active. Reads always
+// re-check expiresAt, so the buffer is invisible. Mirrors the vacation TTL.
+const TTL_BUFFER_MS = 3 * 24 * 60 * 60 * 1000;
+
+function itemToLink(item: Record<string, unknown>): SitterLink {
+  return {
+    id: item.id as string,
+    token: item.token as string,
+    householdId: item.householdId as string,
+    createdBy: item.createdBy as string,
+    createdAt: item.createdAt as string,
+    startsAt: item.startsAt as string,
+    expiresAt: item.expiresAt as string,
+    status: item.status as SitterLinkStatus,
+    label: (item.label as string | null) ?? null,
+  };
+}
+
+/** Strip the secret token before handing a link to the creating member. */
+export function toSummary(link: SitterLink): SitterLinkSummary {
+  return {
+    id: link.id,
+    householdId: link.householdId,
+    createdBy: link.createdBy,
+    createdAt: link.createdAt,
+    startsAt: link.startsAt,
+    expiresAt: link.expiresAt,
+    status: link.status,
+    label: link.label,
+  };
+}
+
+export async function createSitterLink(input: {
+  householdId: string;
+  createdBy: string;
+  startsAt: string;
+  expiresAt: string;
+  label: string | null;
+}): Promise<SitterLink> {
+  // 256-bit CSPRNG token — 64 hex chars. randomBytes draws from the OS CSPRNG;
+  // do NOT swap this for uuid()/Math.random (predictable / lower entropy).
+  const token = randomBytes(32).toString('hex');
+  const id = uuid();
+  const now = new Date().toISOString();
+
+  const link: SitterLink = {
+    id,
+    token,
+    householdId: input.householdId,
+    createdBy: input.createdBy,
+    createdAt: now,
+    startsAt: input.startsAt,
+    expiresAt: input.expiresAt,
+    status: 'active',
+    label: input.label,
+  };
+
+  const item: DynamoDBItem = {
+    PK: `SITTER#${token}`,
+    SK: 'METADATA',
+    // Mirror onto GSI1 so the household can list its own links in one query
+    // (GSI1PK = HOUSEHOLD#{id}#SITTER, newest-first by createdAt).
+    GSI1PK: `HOUSEHOLD#${input.householdId}#SITTER`,
+    GSI1SK: now,
+    entityType: 'SitterLink',
+    ...link,
+    ttl: Math.floor((Date.parse(input.expiresAt) + TTL_BUFFER_MS) / 1000),
+  };
+
+  await dynamodb.send(new PutCommand({ TableName: TABLE_NAME, Item: item }));
+  return link;
+}
+
+/**
+ * Resolve a token to its link ONLY if it is currently usable: it exists, is
+ * active (not revoked), and now is within [startsAt, expiresAt]. Any other
+ * state returns null so the caller answers a single generic 404/410 and the
+ * endpoint can't be used to probe which tokens exist.
+ */
+export async function getActiveLink(
+  token: string,
+  now: Date = new Date()
+): Promise<SitterLink | null> {
+  // Defensive length/charset gate: a token that can't be one of ours never
+  // hits DynamoDB. 64 lowercase hex chars only.
+  if (!/^[0-9a-f]{64}$/.test(token)) return null;
+
+  const result = await dynamodb.send(
+    new GetCommand({
+      TableName: TABLE_NAME,
+      Key: { PK: `SITTER#${token}`, SK: 'METADATA' },
+    })
+  );
+  if (!result.Item) return null;
+
+  const link = itemToLink(result.Item);
+  if (link.status !== 'active') return null;
+  const nowIso = now.toISOString();
+  if (nowIso < link.startsAt) return null; // window not started yet
+  if (nowIso > link.expiresAt) return null; // expired
+  return link;
+}
+
+/** All links for a household (active + revoked + not-yet-expired), newest
+ *  first, for the management UI. Tokens are included so the service layer can
+ *  return them; the HANDLER strips them via toSummary before responding. */
+export async function listSitterLinks(householdId: string): Promise<SitterLink[]> {
+  const result = await dynamodb.send(
+    new QueryCommand({
+      TableName: TABLE_NAME,
+      IndexName: 'GSI1',
+      KeyConditionExpression: 'GSI1PK = :pk',
+      ExpressionAttributeValues: { ':pk': `HOUSEHOLD#${householdId}#SITTER` },
+      ScanIndexForward: false,
+      Limit: 100,
+    })
+  );
+  return (result.Items ?? []).map(itemToLink);
+}
+
+/**
+ * Revoke a link by its opaque id, scoped to the household so one household can
+ * never revoke another's link. Returns false when no matching active/revoked
+ * row exists (→ 404). Idempotent: revoking an already-revoked link succeeds.
+ *
+ * We look the row up via the household's GSI1 partition (so the caller only
+ * needs the non-secret id, never the token) and then conditionally update the
+ * base row.
+ */
+export async function revokeSitterLink(householdId: string, id: string): Promise<boolean> {
+  const links = await listSitterLinks(householdId);
+  const target = links.find((l) => l.id === id);
+  if (!target) return false;
+
+  await dynamodb.send(
+    new UpdateCommand({
+      TableName: TABLE_NAME,
+      Key: { PK: `SITTER#${target.token}`, SK: 'METADATA' },
+      UpdateExpression: 'SET #status = :revoked',
+      ExpressionAttributeNames: { '#status': 'status' },
+      ExpressionAttributeValues: { ':revoked': 'revoked' },
+      // Guard against a row deleted (TTL) between the list read and this write.
+      ConditionExpression: 'attribute_exists(PK)',
+    })
+  );
+  return true;
+}

--- a/backend/src/services/taskService.ts
+++ b/backend/src/services/taskService.ts
@@ -220,6 +220,55 @@ export async function getTasks(
   return annotateTasksWithCoverage(tasks, await getActiveVacationMap(householdId));
 }
 
+/**
+ * The minimal, PII-free task shape a plant-sitter sees. Deliberately NOT the
+ * full Task: no assignee names/ids, no createdBy, no notes (notes can contain
+ * household-private context), no householdId. Just enough to do the job:
+ * which plant, what to do, when it's due.
+ */
+export interface SitterTask {
+  taskId: string;
+  plantName: string;
+  taskType: string;
+  dueDate: string;
+  /** True when dueDate is in the past — drives the "overdue" badge. */
+  overdue: boolean;
+}
+
+/**
+ * Due/overdue tasks for the plant-sitter view, projected to the PII-free
+ * SitterTask shape. "Due" means due within the next `dueWithinDays` days OR
+ * already overdue — the sitter should see everything that needs doing during
+ * their window, not just strictly-overdue items. Tasks for died/gave_away
+ * plants are filtered out (getTasks already does this). The returned objects
+ * expose ONLY plant common name, task type, due date, and id — see SitterTask.
+ */
+export async function getSitterTasks(
+  householdId: string,
+  now: Date = new Date(),
+  dueWithinDays = 7
+): Promise<SitterTask[]> {
+  const cutoff = new Date(now);
+  cutoff.setDate(cutoff.getDate() + dueWithinDays);
+  const cutoffIso = cutoff.toISOString();
+  const nowIso = now.toISOString();
+
+  // getTasks already lifecycle-filters (active plants only) and returns the
+  // denormalized plantName + customType we need — reuse it rather than
+  // re-deriving the projection.
+  const tasks = await getTasks(householdId);
+  return tasks
+    .filter((t) => t.nextDue <= cutoffIso)
+    .sort((a, b) => new Date(a.nextDue).getTime() - new Date(b.nextDue).getTime())
+    .map((t) => ({
+      taskId: t.id,
+      plantName: t.plantName,
+      taskType: t.customType || t.type,
+      dueDate: t.nextDue,
+      overdue: t.nextDue < nowIso,
+    }));
+}
+
 export async function getUpcomingTasks(householdId: string): Promise<TaskWithCoverage[]> {
   const cutoff = new Date();
   cutoff.setDate(cutoff.getDate() + 7);

--- a/backend/tests/integration/sitter-links.test.ts
+++ b/backend/tests/integration/sitter-links.test.ts
@@ -1,0 +1,232 @@
+/**
+ * End-to-end flows for no-account, time-boxed plant-sitter links against the
+ * mock dev server (which mirrors the production handlers — see local-server.ts
+ * contract note). Covers what the unit tests can't: the full create → public
+ * view → public complete → revoke lifecycle, expiry + revocation rejection,
+ * cross-household task rejection, the no-PII guarantee of the public payload,
+ * and that the secret token is returned exactly once.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import request from 'supertest';
+import { app, db, resetDb, seedHouseholdId, seedTaskId } from '../../src/local-server';
+
+const SEED_EMAIL = 'test@example.com';
+const SEED_PASSWORD = 'password123';
+
+async function loginAsSeed(): Promise<string> {
+  const res = await request(app)
+    .post('/auth/login')
+    .send({ email: SEED_EMAIL, password: SEED_PASSWORD });
+  expect(res.status).toBe(200);
+  return res.body.accessToken as string;
+}
+
+/** Signup → confirm → login → create an own household; returns the token. */
+async function createUserWithHousehold(email: string, householdName: string): Promise<string> {
+  const signup = await request(app)
+    .post('/auth/signup')
+    .send({ email, password: 'password-123', name: 'Neighbor' });
+  expect(signup.status).toBe(201);
+  await request(app).post('/auth/confirm').send({ email, code: '123456' });
+  const login = await request(app).post('/auth/login').send({ email, password: 'password-123' });
+  expect(login.status).toBe(200);
+  const token = login.body.accessToken as string;
+  const hh = await request(app)
+    .post('/households')
+    .set('Authorization', `Bearer ${token}`)
+    .send({ name: householdName });
+  expect(hh.status).toBe(201);
+  return token;
+}
+
+function inFuture(days: number): string {
+  return new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+beforeEach(() => {
+  resetDb();
+});
+
+const originalLog = console.log;
+beforeEach(() => {
+  console.log = () => {};
+});
+afterEach(() => {
+  console.log = originalLog;
+});
+
+describe('sitter link creation (authed)', () => {
+  it('creates a link and returns the token + URL exactly once', async () => {
+    const token = await loginAsSeed();
+    const res = await request(app)
+      .post(`/households/${seedHouseholdId}/sitter-links`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ expiresAt: inFuture(7), label: "The Smiths' plants" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.token).toMatch(/^[0-9a-f]{64}$/); // 256-bit hex
+    expect(res.body.url).toContain(`/sit/${res.body.token}`);
+    expect(res.body.status).toBe('active');
+    expect(res.body.label).toBe("The Smiths' plants");
+
+    // The list view never re-exposes the token.
+    const list = await request(app)
+      .get(`/households/${seedHouseholdId}/sitter-links`)
+      .set('Authorization', `Bearer ${token}`);
+    expect(list.status).toBe(200);
+    expect(list.body).toHaveLength(1);
+    expect(list.body[0].token).toBeUndefined();
+    expect(list.body[0].id).toBe(res.body.id);
+  });
+
+  it('rejects an over-long window (> 60 days)', async () => {
+    const token = await loginAsSeed();
+    const res = await request(app)
+      .post(`/households/${seedHouseholdId}/sitter-links`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ expiresAt: inFuture(120) });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects creation for a household the caller is not in (403)', async () => {
+    const other = await createUserWithHousehold('neighbor@example.com', 'Neighbor House');
+    const res = await request(app)
+      .post(`/households/${seedHouseholdId}/sitter-links`)
+      .set('Authorization', `Bearer ${other}`)
+      .send({ expiresAt: inFuture(7) });
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('public sitter view (no auth)', () => {
+  async function createLink(): Promise<string> {
+    const token = await loginAsSeed();
+    const res = await request(app)
+      .post(`/households/${seedHouseholdId}/sitter-links`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ expiresAt: inFuture(7), label: 'Our plants' });
+    return res.body.token as string;
+  }
+
+  it('returns the due task list with NO PII and no auth header', async () => {
+    const sitterToken = await createLink();
+    const res = await request(app).get(`/sitter/${sitterToken}`); // no Authorization
+    expect(res.status).toBe(200);
+
+    expect(res.body.label).toBe('Our plants');
+    expect(Array.isArray(res.body.tasks)).toBe(true);
+    expect(res.body.tasks.length).toBeGreaterThan(0);
+
+    const task = res.body.tasks[0];
+    // Only the PII-free projection — exactly these keys, nothing more.
+    expect(Object.keys(task).sort()).toEqual(
+      ['dueDate', 'overdue', 'plantName', 'taskType', 'taskId'].sort()
+    );
+    expect(task.plantName).toBe('Monstera');
+    expect(task.taskType).toBe('water');
+
+    // Assert the whole payload carries no member identity / household id / notes.
+    const blob = JSON.stringify(res.body);
+    expect(blob).not.toContain(SEED_EMAIL);
+    expect(blob).not.toContain('Test User'); // seed member name
+    expect(blob).not.toContain(seedHouseholdId);
+    expect(blob).not.toMatch(/assignedTo|completedBy|createdBy|notes|email/);
+  });
+
+  it('404s on an unknown / malformed token (no enumeration oracle)', async () => {
+    const bad = await request(app).get('/sitter/not-a-real-token');
+    expect(bad.status).toBe(404);
+    const wrongLen = await request(app).get(`/sitter/${'a'.repeat(64)}`);
+    expect(wrongLen.status).toBe(404);
+    // The two messages are identical — no way to tell "malformed" from "absent".
+    expect(bad.body.message).toBe(wrongLen.body.message);
+  });
+
+  it('410-equivalent: rejects an expired link', async () => {
+    const sitterToken = await createLink();
+    // Force expiry by rewinding the stored window into the past.
+    const link = db.sitterLinks.get(sitterToken)!;
+    link.expiresAt = new Date(Date.now() - 1000).toISOString();
+    const res = await request(app).get(`/sitter/${sitterToken}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects a link whose window has not started yet', async () => {
+    const sitterToken = await createLink();
+    const link = db.sitterLinks.get(sitterToken)!;
+    link.startsAt = inFuture(2);
+    const res = await request(app).get(`/sitter/${sitterToken}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects a revoked link', async () => {
+    const adminToken = await loginAsSeed();
+    const created = await request(app)
+      .post(`/households/${seedHouseholdId}/sitter-links`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ expiresAt: inFuture(7) });
+    const sitterToken = created.body.token as string;
+    const linkId = created.body.id as string;
+
+    const del = await request(app)
+      .delete(`/households/${seedHouseholdId}/sitter-links/${linkId}`)
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(del.status).toBe(204);
+
+    const res = await request(app).get(`/sitter/${sitterToken}`);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('public sitter completion (no auth)', () => {
+  async function createLink(): Promise<string> {
+    const adminToken = await loginAsSeed();
+    const res = await request(app)
+      .post(`/households/${seedHouseholdId}/sitter-links`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ expiresAt: inFuture(7) });
+    return res.body.token as string;
+  }
+
+  it('completes a task and attributes it to "a plant sitter"', async () => {
+    const sitterToken = await createLink();
+    const res = await request(app).post(`/sitter/${sitterToken}/tasks/${seedTaskId}/complete`);
+    expect(res.status).toBe(200);
+    expect(res.body.taskId).toBe(seedTaskId);
+    expect(res.body.overdue).toBe(false);
+
+    // A completion + activity row landed, attributed to the sitter (no member).
+    const completion = [...db.completions.values()].find((c) => c.taskId === seedTaskId);
+    expect(completion?.completedByName).toBe('a plant sitter');
+    expect(completion?.completedBy).toMatch(/^sitter:/);
+  });
+
+  it('rejects completing a task from ANOTHER household (cross-household guard)', async () => {
+    // A second household with its own plant + task.
+    const otherToken = await createUserWithHousehold('other@example.com', 'Other House');
+    const plant = await request(app)
+      .post('/plants')
+      .set('Authorization', `Bearer ${otherToken}`)
+      .send({ name: 'Fern' });
+    const otherTask = await request(app)
+      .post('/tasks')
+      .set('Authorization', `Bearer ${otherToken}`)
+      .send({ plantId: plant.body.id, type: 'water', frequency: 7 });
+    expect(otherTask.status).toBe(201);
+
+    // A sitter link scoped to the SEED household must not be able to complete
+    // the OTHER household's task.
+    const sitterToken = await createLink();
+    const res = await request(app).post(
+      `/sitter/${sitterToken}/tasks/${otherTask.body.id}/complete`
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('404s completion on an expired link', async () => {
+    const sitterToken = await createLink();
+    db.sitterLinks.get(sitterToken)!.expiresAt = new Date(Date.now() - 1000).toISOString();
+    const res = await request(app).post(`/sitter/${sitterToken}/tasks/${seedTaskId}/complete`);
+    expect(res.status).toBe(404);
+  });
+});

--- a/backend/tests/unit/handlers/sitter.test.ts
+++ b/backend/tests/unit/handlers/sitter.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Unit tests for the PUBLIC (auth=none) plant-sitter Lambda handlers
+ * (handlers/tasks/handler.ts: getSitterView / completeSitterTask). These run
+ * the real middy stack — so unlike the local-server integration tests, they
+ * exercise the IP rate-limit middleware and confirm the handlers work with NO
+ * Cognito authorizer on the event (genuinely anonymous).
+ *
+ * sitterService + taskService are mocked so we test the handler wiring (token
+ * validation gate, cross-household guard, PII-free projection, rate limit) in
+ * isolation.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from 'aws-lambda';
+
+vi.mock('../../../src/services/sitterService.js');
+vi.mock('../../../src/services/taskService.js');
+vi.mock('../../../src/services/activity.js', () => ({ recordActivity: vi.fn(async () => {}) }));
+
+const ctx = {} as Context;
+
+/** Anonymous event — NO authorizer claims, as the gateway delivers for an
+ *  auth=none route. Each call uses a unique IP unless one is pinned, so the
+ *  per-route IP rate-limit buckets don't bleed across tests. */
+function anonEvent(
+  overrides: Partial<APIGatewayProxyEvent> = {},
+  ip = `10.0.0.${Math.floor(Math.random() * 250) + 1}`
+): APIGatewayProxyEvent {
+  return {
+    body: null,
+    headers: {},
+    httpMethod: 'GET',
+    isBase64Encoded: false,
+    multiValueHeaders: {},
+    multiValueQueryStringParameters: null,
+    path: '/sitter/x',
+    pathParameters: {},
+    queryStringParameters: null,
+    requestContext: {
+      identity: { sourceIp: ip },
+    } as APIGatewayProxyEvent['requestContext'],
+    resource: '/',
+    stageVariables: null,
+    ...overrides,
+  };
+}
+
+const TOKEN = 'a'.repeat(64);
+function activeLink(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'link-1',
+    token: TOKEN,
+    householdId: 'hh-1',
+    createdBy: 'u1',
+    createdAt: 'now',
+    startsAt: 'now',
+    expiresAt: '2999-01-01T00:00:00.000Z',
+    status: 'active',
+    label: 'Our plants',
+    ...overrides,
+  };
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  const { __resetRateLimitForTests } = await import('../../../src/middleware/rateLimit.js');
+  __resetRateLimitForTests();
+});
+
+describe('GET /sitter/{token} (public)', () => {
+  it('returns the PII-free due-task list for a valid token, no auth required', async () => {
+    const { getActiveLink } = await import('../../../src/services/sitterService.js');
+    const { getSitterTasks } = await import('../../../src/services/taskService.js');
+    vi.mocked(getActiveLink).mockResolvedValueOnce(activeLink() as never);
+    vi.mocked(getSitterTasks).mockResolvedValueOnce([
+      { taskId: 't1', plantName: 'Monstera', taskType: 'water', dueDate: 'now', overdue: true },
+    ] as never);
+
+    const { getSitterView } = await import('../../../src/handlers/tasks/handler.js');
+    const res = (await getSitterView(
+      anonEvent({ path: '/sitter/' + TOKEN, pathParameters: { token: TOKEN } }),
+      ctx,
+      () => {}
+    )) as APIGatewayProxyResult;
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.label).toBe('Our plants');
+    expect(body.tasks[0]).toEqual({
+      taskId: 't1',
+      plantName: 'Monstera',
+      taskType: 'water',
+      dueDate: 'now',
+      overdue: true,
+    });
+    // No member identity / household id leaked anywhere in the payload.
+    expect(res.body).not.toContain('hh-1');
+    expect(res.body).not.toContain('createdBy');
+  });
+
+  it('404s (generic) on an invalid/expired/revoked token', async () => {
+    const { getActiveLink } = await import('../../../src/services/sitterService.js');
+    vi.mocked(getActiveLink).mockResolvedValueOnce(null);
+    const { getSitterView } = await import('../../../src/handlers/tasks/handler.js');
+    const res = (await getSitterView(
+      anonEvent({ pathParameters: { token: 'bad' } }),
+      ctx,
+      () => {}
+    )) as APIGatewayProxyResult;
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('applies an IP rate limit (429 after 60 requests/min)', async () => {
+    const { getActiveLink } = await import('../../../src/services/sitterService.js');
+    const { getSitterTasks } = await import('../../../src/services/taskService.js');
+    vi.mocked(getActiveLink).mockResolvedValue(activeLink() as never);
+    vi.mocked(getSitterTasks).mockResolvedValue([] as never);
+    const { getSitterView } = await import('../../../src/handlers/tasks/handler.js');
+
+    // Pin one IP so all requests share a bucket.
+    const event = () =>
+      anonEvent({ path: '/sitter/' + TOKEN, pathParameters: { token: TOKEN } }, '203.0.113.9');
+    for (let i = 0; i < 60; i++) {
+      const r = (await getSitterView(event(), ctx, () => {})) as APIGatewayProxyResult;
+      expect(r.statusCode).toBe(200);
+    }
+    const limited = (await getSitterView(event(), ctx, () => {})) as APIGatewayProxyResult;
+    expect(limited.statusCode).toBe(429);
+  });
+});
+
+describe('POST /sitter/{token}/tasks/{taskId}/complete (public)', () => {
+  it('completes a task in the token household and returns the PII-free shape', async () => {
+    const { getActiveLink } = await import('../../../src/services/sitterService.js');
+    const { getTask, completeTask } = await import('../../../src/services/taskService.js');
+    vi.mocked(getActiveLink).mockResolvedValueOnce(activeLink() as never);
+    vi.mocked(getTask).mockResolvedValueOnce({ id: 't1', householdId: 'hh-1' } as never);
+    vi.mocked(completeTask).mockResolvedValueOnce({
+      id: 't1',
+      plantId: 'p1',
+      plantName: 'Monstera',
+      type: 'water',
+      customType: null,
+      nextDue: '2999-01-02T00:00:00.000Z',
+    } as never);
+
+    const { completeSitterTask } = await import('../../../src/handlers/tasks/handler.js');
+    const res = (await completeSitterTask(
+      anonEvent({
+        httpMethod: 'POST',
+        path: `/sitter/${TOKEN}/tasks/t1/complete`,
+        pathParameters: { token: TOKEN, taskId: 't1' },
+      }),
+      ctx,
+      () => {}
+    )) as APIGatewayProxyResult;
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body).toEqual({
+      taskId: 't1',
+      plantName: 'Monstera',
+      taskType: 'water',
+      dueDate: '2999-01-02T00:00:00.000Z',
+      overdue: false,
+    });
+
+    // The completion was attributed to "a plant sitter", not a real user.
+    expect(vi.mocked(completeTask)).toHaveBeenCalledWith(
+      'hh-1',
+      't1',
+      'sitter:link-1',
+      'a plant sitter'
+    );
+  });
+
+  it('rejects a task that belongs to ANOTHER household (cross-household guard → 404)', async () => {
+    const { getActiveLink } = await import('../../../src/services/sitterService.js');
+    const { getTask, completeTask } = await import('../../../src/services/taskService.js');
+    vi.mocked(getActiveLink).mockResolvedValueOnce(activeLink() as never);
+    // getTask is scoped to the token's household; a foreign task simply isn't found.
+    vi.mocked(getTask).mockResolvedValueOnce(null);
+
+    const { completeSitterTask } = await import('../../../src/handlers/tasks/handler.js');
+    const res = (await completeSitterTask(
+      anonEvent({
+        httpMethod: 'POST',
+        pathParameters: { token: TOKEN, taskId: 'foreign-task' },
+      }),
+      ctx,
+      () => {}
+    )) as APIGatewayProxyResult;
+
+    expect(res.statusCode).toBe(404);
+    expect(vi.mocked(completeTask)).not.toHaveBeenCalled();
+  });
+
+  it('404s when the token is expired/revoked (re-validated on the write path)', async () => {
+    const { getActiveLink } = await import('../../../src/services/sitterService.js');
+    vi.mocked(getActiveLink).mockResolvedValueOnce(null);
+    const { completeSitterTask } = await import('../../../src/handlers/tasks/handler.js');
+    const res = (await completeSitterTask(
+      anonEvent({ httpMethod: 'POST', pathParameters: { token: TOKEN, taskId: 't1' } }),
+      ctx,
+      () => {}
+    )) as APIGatewayProxyResult;
+    expect(res.statusCode).toBe(404);
+  });
+});

--- a/backend/tests/unit/services/sitterService.test.ts
+++ b/backend/tests/unit/services/sitterService.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+  PutCommand: vi.fn((input) => ({ input, kind: 'Put' })),
+  GetCommand: vi.fn((input) => ({ input, kind: 'Get' })),
+  QueryCommand: vi.fn((input) => ({ input, kind: 'Query' })),
+  UpdateCommand: vi.fn((input) => ({ input, kind: 'Update' })),
+}));
+vi.mock('../../../src/utils/dynamodb.js', () => ({
+  dynamodb: { send: vi.fn() },
+  TABLE_NAME: 'test-table',
+}));
+
+async function load() {
+  const { dynamodb } = await import('../../../src/utils/dynamodb.js');
+  const svc = await import('../../../src/services/sitterService.js');
+  return { dynamodb, svc };
+}
+
+const HH = 'hh-1';
+
+function activeRow(overrides: Record<string, unknown> = {}) {
+  const now = Date.now();
+  return {
+    Item: {
+      id: 'link-1',
+      token: 'a'.repeat(64),
+      householdId: HH,
+      createdBy: 'u1',
+      createdAt: new Date(now - 1000).toISOString(),
+      startsAt: new Date(now - 1000).toISOString(),
+      expiresAt: new Date(now + 60_000).toISOString(),
+      status: 'active',
+      label: 'Our plants',
+      ...overrides,
+    },
+  };
+}
+
+describe('sitterService.createSitterLink', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('mints a 256-bit hex token and writes the row with a TTL + GSI1 key', async () => {
+    const { dynamodb, svc } = await load();
+    vi.mocked(dynamodb.send).mockResolvedValueOnce({} as never);
+
+    const link = await svc.createSitterLink({
+      householdId: HH,
+      createdBy: 'u1',
+      startsAt: new Date().toISOString(),
+      expiresAt: new Date(Date.now() + 7 * 86_400_000).toISOString(),
+      label: 'Our plants',
+    });
+
+    // 256 bits = 64 hex chars, from the OS CSPRNG.
+    expect(link.token).toMatch(/^[0-9a-f]{64}$/);
+
+    const cmd = vi.mocked(dynamodb.send).mock.calls[0][0] as unknown as {
+      input: { Item: Record<string, unknown> };
+    };
+    expect(cmd.input.Item.PK).toBe(`SITTER#${link.token}`);
+    expect(cmd.input.Item.entityType).toBe('SitterLink');
+    expect(cmd.input.Item.GSI1PK).toBe(`HOUSEHOLD#${HH}#SITTER`);
+    expect(typeof cmd.input.Item.ttl).toBe('number');
+  });
+
+  it('mints a fresh, unique token each call (no reuse)', async () => {
+    const { dynamodb, svc } = await load();
+    vi.mocked(dynamodb.send).mockResolvedValue({} as never);
+    const a = await svc.createSitterLink({
+      householdId: HH,
+      createdBy: 'u1',
+      startsAt: new Date().toISOString(),
+      expiresAt: new Date(Date.now() + 86_400_000).toISOString(),
+      label: null,
+    });
+    const b = await svc.createSitterLink({
+      householdId: HH,
+      createdBy: 'u1',
+      startsAt: new Date().toISOString(),
+      expiresAt: new Date(Date.now() + 86_400_000).toISOString(),
+      label: null,
+    });
+    expect(a.token).not.toBe(b.token);
+  });
+});
+
+describe('sitterService.getActiveLink', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns the link for an active, in-window token', async () => {
+    const { dynamodb, svc } = await load();
+    vi.mocked(dynamodb.send).mockResolvedValueOnce(activeRow() as never);
+    const link = await svc.getActiveLink('a'.repeat(64));
+    expect(link?.householdId).toBe(HH);
+  });
+
+  it('rejects a malformed token WITHOUT hitting DynamoDB (no oracle, no read cost)', async () => {
+    const { dynamodb, svc } = await load();
+    const link = await svc.getActiveLink('not-hex');
+    expect(link).toBeNull();
+    expect(dynamodb.send).not.toHaveBeenCalled();
+  });
+
+  it('returns null for a missing row', async () => {
+    const { dynamodb, svc } = await load();
+    vi.mocked(dynamodb.send).mockResolvedValueOnce({} as never);
+    expect(await svc.getActiveLink('a'.repeat(64))).toBeNull();
+  });
+
+  it('returns null for a revoked link', async () => {
+    const { dynamodb, svc } = await load();
+    vi.mocked(dynamodb.send).mockResolvedValueOnce(activeRow({ status: 'revoked' }) as never);
+    expect(await svc.getActiveLink('a'.repeat(64))).toBeNull();
+  });
+
+  it('returns null for an expired link (defence in depth past the TTL sweep)', async () => {
+    const { dynamodb, svc } = await load();
+    vi.mocked(dynamodb.send).mockResolvedValueOnce(
+      activeRow({ expiresAt: new Date(Date.now() - 1000).toISOString() }) as never
+    );
+    expect(await svc.getActiveLink('a'.repeat(64))).toBeNull();
+  });
+
+  it('returns null before the window starts', async () => {
+    const { dynamodb, svc } = await load();
+    vi.mocked(dynamodb.send).mockResolvedValueOnce(
+      activeRow({ startsAt: new Date(Date.now() + 60_000).toISOString() }) as never
+    );
+    expect(await svc.getActiveLink('a'.repeat(64))).toBeNull();
+  });
+});
+
+describe('sitterService.toSummary', () => {
+  it('strips the secret token from the management view', async () => {
+    const { svc } = await load();
+    const summary = svc.toSummary({
+      id: 'l1',
+      token: 'a'.repeat(64),
+      householdId: HH,
+      createdBy: 'u1',
+      createdAt: 'now',
+      startsAt: 'now',
+      expiresAt: 'later',
+      status: 'active',
+      label: null,
+    });
+    expect((summary as Record<string, unknown>).token).toBeUndefined();
+    expect(summary.id).toBe('l1');
+  });
+});
+
+describe('sitterService.revokeSitterLink', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns false when the id is not in the household (no cross-household revoke)', async () => {
+    const { dynamodb, svc } = await load();
+    // listSitterLinks query returns one link with a different id.
+    vi.mocked(dynamodb.send).mockResolvedValueOnce({ Items: [activeRow().Item] } as never);
+    const ok = await svc.revokeSitterLink(HH, 'some-other-id');
+    expect(ok).toBe(false);
+  });
+
+  it('flips status to revoked for a matching id', async () => {
+    const { dynamodb, svc } = await load();
+    vi.mocked(dynamodb.send)
+      .mockResolvedValueOnce({ Items: [activeRow().Item] } as never) // list
+      .mockResolvedValueOnce({} as never); // update
+    const ok = await svc.revokeSitterLink(HH, 'link-1');
+    expect(ok).toBe(true);
+    const update = vi.mocked(dynamodb.send).mock.calls[1][0] as unknown as {
+      input: { ExpressionAttributeValues: Record<string, unknown> };
+    };
+    expect(update.input.ExpressionAttributeValues[':revoked']).toBe('revoked');
+  });
+});

--- a/docs/api-spec.yaml
+++ b/docs/api-spec.yaml
@@ -208,6 +208,58 @@ paths:
               schema:
                 $ref: '#/components/schemas/Task'
 
+  /sitter/{token}:
+    get:
+      summary: Public plant-sitter view — due/overdue tasks for a time-boxed link. No auth; token is the only credential. Returns ONLY plant common name, task type, due date, taskId (no PII).
+      tags: [Tasks]
+      security: []
+      parameters:
+        - { name: token, in: path, required: true, schema: { type: string } }
+      responses:
+        '200':
+          description: Due tasks for the sitter (PII-free projection)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  label: { type: string, nullable: true }
+                  expiresAt: { type: string, format: date-time }
+                  tasks:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        taskId: { type: string }
+                        plantName: { type: string }
+                        taskType: { type: string }
+                        dueDate: { type: string, format: date-time }
+                        overdue: { type: boolean }
+        '404': { $ref: '#/components/responses/NotFound' }
+
+  /sitter/{token}/tasks/{taskId}/complete:
+    post:
+      summary: Public plant-sitter task completion. Validates the token and that the task belongs to the token's household; attributed as "a plant sitter". No auth, no PII.
+      tags: [Tasks]
+      security: []
+      parameters:
+        - { name: token, in: path, required: true, schema: { type: string } }
+        - { name: taskId, in: path, required: true, schema: { type: string } }
+      responses:
+        '200':
+          description: Task completed (PII-free projection)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  taskId: { type: string }
+                  plantName: { type: string }
+                  taskType: { type: string }
+                  dueDate: { type: string, format: date-time }
+                  overdue: { type: boolean }
+        '404': { $ref: '#/components/responses/NotFound' }
+
   /households:
     post:
       summary: Create a new household
@@ -585,6 +637,60 @@ paths:
       responses:
         '204': { description: Member removed }
         '403': { $ref: '#/components/responses/Forbidden' }
+
+  /households/{id}/sitter-links:
+    post:
+      summary: Create a no-account, time-boxed plant-sitter link (admin only). Returns the token/URL exactly once.
+      tags: [Households]
+      parameters:
+        - $ref: '#/components/parameters/HouseholdId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [expiresAt]
+              properties:
+                startsAt: { type: string, format: date-time }
+                expiresAt: { type: string, format: date-time }
+                label: { type: string, maxLength: 60 }
+      responses:
+        '201':
+          description: Sitter link created (token returned once)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id: { type: string }
+                  token: { type: string }
+                  url: { type: string }
+                  startsAt: { type: string, format: date-time }
+                  expiresAt: { type: string, format: date-time }
+                  status: { type: string, enum: [active, revoked] }
+                  label: { type: string, nullable: true }
+        '403': { $ref: '#/components/responses/Forbidden' }
+    get:
+      summary: List the household's plant-sitter links (admin only). Never returns tokens.
+      tags: [Households]
+      parameters:
+        - $ref: '#/components/parameters/HouseholdId'
+      responses:
+        '200': { $ref: '#/components/responses/Ok' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+
+  /households/{id}/sitter-links/{linkId}:
+    delete:
+      summary: Revoke a plant-sitter link by its non-secret id (admin only). Idempotent.
+      tags: [Households]
+      parameters:
+        - $ref: '#/components/parameters/HouseholdId'
+        - { name: linkId, in: path, required: true, schema: { type: string } }
+      responses:
+        '204': { description: Sitter link revoked }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
 
   # --- Notifications ---
   /notifications/prefs:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -76,6 +76,7 @@ const BlogPost = lazyNamed(() => import('@/features/blog/BlogPost'), 'BlogPost')
 const CareIndex = lazyNamed(() => import('@/features/care/CareIndex'), 'CareIndex');
 const CareGuidePage = lazyNamed(() => import('@/features/care/CareGuidePage'), 'CareGuidePage');
 const PetSafePage = lazyNamed(() => import('@/features/petsafe/PetSafePage'), 'PetSafePage');
+const SitPage = lazyNamed(() => import('@/features/sitter/SitPage'), 'SitPage');
 const ChangelogPage = lazyNamed(
   () => import('@/features/changelog/ChangelogPage'),
   'ChangelogPage'
@@ -152,6 +153,9 @@ function App() {
               <Route path="/care" element={<CareIndex />} />
               <Route path="/care/:slug" element={<CareGuidePage />} />
               <Route path="/pet-safe" element={<PetSafePage />} />
+              {/* Public, no-account plant-sitting page — works logged-out (the
+                  sitter endpoints have no auth; the token is the credential). */}
+              <Route path="/sit/:token" element={<SitPage />} />
               <Route path="/blog/:slug" element={<BlogPost />} />
               <Route path="/changelog" element={<ChangelogPage />} />
               <Route path="/legal/privacy" element={<PrivacyPage />} />

--- a/frontend/src/features/household/HouseholdPage.tsx
+++ b/frontend/src/features/household/HouseholdPage.tsx
@@ -18,6 +18,7 @@ import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { useActiveHouseholdId } from '@/hooks/useActiveHouseholdId';
 import { MemberVacation } from './MemberVacation';
 import { useVacationWindows } from './useVacationWindows';
+import { SitterLinksCard } from './SitterLinksCard';
 
 export function HouseholdPage() {
   useDocumentTitle('Household');
@@ -164,6 +165,10 @@ export function HouseholdPage() {
           )}
         </Card>
       )}
+
+      {/* Plant-sitter links — admin-only, like invites. A separate component
+          so the create/copy/revoke state stays self-contained. */}
+      {isAdmin && householdId && <SitterLinksCard householdId={householdId} />}
 
       {/* Location — drives climate-aware care tips. Admin-only because the
           location is shared across the household. Non-admins still see what

--- a/frontend/src/features/household/SitterLinksCard.tsx
+++ b/frontend/src/features/household/SitterLinksCard.tsx
@@ -1,0 +1,175 @@
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { ClipboardDocumentIcon, KeyIcon, TrashIcon } from '@heroicons/react/24/outline';
+import { householdService, type CreatedSitterLink } from '@/services/householdService';
+import { Card, CardHeader } from '@/components/Card';
+import { Button } from '@/components/Button';
+import { Input } from '@/components/Input';
+import { Alert } from '@/components/Alert';
+import { getErrorMessage } from '@/services/api';
+
+/**
+ * Admin-only UI to create, copy, and revoke no-account plant-sitter links.
+ * Mirrors the invite-link pattern: the secret token/URL is shown exactly once
+ * (right after creation) and never again — the list only shows the link's
+ * window + status, so a leaked screenshot of the management page can't be used
+ * to access the household. Revoking flips a link to inactive immediately.
+ */
+export function SitterLinksCard({ householdId }: { householdId: string }) {
+  const queryClient = useQueryClient();
+  const [created, setCreated] = useState<CreatedSitterLink | null>(null);
+  const [copied, setCopied] = useState(false);
+  // Default the window to two weeks out — a typical trip length.
+  const [days, setDays] = useState('14');
+  const [label, setLabel] = useState('');
+
+  const linksQuery = useQuery({
+    queryKey: ['sitter-links', householdId],
+    queryFn: () => householdService.listSitterLinks(householdId),
+  });
+
+  const createMutation = useMutation({
+    mutationFn: () => {
+      const n = Math.max(1, Math.min(60, parseInt(days, 10) || 14));
+      const expiresAt = new Date(Date.now() + n * 24 * 60 * 60 * 1000).toISOString();
+      return householdService.createSitterLink(householdId, {
+        expiresAt,
+        label: label.trim() || undefined,
+      });
+    },
+    onSuccess: (link) => {
+      setCreated(link);
+      setCopied(false);
+      setLabel('');
+      queryClient.invalidateQueries({ queryKey: ['sitter-links', householdId] });
+    },
+  });
+
+  const revokeMutation = useMutation({
+    mutationFn: (linkId: string) => householdService.revokeSitterLink(householdId, linkId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['sitter-links', householdId] });
+    },
+  });
+
+  const handleCopy = async () => {
+    if (created) {
+      await navigator.clipboard.writeText(created.url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
+  const activeLinks = (linksQuery.data ?? []).filter((l) => l.status === 'active');
+
+  return (
+    <Card>
+      <CardHeader
+        title="Plant-sitter links"
+        description="Going away? Share a temporary link so a neighbour or friend can see what needs care and check it off — no account needed. The link expires on its own, and you can revoke it any time."
+      />
+
+      {created ? (
+        <div className="space-y-3">
+          <Alert variant="success" title="Your sitter link is ready">
+            Copy it now — for security, we won’t show the full link again. You can always create a
+            new one.
+          </Alert>
+          <div className="flex items-center gap-2">
+            <input
+              type="text"
+              readOnly
+              value={created.url}
+              className="input flex-1 bg-gray-50"
+              aria-label="Plant-sitter link"
+            />
+            <Button
+              variant="secondary"
+              onClick={handleCopy}
+              leftIcon={<ClipboardDocumentIcon className="h-4 w-4" aria-hidden="true" />}
+            >
+              {copied ? 'Copied!' : 'Copy'}
+            </Button>
+          </div>
+          <p className="text-xs text-gray-600">
+            Expires {new Date(created.expiresAt).toLocaleDateString()}.
+          </p>
+          <Button variant="secondary" size="sm" onClick={() => setCreated(null)}>
+            Done
+          </Button>
+        </div>
+      ) : (
+        <form
+          className="space-y-3"
+          onSubmit={(e) => {
+            e.preventDefault();
+            createMutation.mutate();
+          }}
+        >
+          <div className="grid gap-3 sm:grid-cols-2">
+            <Input
+              label="Lasts for (days)"
+              type="number"
+              min={1}
+              max={60}
+              value={days}
+              onChange={(e) => setDays(e.target.value)}
+              helperText="Up to 60 days."
+            />
+            <Input
+              label="Label (optional)"
+              placeholder="e.g. The Smiths’ plants"
+              value={label}
+              maxLength={60}
+              onChange={(e) => setLabel(e.target.value)}
+              helperText="A friendly name your sitter sees. No personal details."
+            />
+          </div>
+          <Button
+            type="submit"
+            isLoading={createMutation.isPending}
+            leftIcon={<KeyIcon className="h-4 w-4" aria-hidden="true" />}
+          >
+            Create sitter link
+          </Button>
+        </form>
+      )}
+
+      {createMutation.isError && (
+        <Alert variant="error" className="mt-4">
+          {getErrorMessage(createMutation.error)}
+        </Alert>
+      )}
+
+      {activeLinks.length > 0 && (
+        <div className="mt-6">
+          <h3 className="text-sm font-medium text-gray-900">Active links</h3>
+          <ul className="mt-2 divide-y divide-gray-100 rounded-lg border border-gray-200">
+            {activeLinks.map((link) => (
+              <li key={link.id} className="flex items-center justify-between gap-4 px-4 py-3">
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium text-gray-900">
+                    {link.label || 'Sitter link'}
+                  </p>
+                  <p className="text-xs text-gray-500">
+                    Expires {new Date(link.expiresAt).toLocaleDateString()}
+                  </p>
+                </div>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  isLoading={revokeMutation.isPending && revokeMutation.variables === link.id}
+                  onClick={() => revokeMutation.mutate(link.id)}
+                  leftIcon={<TrashIcon className="h-4 w-4 text-red-500" aria-hidden="true" />}
+                  aria-label={`Revoke sitter link ${link.label || ''}`.trim()}
+                >
+                  Revoke
+                </Button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/frontend/src/features/sitter/SitPage.tsx
+++ b/frontend/src/features/sitter/SitPage.tsx
@@ -1,0 +1,215 @@
+import { useEffect, useState, useCallback } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { BrandMark } from '@/components/BrandMark';
+import { Footer } from '@/components/Footer';
+import { Alert } from '@/components/Alert';
+import { Button } from '@/components/Button';
+import { LoadingSpinner } from '@/components/LoadingSpinner';
+import { useMetaTags } from '@/hooks/useMetaTags';
+import { sitterService, SitterLinkInactiveError, type SitterTask } from '@/services/sitterService';
+
+/**
+ * Public, no-account plant-sitting page. A household member shares a
+ * time-boxed link before they travel; the sitter opens /sit/{token}, sees the
+ * household's due tasks ("Water the Monstera"), and taps Done — without ever
+ * creating an account or joining the household.
+ *
+ * Auth-free by design: it talks to the public GET /sitter/{token} +
+ * POST /sitter/{token}/tasks/{taskId}/complete endpoints via the bare-fetch
+ * sitterService (no axios interceptors), exactly like the pet-safe page. The
+ * endpoints expose no PII — just the plant common name, task type, and due
+ * date. An expired/revoked link shows a friendly message, not a raw error.
+ */
+
+/** Turn a task type + plant name into a warm, plain instruction. */
+function instructionFor(task: SitterTask): string {
+  const plant = task.plantName || 'this plant';
+  switch (task.taskType) {
+    case 'water':
+      return `Water the ${plant}`;
+    case 'fertilize':
+      return `Feed the ${plant}`;
+    case 'prune':
+      return `Prune the ${plant}`;
+    case 'repot':
+      return `Repot the ${plant}`;
+    default:
+      // Custom task types come through as free text — show them as-is.
+      return `${task.taskType} — ${plant}`;
+  }
+}
+
+function dueLabel(task: SitterTask, now: number): string {
+  const due = new Date(task.dueDate).getTime();
+  if (task.overdue) return 'Overdue';
+  const days = Math.round((due - now) / (24 * 60 * 60 * 1000));
+  if (days <= 0) return 'Due today';
+  if (days === 1) return 'Due tomorrow';
+  return `Due in ${days} days`;
+}
+
+export function SitPage() {
+  const { token = '' } = useParams<{ token: string }>();
+
+  useMetaTags({
+    title: 'Plant-sitting — Family Greenhouse',
+    description: 'See which plants need care and check them off. No sign-up needed.',
+  });
+
+  const [label, setLabel] = useState<string | null>(null);
+  const [tasks, setTasks] = useState<SitterTask[]>([]);
+  const [status, setStatus] = useState<'loading' | 'ready' | 'inactive' | 'error'>('loading');
+  // taskIds currently being completed (optimistic in-flight), and ones done.
+  const [pending, setPending] = useState<Set<string>>(new Set());
+  const [done, setDone] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setStatus('loading');
+    sitterService
+      .getView(token, controller.signal)
+      .then((view) => {
+        setLabel(view.label);
+        setTasks(view.tasks);
+        setStatus('ready');
+      })
+      .catch((err: unknown) => {
+        if (err instanceof DOMException && err.name === 'AbortError') return;
+        setStatus(err instanceof SitterLinkInactiveError ? 'inactive' : 'error');
+      });
+    return () => controller.abort();
+  }, [token]);
+
+  const handleComplete = useCallback(
+    async (taskId: string) => {
+      // Optimistic: mark pending immediately; revert on failure.
+      setPending((p) => new Set(p).add(taskId));
+      try {
+        await sitterService.completeTask(token, taskId);
+        setDone((d) => new Set(d).add(taskId));
+      } catch (err) {
+        if (err instanceof SitterLinkInactiveError) {
+          // The window closed while the page was open — fall back to the
+          // friendly inactive screen rather than leaving a stuck button.
+          setStatus('inactive');
+          return;
+        }
+        // Otherwise leave the task actionable so the sitter can retry.
+      } finally {
+        setPending((p) => {
+          const next = new Set(p);
+          next.delete(taskId);
+          return next;
+        });
+      }
+    },
+    [token]
+  );
+
+  const now = Date.now();
+  const remaining = tasks.filter((t) => !done.has(t.taskId));
+  const allDone = status === 'ready' && remaining.length === 0;
+
+  return (
+    <div className="min-h-screen bg-white flex flex-col">
+      <header className="border-b border-gray-200">
+        <nav className="mx-auto max-w-2xl flex items-center justify-between p-6">
+          <Link to="/" aria-label="Family Greenhouse home">
+            <BrandMark variant="wordmark" size="sm" />
+          </Link>
+        </nav>
+      </header>
+
+      <main className="flex-1 mx-auto max-w-2xl w-full px-6 py-12">
+        {status === 'loading' && (
+          <div className="flex min-h-[40vh] items-center justify-center" role="status">
+            <LoadingSpinner size="lg" />
+            <span className="sr-only">Loading plant-sitting tasks…</span>
+          </div>
+        )}
+
+        {status === 'inactive' && (
+          <div className="mt-8">
+            <Alert variant="info" title="This plant-sitting link is no longer active">
+              The link may have expired or been turned off by the person who shared it. If you’re
+              still helping out, ask them for a fresh link.
+            </Alert>
+          </div>
+        )}
+
+        {status === 'error' && (
+          <div className="mt-8">
+            <Alert variant="error" title="Something went wrong">
+              We couldn’t load the plant-sitting list just now. Please refresh and try again in a
+              moment.
+            </Alert>
+          </div>
+        )}
+
+        {status === 'ready' && (
+          <>
+            <h1 className="font-serif text-3xl font-semibold tracking-tight text-gray-900 sm:text-4xl">
+              {label ? `${label}: what needs doing` : 'Thanks for plant-sitting!'}
+            </h1>
+            <p className="mt-3 text-base text-gray-600">
+              Here’s what needs a little care while they’re away. Tap <strong>Done</strong> once
+              you’ve looked after each one — no account needed.
+            </p>
+
+            {/* Live region announces completions to screen readers. */}
+            <div className="mt-10 space-y-3" aria-live="polite">
+              {allDone ? (
+                <Alert variant="success" title="All caught up — you’re a star 🌿">
+                  Every plant has been looked after. Thank you so much for helping out!
+                </Alert>
+              ) : (
+                <ul className="space-y-3">
+                  {remaining.map((task) => {
+                    const isPending = pending.has(task.taskId);
+                    return (
+                      <li
+                        key={task.taskId}
+                        className="flex items-center justify-between gap-4 rounded-lg border border-gray-200 bg-white p-4 shadow-sm"
+                      >
+                        <div className="min-w-0">
+                          <p className="font-medium text-gray-900">{instructionFor(task)}</p>
+                          <p
+                            className={
+                              'mt-0.5 text-sm ' +
+                              (task.overdue ? 'text-amber-700' : 'text-gray-500')
+                            }
+                          >
+                            {dueLabel(task, now)}
+                          </p>
+                        </div>
+                        <Button
+                          variant="primary"
+                          size="sm"
+                          isLoading={isPending}
+                          onClick={() => handleComplete(task.taskId)}
+                          aria-label={`Mark "${instructionFor(task)}" as done`}
+                        >
+                          Done
+                        </Button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
+
+            <p className="mt-10 text-sm text-gray-500">
+              Looking after plants regularly?{' '}
+              <Link to="/" className="text-primary-700 underline hover:text-primary-800">
+                Family Greenhouse
+              </Link>{' '}
+              keeps a whole household’s plant care in one shared place.
+            </p>
+          </>
+        )}
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/frontend/src/services/householdService.ts
+++ b/frontend/src/services/householdService.ts
@@ -36,6 +36,30 @@ export interface JoinHouseholdData {
   inviteCode: string;
 }
 
+/** The non-secret view of a sitter link (list/management). No token. */
+export interface SitterLinkSummary {
+  id: string;
+  householdId: string;
+  createdBy: string;
+  createdAt: string;
+  startsAt: string;
+  expiresAt: string;
+  status: 'active' | 'revoked';
+  label: string | null;
+}
+
+/** The create response — the ONLY time the token + URL are exposed. */
+export interface CreatedSitterLink extends SitterLinkSummary {
+  token: string;
+  url: string;
+}
+
+export interface CreateSitterLinkData {
+  expiresAt: string;
+  startsAt?: string;
+  label?: string;
+}
+
 export const householdService = {
   async getHousehold(id: string): Promise<HouseholdWithMembers> {
     const response = await api.get<HouseholdWithMembers>(`/households/${id}`);
@@ -84,6 +108,26 @@ export const householdService = {
       { role }
     );
     return response.data;
+  },
+
+  async createSitterLink(
+    householdId: string,
+    data: CreateSitterLinkData
+  ): Promise<CreatedSitterLink> {
+    const response = await api.post<CreatedSitterLink>(
+      `/households/${householdId}/sitter-links`,
+      data
+    );
+    return response.data;
+  },
+
+  async listSitterLinks(householdId: string): Promise<SitterLinkSummary[]> {
+    const response = await api.get<SitterLinkSummary[]>(`/households/${householdId}/sitter-links`);
+    return response.data;
+  },
+
+  async revokeSitterLink(householdId: string, linkId: string): Promise<void> {
+    await api.delete(`/households/${householdId}/sitter-links/${linkId}`);
   },
 
   async getActivity(householdId: string, limit = 50): Promise<ActivityEvent[]> {

--- a/frontend/src/services/sitterService.ts
+++ b/frontend/src/services/sitterService.ts
@@ -1,0 +1,69 @@
+/**
+ * Client for the PUBLIC plant-sitter endpoints (GET /sitter/{token},
+ * POST /sitter/{token}/tasks/{taskId}/complete).
+ *
+ * These are unauthenticated by design — a plant sitter opens a time-boxed link
+ * and never signs in — so we call them with a bare `fetch` against the same
+ * API base the axios client uses, exactly like petToxicityService. That
+ * deliberately skips the auth-header + 401-refresh interceptors, which would
+ * otherwise try to refresh a (non-existent) session for an anonymous visitor.
+ *
+ * The 256-bit token in the path is the only credential. The endpoints expose
+ * NO PII — just the plant common name, task type, due date, and id.
+ */
+
+export interface SitterTask {
+  taskId: string;
+  plantName: string;
+  taskType: string;
+  dueDate: string;
+  overdue: boolean;
+}
+
+export interface SitterView {
+  /** Friendly, non-PII household label the creator chose, if any. */
+  label: string | null;
+  expiresAt: string;
+  tasks: SitterTask[];
+}
+
+/** Thrown when the link is missing/expired/revoked (404) so the page can show
+ *  a friendly "this link is no longer active" message rather than a raw error. */
+export class SitterLinkInactiveError extends Error {
+  constructor() {
+    super('This sitter link is invalid or has expired.');
+    this.name = 'SitterLinkInactiveError';
+  }
+}
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:4000';
+
+export const sitterService = {
+  async getView(token: string, signal?: AbortSignal): Promise<SitterView> {
+    const response = await fetch(`${API_URL}/sitter/${encodeURIComponent(token)}`, {
+      signal,
+      headers: { Accept: 'application/json' },
+    });
+    if (response.status === 404 || response.status === 410) {
+      throw new SitterLinkInactiveError();
+    }
+    if (!response.ok) {
+      throw new Error(`Sitter view failed (${response.status})`);
+    }
+    return (await response.json()) as SitterView;
+  },
+
+  async completeTask(token: string, taskId: string): Promise<SitterTask> {
+    const response = await fetch(
+      `${API_URL}/sitter/${encodeURIComponent(token)}/tasks/${encodeURIComponent(taskId)}/complete`,
+      { method: 'POST', headers: { Accept: 'application/json' } }
+    );
+    if (response.status === 404 || response.status === 410) {
+      throw new SitterLinkInactiveError();
+    }
+    if (!response.ok) {
+      throw new Error(`Sitter completion failed (${response.status})`);
+    }
+    return (await response.json()) as SitterTask;
+  },
+};

--- a/frontend/tests/e2e/a11y.spec.ts
+++ b/frontend/tests/e2e/a11y.spec.ts
@@ -89,4 +89,31 @@ test.describe('A11y — public routes (WCAG 2.0/2.1/2.2 AA)', () => {
     await page.waitForLoadState('networkidle');
     await expectNoA11yViolations(page, 'pet-safe');
   });
+
+  test('plant-sitter page (with due tasks)', async ({ page }) => {
+    // The public sitter page fetches GET /sitter/{token}; stub it so the
+    // task-list state (the busiest layout) is what axe scans. No auth needed.
+    await page.route('**/sitter/**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          label: 'The Smiths’ plants',
+          expiresAt: new Date(Date.now() + 7 * 86_400_000).toISOString(),
+          tasks: [
+            {
+              taskId: 't1',
+              plantName: 'Monstera',
+              taskType: 'water',
+              dueDate: new Date(Date.now() - 1000).toISOString(),
+              overdue: true,
+            },
+          ],
+        }),
+      })
+    );
+    await page.goto('/sit/' + 'a'.repeat(64));
+    await page.waitForLoadState('networkidle');
+    await expectNoA11yViolations(page, 'sitter');
+  });
 });

--- a/frontend/tests/unit/features/SitPage.test.tsx
+++ b/frontend/tests/unit/features/SitPage.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { SitPage } from '@/features/sitter/SitPage';
+import {
+  sitterService,
+  SitterLinkInactiveError,
+  type SitterTask,
+  type SitterView,
+} from '@/services/sitterService';
+
+vi.mock('@/services/sitterService', async () => {
+  const actual = await vi.importActual<typeof import('@/services/sitterService')>(
+    '@/services/sitterService'
+  );
+  return {
+    ...actual,
+    sitterService: { getView: vi.fn(), completeTask: vi.fn() },
+  };
+});
+
+const getView = vi.mocked(sitterService.getView);
+const completeTask = vi.mocked(sitterService.completeTask);
+
+function renderPage(token = 'a'.repeat(64)) {
+  return render(
+    <MemoryRouter initialEntries={[`/sit/${token}`]}>
+      <Routes>
+        <Route path="/sit/:token" element={<SitPage />} />
+        <Route path="/" element={<div>Home</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+const waterTask: SitterTask = {
+  taskId: 't1',
+  plantName: 'Monstera',
+  taskType: 'water',
+  dueDate: new Date(Date.now() - 1000).toISOString(),
+  overdue: true,
+};
+
+const view: SitterView = {
+  label: 'The Smiths’ plants',
+  expiresAt: new Date(Date.now() + 7 * 86_400_000).toISOString(),
+  tasks: [waterTask],
+};
+
+describe('SitPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the due-task list with a warm, plain instruction', async () => {
+    getView.mockResolvedValue(view);
+    renderPage();
+
+    expect(await screen.findByText(/Water the Monstera/i)).toBeInTheDocument();
+    expect(screen.getByText(/Overdue/i)).toBeInTheDocument();
+    // Single h1 for accessibility.
+    expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
+    // The token is passed straight through to the service.
+    expect(getView).toHaveBeenCalledWith('a'.repeat(64), expect.anything());
+  });
+
+  it('checks a task off and removes it from the list (optimistic)', async () => {
+    getView.mockResolvedValue(view);
+    completeTask.mockResolvedValue({ ...waterTask, overdue: false });
+    const user = userEvent.setup();
+    renderPage();
+
+    const doneBtn = await screen.findByRole('button', {
+      name: /mark .*Water the Monstera.* as done/i,
+    });
+    await user.click(doneBtn);
+
+    await waitFor(() => expect(screen.queryByText(/Water the Monstera/i)).not.toBeInTheDocument());
+    expect(completeTask).toHaveBeenCalledWith('a'.repeat(64), 't1');
+    expect(await screen.findByText(/all caught up/i)).toBeInTheDocument();
+  });
+
+  it('shows a friendly message for an expired / revoked link', async () => {
+    getView.mockRejectedValue(new SitterLinkInactiveError());
+    renderPage();
+
+    expect(await screen.findByText(/no longer active/i)).toBeInTheDocument();
+    // No raw error / stack — just the friendly copy.
+    expect(screen.queryByText(/something went wrong/i)).not.toBeInTheDocument();
+  });
+
+  it('shows a generic error for an unexpected failure', async () => {
+    getView.mockRejectedValue(new Error('boom'));
+    renderPage();
+    expect(await screen.findByText(/something went wrong/i)).toBeInTheDocument();
+  });
+
+  it('falls back to the inactive screen if the link expires mid-session', async () => {
+    getView.mockResolvedValue(view);
+    completeTask.mockRejectedValue(new SitterLinkInactiveError());
+    const user = userEvent.setup();
+    renderPage();
+
+    const doneBtn = await screen.findByRole('button', { name: /as done/i });
+    await user.click(doneBtn);
+    expect(await screen.findByText(/no longer active/i)).toBeInTheDocument();
+  });
+});

--- a/infrastructure/modules/api/main.tf
+++ b/infrastructure/modules/api/main.tf
@@ -578,6 +578,14 @@ locals {
     "PUT /tasks/vacation"             = { group = "tasks", auth = "jwt" }
     "DELETE /tasks/vacation/{userId}" = { group = "tasks", auth = "jwt" }
 
+    # Plant-sitter PUBLIC endpoints (auth=none). A no-account sitter opens a
+    # time-boxed link; the 256-bit token in the path is the only credential.
+    # The handlers validate the token (existence + active + window) on every
+    # call, expose only a PII-free due-task projection, and are IP-rate-limited.
+    # Served by the tasks group (it owns task listing + completion).
+    "GET /sitter/{token}"                          = { group = "tasks", auth = "none" }
+    "POST /sitter/{token}/tasks/{taskId}/complete" = { group = "tasks", auth = "none" }
+
     # --- households (invite preview is public) ---
     "POST /households"                                    = { group = "households", auth = "jwt" }
     "GET /households/{id}"                                = { group = "households", auth = "jwt" }
@@ -589,6 +597,11 @@ locals {
     "GET /households/{id}/year-in-review"                 = { group = "households", auth = "jwt" }
     "PUT /households/{householdId}/members/{userId}/role" = { group = "households", auth = "jwt" }
     "DELETE /households/{householdId}/members/{userId}"   = { group = "households", auth = "jwt" }
+    # Sitter-link management (authed, admin-gated). Create returns the token
+    # once; list/revoke never expose it. The public sitter routes are above.
+    "POST /households/{id}/sitter-links"            = { group = "households", auth = "jwt" }
+    "GET /households/{id}/sitter-links"             = { group = "households", auth = "jwt" }
+    "DELETE /households/{id}/sitter-links/{linkId}" = { group = "households", auth = "jwt" }
 
     # --- me ---
     "DELETE /me"           = { group = "me", auth = "jwt" }


### PR DESCRIPTION
## What

A no-account, time-boxed **sitter link** so a plant-sitter (neighbour, friend) can see a household's due tasks and mark them done **without creating an account or joining the household**. A household member generates the link before they travel; the sitter opens it, sees "Water the Monstera," taps Done. The link expires on its own and can be revoked.

## How it works

**Public, no-auth endpoints** (the token in the path is the only credential):
- `GET /sitter/{token}` → validates the token, returns the household's due/overdue tasks in a minimal, PII-free shape.
- `POST /sitter/{token}/tasks/{taskId}/complete` → re-validates the token, confirms the task belongs to that token's household, completes it via the existing task service, attributed as "a plant sitter".

**Authed management** (Cognito, admin-gated — mirrors invite links):
- `POST /households/{id}/sitter-links` → create; returns the token/URL **once**.
- `GET /households/{id}/sitter-links` → list (never returns tokens).
- `DELETE /households/{id}/sitter-links/{linkId}` → revoke (idempotent).

Frontend: a public `/sit/{token}` page (bare fetch, no auth interceptors; optimistic check-off; friendly expired/all-caught-up states; mobile-first, accessible) plus an admin card on the household page to create/copy/revoke links.

Reuses the existing invite pattern for entropy/storage/expiry, the rate-limit + validateBody middleware, the existing `completeTask` service, and the public-endpoint wiring (route-parity, route-terraform-parity, check-api-spec all green).

## Endpoints + auth

| Method & path | Auth |
| --- | --- |
| `GET /sitter/{token}` | none (public, IP rate-limited) |
| `POST /sitter/{token}/tasks/{taskId}/complete` | none (public, IP rate-limited) |
| `POST /households/{id}/sitter-links` | Cognito JWT, household admin |
| `GET /households/{id}/sitter-links` | Cognito JWT, household admin |
| `DELETE /households/{id}/sitter-links/{linkId}` | Cognito JWT, household admin |

## Public payload shape

`GET /sitter/{token}` →
```json
{
  "label": "The Smiths' plants",
  "expiresAt": "2026-07-01T00:00:00.000Z",
  "tasks": [
    { "taskId": "…", "plantName": "Monstera", "taskType": "water", "dueDate": "…", "overdue": true }
  ]
}
```
`POST …/complete` → `{ "taskId", "plantName", "taskType", "dueDate", "overdue" }`. No other fields are ever returned.

## SECURITY NOTES (for the reviewer)

- **What the public endpoints expose:** only `plantName` (common name), `taskType`, `dueDate`, `taskId`, plus the creator-chosen friendly `label` and `expiresAt`. **No** member names/emails, no `householdId`, no other households, no full plant records, no task notes (notes can carry private context). The PII-free projection is built in `taskService.getSitterTasks`; the handlers never return the full `Task`. Tests assert the payload contains no member name / email / household id / notes.
- **Token strength:** 256-bit token from the OS CSPRNG (`crypto.randomBytes(32)`, 64 hex chars) — double the existing 128-bit invite code, not guessable from a leaked log line or DDB dump.
- **Expiry:** enforced on **every** public call. `getActiveLink` re-checks both `status === 'active'` and `startsAt ≤ now ≤ expiresAt` on each read — it does not rely on the DynamoDB TTL sweeper for correctness (the TTL is a janitor, with a buffer so a skewed sweep can't drop a still-valid link).
- **Revocation:** `status: 'revoked'` short-circuits validation immediately, before the TTL would expire the row. Revoke is scoped to the household (you can only revoke your own links) and idempotent.
- **No enumeration / no oracle:** a malformed token is rejected by a charset/length gate before touching DynamoDB; every failure mode (missing / expired / revoked / malformed) returns the **same** generic 404 with the same message, so the endpoint can't be used to probe which tokens exist.
- **Cross-household isolation:** completion reads the task scoped to the token's `householdId`, so a forged `taskId` from another household simply isn't found (404) — there is no path to another partition. Covered by a dedicated test.
- **Rate limiting:** public read 60/min per IP, public write 30/min per IP (in-memory per-warm-container limiter, same brake the invite/toxicity/thumbnail public routes use). Admin management routes sit behind Cognito + admin role.
- **Attribution:** sitter completions are recorded with `completedByName: "a plant sitter"` and a synthetic, non-PII `actorId` (`sitter:{linkId}`) so the activity feed is traceable without inventing a fake user.

## Tests

- Backend: `npm test` → **894 passing** (adds sitterService unit tests for token entropy + window/revoke validation; public-handler tests for the PII-free payload, cross-household rejection, and the 429 rate limit; an integration lifecycle test create→view→complete→revoke with expiry/cross-household/no-PII assertions).
- Frontend: `vitest run` → **302 passing** (adds the public `/sit/{token}` page: renders due tasks, optimistic check-off, expired/revoked + error states).
- Green locally: route-parity, route-terraform-parity, check-api-spec, both builds, lint, prettier `format:check`, `terraform fmt`/`validate`, size budgets. Added an axe a11y scan for the sitter page.

⚠️ Please security-review before merge — auto-merge intentionally not enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)