### PR TITLE
chore(deps-dev): bump typescript to 6.0.3

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -55,7 +55,7 @@
     "express": "^4.19.2",
     "supertest": "^7.2.2",
     "tsx": "^4.7.1",
-    "typescript": "^5.4.3",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.61.1",
     "vitest": "^4.0.0"
   }

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -19,6 +19,12 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "allowSyntheticDefaultImports": true,
+    // TypeScript 6.0 deprecates `baseUrl` (TS5101) and errors on it unless
+    // silenced. We still use baseUrl for the `@/*` path alias below, so opt
+    // into the 6.0 deprecation grace period; the alias can move to a
+    // baseUrl-free form (paths resolve relative to this tsconfig) before TS 7.0
+    // removes the option entirely.
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -102,7 +102,7 @@
     "postcss": "^8.4.38",
     "size-limit": "^12.1.0",
     "tailwindcss": "^3.4.3",
-    "typescript": "^5.4.3",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.61.1",
     "vite": "^7.3.5",
     "vite-plugin-pwa": "^1.2.0",

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -19,6 +19,12 @@
     "forceConsistentCasingInFileNames": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
+    // TypeScript 6.0 deprecates `baseUrl` (TS5101) and errors on it unless
+    // silenced. We still use baseUrl for the `@/*` path aliases below, so opt
+    // into the 6.0 deprecation grace period; the aliases can move to a
+    // baseUrl-free form (paths resolve relative to this tsconfig) before TS 7.0
+    // removes the option entirely.
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "husky": "^9.0.11",
         "lint-staged": "^15.2.2",
         "prettier": "^3.2.5",
-        "typescript": "^5.4.3",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.61.1"
       },
       "engines": {
@@ -79,7 +79,7 @@
         "express": "^4.19.2",
         "supertest": "^7.2.2",
         "tsx": "^4.7.1",
-        "typescript": "^5.4.3",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.61.1",
         "vitest": "^4.0.0"
       }
@@ -454,7 +454,7 @@
         "postcss": "^8.4.38",
         "size-limit": "^12.1.0",
         "tailwindcss": "^3.4.3",
-        "typescript": "^5.4.3",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.61.1",
         "vite": "^7.3.5",
         "vite-plugin-pwa": "^1.2.0",
@@ -18064,9 +18064,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "husky": "^9.0.11",
     "lint-staged": "^15.2.2",
     "prettier": "^3.2.5",
-    "typescript": "^5.4.3",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.61.1"
   },
   "lint-staged": {


### PR DESCRIPTION
Bumps `typescript` from 5.4.x to `^6.0.3` across the root, frontend, and backend workspaces.

## Why a fresh PR (replaces #80)

Dependabot's PR #80 was branched from an old `main` that predated the eslint flat-config migration, so it carried stale `.eslintrc.cjs` state and a `--ext` lint script that no longer match `main`. Rather than merge that stale branch, this PR rebuilds the same bump on top of current `main`. #80 should be closed in favor of this.

## The one breaking change: `baseUrl` deprecation (TS5101)

TypeScript 6.0 deprecates the `baseUrl` compiler option and **errors** on it unless silenced:

```
tsconfig.json(22,5): error TS5101: Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0. Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
```

Both `frontend/tsconfig.json` and `backend/tsconfig.json` still rely on `baseUrl` for their `@/*` path aliases, so this PR adds `"ignoreDeprecations": "6.0"` to both. This is the minimal, reversible fix the compiler itself suggests; a follow-up can migrate the aliases to a baseUrl-free form (paths resolve relative to the tsconfig since TS 4.1) before TS 7.0 removes the option entirely.

No other 6.0 breakages surfaced — the full typecheck across both workspaces is clean.

## Verification (all green locally)

- `npm run typecheck` — frontend + backend clean under 6.0.3
- `npm run lint` — flat config, clean
- `npm run build` — frontend + backend
- `npm run format:check` — clean
- `npm run test` — frontend 321 pass, backend 914 pass

## What a reviewer should check

- The `ignoreDeprecations: "6.0"` opt-in is acceptable as an interim vs. removing `baseUrl` now.
- Close stale Dependabot PR #80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)