### PR TITLE
feat(onboarding): welcome email and first-plant activation polish

### DIFF
--- a/backend/src/handlers/households/handler.ts
+++ b/backend/src/handlers/households/handler.ts
@@ -18,6 +18,7 @@ import {
   CreateSitterLinkInput,
 } from '../../models/schemas.js';
 import * as householdService from '../../services/householdService.js';
+import * as welcomeEmail from '../../services/welcomeEmail.js';
 import * as taskService from '../../services/taskService.js';
 import * as sitterService from '../../services/sitterService.js';
 import * as cognitoUsers from '../../services/cognitoUsers.js';
@@ -54,8 +55,26 @@ export const createHousehold = createHandler(
     // keeps the "first household stays default" property — switching to a
     // newer household requires the X-Household-Id header from the
     // frontend's HouseholdSwitcher.
+    //
+    // The absence of an existing household claim is also our fire-once signal
+    // for the welcome email: this is the user's genuine first household (a new
+    // account finishing setup), not an "add another household" from the
+    // switcher, so they get exactly one warm welcome. It's best-effort —
+    // sendWelcomeEmail swallows its own failures, but we also don't await it on
+    // the critical path: a slow or flaky SES send must never delay or break
+    // onboarding.
     if (!user.householdId) {
       await cognitoUsers.setHouseholdClaims(user.userId, household.id, 'admin');
+
+      const appUrl = process.env.FRONTEND_URL || process.env.ALLOWED_ORIGIN;
+      if (appUrl) {
+        void welcomeEmail.sendWelcomeEmail(user.userId, user.email, userName, appUrl);
+      } else {
+        logger.warn(
+          { userId: user.userId, msg: 'welcome_email_skipped_no_base_url' },
+          'welcome_email_skipped_no_base_url'
+        );
+      }
     }
 
     audit('household.created', {

--- a/backend/src/services/welcomeEmail.ts
+++ b/backend/src/services/welcomeEmail.ts
@@ -1,0 +1,77 @@
+/**
+ * One-time welcome email, sent when a brand-new user finishes setup by
+ * creating their very first household.
+ *
+ * Like the digest/recap emails this is plain text (emailNotifier ships no HTML
+ * yet) and goes straight through `emailNotifier.sendEmail` — it's a single
+ * transactional onboarding touch, not a real-time ping, so it skips the
+ * `notifier.sendToUser` channel fan-out and the DND window.
+ *
+ * Fire-once + best-effort are the caller's responsibility: the handler only
+ * calls this on the genuine first-household path (the user had no household
+ * before), and wraps it in try/catch so a flaky SES region can never break
+ * onboarding. See handlers/households/handler.ts.
+ */
+import { logger } from '../utils/logger.js';
+import * as emailNotifier from './emailNotifier.js';
+
+/** Compose the plain-text welcome email. Pure + exported so it's unit-testable
+ *  and the copy can be asserted without reaching SES. `appUrl` is the
+ *  FRONTEND_URL base (no trailing slash); links hang off it. */
+export function composeWelcomeEmail(
+  userName: string,
+  appUrl: string
+): { subject: string; text: string } {
+  const base = appUrl.replace(/\/+$/, '');
+  // A genuine first name when we have one, otherwise a warm generic greeting.
+  const greeting = userName.trim() ? `Hi ${userName.trim()},` : 'Hi there,';
+  const subject = 'Welcome to Family Greenhouse 🌱';
+  const text = [
+    greeting,
+    '',
+    "You're all set up — welcome to Family Greenhouse. We're glad you're here.",
+    '',
+    'The best first step is to add your first plant. It takes less than a',
+    'minute: give it a name, or start from a species suggestion and we’ll fill',
+    'in the care details for you.',
+    '',
+    `Add your first plant: ${base}/plants/new`,
+    '',
+    'A couple of small tips to get started:',
+    '  - Most houseplants would rather be a little too dry than too wet — when',
+    '    in doubt, wait a day and check the soil with your finger.',
+    '  - Bright, indirect light suits the widest range of plants. A spot near a',
+    '    window that never gets harsh midday sun is a safe bet.',
+    '',
+    `Not sure where to begin? Our care guides cover the popular plants: ${base}/care`,
+    '',
+    'Happy growing,',
+    'The Family Greenhouse team',
+  ].join('\n');
+  return { subject, text };
+}
+
+/**
+ * Send the welcome email to a newly-onboarded user. Best-effort: any failure
+ * is logged and swallowed so it can never break the household-creation flow.
+ * Returns true if a send was attempted without throwing (a dry-run when SES is
+ * unconfigured still counts), false if it failed.
+ */
+export async function sendWelcomeEmail(
+  userId: string,
+  email: string,
+  userName: string,
+  appUrl: string
+): Promise<boolean> {
+  try {
+    const { subject, text } = composeWelcomeEmail(userName, appUrl);
+    await emailNotifier.sendEmail({ to: email, subject, text });
+    return true;
+  } catch (err) {
+    logger.warn(
+      { err: (err as Error).message, userId, msg: 'welcome_email_failed' },
+      'welcome_email_failed'
+    );
+    return false;
+  }
+}

--- a/backend/tests/unit/handlers/households.test.ts
+++ b/backend/tests/unit/handlers/households.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from 'aws-lambda';
 
 vi.mock('../../../src/services/householdService.js');
+vi.mock('../../../src/services/welcomeEmail.js');
 vi.mock('../../../src/services/taskService.js');
 vi.mock('../../../src/services/activity.js');
 vi.mock('../../../src/services/cognitoUsers.js');
@@ -121,6 +122,93 @@ describe('households handler', () => {
       'a@b.com'
     );
     expect(cognitoUsers.setHouseholdClaims).toHaveBeenCalledWith('user-1', 'hh-new', 'admin');
+  });
+
+  it('createHousehold sends exactly one welcome email on the genuine first household', async () => {
+    const householdService = await import('../../../src/services/householdService.js');
+    const cognitoUsers = await import('../../../src/services/cognitoUsers.js');
+    const welcomeEmail = await import('../../../src/services/welcomeEmail.js');
+    const { createHousehold } = await import('../../../src/handlers/households/handler.js');
+    vi.mocked(cognitoUsers.getUserName).mockResolvedValueOnce('Alice');
+    vi.mocked(householdService.createHousehold).mockResolvedValueOnce({
+      id: 'hh-new',
+      name: 'Home',
+      createdAt: '',
+      createdBy: 'user-1',
+    });
+    vi.mocked(cognitoUsers.setHouseholdClaims).mockResolvedValueOnce(undefined);
+    vi.mocked(welcomeEmail.sendWelcomeEmail).mockResolvedValueOnce(true);
+    // No `custom:household_id` claim ⇒ this is the user's first household.
+    const event = buildEvent(
+      { sub: 'user-1', email: 'a@b.com' },
+      {
+        httpMethod: 'POST',
+        body: JSON.stringify({ name: 'Home' }),
+        headers: { 'content-type': 'application/json' },
+      }
+    );
+    const res = (await createHousehold(event, fakeContext, () => {})) as APIGatewayProxyResult;
+    expect(res.statusCode).toBe(201);
+    expect(welcomeEmail.sendWelcomeEmail).toHaveBeenCalledTimes(1);
+    expect(welcomeEmail.sendWelcomeEmail).toHaveBeenCalledWith(
+      'user-1',
+      'a@b.com',
+      'Alice',
+      'https://test.familygreenhouse.net'
+    );
+  });
+
+  it('createHousehold does NOT welcome again when the user already has a household', async () => {
+    const householdService = await import('../../../src/services/householdService.js');
+    const cognitoUsers = await import('../../../src/services/cognitoUsers.js');
+    const welcomeEmail = await import('../../../src/services/welcomeEmail.js');
+    const { createHousehold } = await import('../../../src/handlers/households/handler.js');
+    vi.mocked(cognitoUsers.getUserName).mockResolvedValueOnce('Alice');
+    vi.mocked(householdService.createHousehold).mockResolvedValueOnce({
+      id: 'hh-second',
+      name: 'Vacation',
+      createdAt: '',
+      createdBy: 'user-1',
+    });
+    // adminClaims carries an existing household_id ⇒ "add another household".
+    const event = buildEvent(adminClaims, {
+      httpMethod: 'POST',
+      body: JSON.stringify({ name: 'Vacation' }),
+      headers: { 'content-type': 'application/json' },
+    });
+    const res = (await createHousehold(event, fakeContext, () => {})) as APIGatewayProxyResult;
+    expect(res.statusCode).toBe(201);
+    expect(welcomeEmail.sendWelcomeEmail).not.toHaveBeenCalled();
+  });
+
+  it('createHousehold still succeeds (non-blocking) when the welcome email fails', async () => {
+    const householdService = await import('../../../src/services/householdService.js');
+    const cognitoUsers = await import('../../../src/services/cognitoUsers.js');
+    const welcomeEmail = await import('../../../src/services/welcomeEmail.js');
+    const { createHousehold } = await import('../../../src/handlers/households/handler.js');
+    vi.mocked(cognitoUsers.getUserName).mockResolvedValueOnce('Alice');
+    vi.mocked(householdService.createHousehold).mockResolvedValueOnce({
+      id: 'hh-new',
+      name: 'Home',
+      createdAt: '',
+      createdBy: 'user-1',
+    });
+    vi.mocked(cognitoUsers.setHouseholdClaims).mockResolvedValueOnce(undefined);
+    // Simulate the worst case: the welcome send rejects. Onboarding must not
+    // observe it — the handler fires it without awaiting and the service
+    // swallows its own errors, so the 201 still comes back.
+    vi.mocked(welcomeEmail.sendWelcomeEmail).mockRejectedValueOnce(new Error('SES down'));
+    const event = buildEvent(
+      { sub: 'user-1', email: 'a@b.com' },
+      {
+        httpMethod: 'POST',
+        body: JSON.stringify({ name: 'Home' }),
+        headers: { 'content-type': 'application/json' },
+      }
+    );
+    const res = (await createHousehold(event, fakeContext, () => {})) as APIGatewayProxyResult;
+    expect(res.statusCode).toBe(201);
+    expect(welcomeEmail.sendWelcomeEmail).toHaveBeenCalledTimes(1);
   });
 
   it('getHousehold rejects cross-household access', async () => {

--- a/backend/tests/unit/services/welcomeEmail.test.ts
+++ b/backend/tests/unit/services/welcomeEmail.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../src/services/emailNotifier.js');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('welcomeEmail.composeWelcomeEmail', () => {
+  it('greets the user by name and points at the add-first-plant and care links', async () => {
+    const { composeWelcomeEmail } = await import('../../../src/services/welcomeEmail.js');
+    const { subject, text } = composeWelcomeEmail('Alice', 'https://app.example.net');
+    expect(subject).toMatch(/welcome/i);
+    expect(text).toContain('Hi Alice,');
+    expect(text).toContain('https://app.example.net/plants/new');
+    expect(text).toContain('https://app.example.net/care');
+  });
+
+  it('falls back to a generic greeting when the name is blank', async () => {
+    const { composeWelcomeEmail } = await import('../../../src/services/welcomeEmail.js');
+    const { text } = composeWelcomeEmail('   ', 'https://app.example.net');
+    expect(text).toContain('Hi there,');
+  });
+
+  it('does not double up the slash when the base url has a trailing slash', async () => {
+    const { composeWelcomeEmail } = await import('../../../src/services/welcomeEmail.js');
+    const { text } = composeWelcomeEmail('Bo', 'https://app.example.net/');
+    expect(text).toContain('https://app.example.net/plants/new');
+    expect(text).not.toContain('https://app.example.net//plants/new');
+  });
+});
+
+describe('welcomeEmail.sendWelcomeEmail', () => {
+  it('sends exactly one email through the shared SES sender', async () => {
+    const emailNotifier = await import('../../../src/services/emailNotifier.js');
+    vi.mocked(emailNotifier.sendEmail).mockResolvedValueOnce(undefined);
+    const { sendWelcomeEmail } = await import('../../../src/services/welcomeEmail.js');
+
+    const ok = await sendWelcomeEmail('user-1', 'a@b.com', 'Alice', 'https://app.example.net');
+
+    expect(ok).toBe(true);
+    expect(emailNotifier.sendEmail).toHaveBeenCalledTimes(1);
+    expect(emailNotifier.sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ to: 'a@b.com', subject: expect.stringMatching(/welcome/i) })
+    );
+  });
+
+  it('is best-effort: swallows an SES failure and returns false instead of throwing', async () => {
+    const emailNotifier = await import('../../../src/services/emailNotifier.js');
+    vi.mocked(emailNotifier.sendEmail).mockRejectedValueOnce(new Error('SES down'));
+    const { sendWelcomeEmail } = await import('../../../src/services/welcomeEmail.js');
+
+    await expect(
+      sendWelcomeEmail('user-1', 'a@b.com', 'Alice', 'https://app.example.net')
+    ).resolves.toBe(false);
+  });
+});

--- a/frontend/src/components/EmptyState.tsx
+++ b/frontend/src/components/EmptyState.tsx
@@ -5,9 +5,13 @@ interface EmptyStateProps {
   title: string;
   description?: string;
   action?: ReactNode;
+  /** Optional reassuring line under the action (e.g. "Takes under a minute").
+   *  Kept visually quieter than the description so the primary CTA stays the
+   *  focal point. */
+  hint?: ReactNode;
 }
 
-export function EmptyState({ icon, title, description, action }: EmptyStateProps) {
+export function EmptyState({ icon, title, description, action, hint }: EmptyStateProps) {
   return (
     <div className="flex flex-col items-center text-center py-12 px-6">
       {/* The icon renders without a fixed-size wrapper because the
@@ -24,6 +28,7 @@ export function EmptyState({ icon, title, description, action }: EmptyStateProps
       <h3 className="font-serif text-xl text-ink">{title}</h3>
       {description && <p className="mt-1 text-sm text-gray-600 max-w-md">{description}</p>}
       {action && <div className="mt-6">{action}</div>}
+      {hint && <p className="mt-3 text-xs text-gray-500">{hint}</p>}
     </div>
   );
 }

--- a/frontend/src/features/dashboard/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/DashboardPage.tsx
@@ -260,13 +260,14 @@ export function DashboardPage() {
           <Alert variant="error">{getErrorMessage(plantsError)}</Alert>
         ) : !plants || plants.length === 0 ? (
           <EmptyState
-            title="No plants yet"
-            description="Add your first plant to get started."
+            title="Let's add your first plant"
+            description="Name it, or start from a species suggestion and we'll fill in the care details. We'll handle the watering reminders from there."
             action={
               <Link to="/plants/new">
-                <Button>Add plant</Button>
+                <Button size="lg">Add your first plant</Button>
               </Link>
             }
+            hint="Takes less than a minute."
           />
         ) : (
           <div className="grid grid-cols-2 gap-3 sm:gap-4 sm:grid-cols-3 lg:grid-cols-4">

--- a/frontend/src/features/plants/PlantsPage.tsx
+++ b/frontend/src/features/plants/PlantsPage.tsx
@@ -188,13 +188,16 @@ export function PlantsPage() {
         ) : (
           <EmptyState
             icon={<EmptyPlants className="mx-auto h-40 w-auto" />}
-            title="No plants yet"
-            description="Add your first plant to get started tracking care."
+            title="Let's add your first plant"
+            description="Name it, or start typing a species and we'll fill in the care details for you. Once it's in, we'll track watering and the rest for you."
             action={
               <Link to="/plants/new">
-                <Button>Add your first plant</Button>
+                <Button size="lg" leftIcon={<PlusIcon className="h-5 w-5" aria-hidden="true" />}>
+                  Add your first plant
+                </Button>
               </Link>
             }
+            hint="Takes less than a minute."
           />
         )
       ) : viewMode === 'grid' ? (

--- a/frontend/tests/unit/features/PlantsPageEmpty.test.tsx
+++ b/frontend/tests/unit/features/PlantsPageEmpty.test.tsx
@@ -1,0 +1,50 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { PlantsPage } from '@/features/plants/PlantsPage';
+import { useAuthStore } from '@/store/authStore';
+import { server } from '../../msw/server';
+
+const API = 'http://localhost:4000';
+
+function renderPlants() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/plants']}>
+        <Routes>
+          <Route path="/plants" element={<PlantsPage />} />
+          <Route path="/plants/new" element={<div>Add Plant Page</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('PlantsPage empty state (first-plant activation)', () => {
+  beforeEach(() => {
+    useAuthStore.setState({ accessToken: 'access-1', user: { householdId: 'hh-1' } as never });
+  });
+
+  it('shows a single warm primary CTA to add the first plant, linking to /plants/new', async () => {
+    server.use(http.get(`${API}/plants`, () => HttpResponse.json([])));
+    renderPlants();
+
+    // Warm, action-led heading instead of the old "No plants yet".
+    expect(await screen.findByText(/let's add your first plant/i)).toBeInTheDocument();
+
+    // The empty-state CTA points the user straight at the add-plant flow.
+    const cta = await screen.findByRole('link', { name: /add your first plant/i });
+    expect(cta).toHaveAttribute('href', '/plants/new');
+  });
+
+  it('reassures the user that it is quick', async () => {
+    server.use(http.get(`${API}/plants`, () => HttpResponse.json([])));
+    renderPlants();
+    expect(await screen.findByText(/less than a minute/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What & why

A brand-new user currently gets no warm first touch after signing up, and a fresh, empty account doesn't make the obvious next step (add your first plant) prominent enough. This PR closes both gaps with small, tasteful changes.

### 1. Welcome email on first household setup

Send one friendly, plain-text welcome email the moment a new user completes onboarding by creating their **first** household.

- New `backend/src/services/welcomeEmail.ts` reuses the existing SES sender (`emailNotifier.sendEmail`, the `hello@` from-address) and matches the plain-text brand voice of the digest/recap emails. The body welcomes the user, points them at "add your first plant" (`FRONTEND_URL/plants/new`), offers two genuine care tips, and links the care guides (`FRONTEND_URL/care`).
- Wired into `households` handler's `createHousehold`. The fire-once signal is the absence of an existing household claim (`!user.householdId`) — i.e. the genuine first-household path, **not** the "add another household" path from the switcher. So it sends exactly once per new user.
- Best-effort / non-blocking: `sendWelcomeEmail` wraps the send in try/catch + `logger.warn`, and the handler fires it **without awaiting**, so a slow or failing SES send can never delay or break onboarding. Falls back to a structured log line when no base URL is configured.
- This is transactional onboarding, not marketing — no list mechanism added.

### 2. First-plant activation polish

Make the zero-plant moment frictionless and obvious.

- `EmptyState` gains an optional, visually-quiet `hint` line so the primary CTA stays the focal point.
- The zero-plant empty states on **Plants** and **Dashboard** now lead with a warm, action-led heading ("Let's add your first plant"), copy that mentions starting from a species suggestion, a single prominent primary CTA, and a "Takes less than a minute" reassurance.
- Mobile-first, semantic markup, no new interactive patterns — the existing a11y suite stays green.

## Tests

- Backend: new `welcomeEmail.test.ts` (compose copy + links, fire-once send, best-effort swallow on SES failure) and handler tests asserting the email fires once on the genuine first household, does **not** fire on "add another household", and that onboarding still returns 201 when the welcome send rejects. Full backend suite green (902 tests), route-parity included.
- Frontend: new `PlantsPageEmpty.test.tsx` covering the warm single primary CTA → `/plants/new` and the quick-reassurance hint. Full frontend suite green (316 tests), a11y suite green.
- Both builds pass; size budgets pass with headroom; prettier clean; changed source files lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)