### PR TITLE
fix(security): harden mail forwarder, rate-limit chat stream, tighten iam/pitr/mfa

### DIFF
--- a/backend/src/handlers/chat/streamHandler.ts
+++ b/backend/src/handlers/chat/streamHandler.ts
@@ -51,6 +51,14 @@ interface StreamRequestEvent {
   body?: string | null;
   isBase64Encoded?: boolean;
   headers?: Record<string, string | undefined>;
+  /**
+   * Connection metadata stamped by the Lambda Function URL service. We read
+   * ONLY `requestContext.http.sourceIp` — that value is set by AWS and the
+   * caller cannot forge it. This is deliberately NOT
+   * `requestContext.authorizer`: on an auth-NONE Function URL that field IS
+   * caller-controlled and is never trusted here for identity (see module doc).
+   */
+  requestContext?: { http?: { sourceIp?: string } };
 }
 
 /** Writable side of awslambda's responseStream (Node Writable subset). */
@@ -90,6 +98,62 @@ class HttpishError extends Error {
 }
 
 /**
+ * Per-source-IP request rate limit for the streaming chat Function URL.
+ *
+ * The Function URL has no API Gateway in front of it (auth NONE — see the
+ * module header), so it also inherits none of API Gateway's stage throttling.
+ * The Bedrock turn behind it is the most expensive path in the app, and the
+ * function caps at 15 reserved concurrent executions; without a brake a single
+ * source can rapid-fire requests, monopolise those 15 slots, and force a JWT
+ * verification + DynamoDB membership read on every one. This in-memory token
+ * bucket is that brake, checked before any of that work.
+ *
+ * Same per-warm-container caveat as middleware/rateLimit.ts: the effective
+ * ceiling multiplies with Lambda concurrency, so treat it as a brake on a
+ * single hot source, not a hard global cap — the 15 reserved-concurrency
+ * ceiling is the hard global limit. The per-household monthly token budget
+ * (services/chat) bounds total spend; this bounds burst rate.
+ *
+ * 60/min/IP is generous for an interactive chat shared behind a household NAT
+ * (a message every second sustained) but turns a reconnect flood from
+ * unbounded into bounded.
+ */
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX = 60;
+const RATE_LIMIT_SWEEP_THRESHOLD = 5_000;
+const rateBuckets = new Map<string, { count: number; resetAt: number }>();
+
+function enforceRateLimit(event: StreamRequestEvent): void {
+  // sourceIp is AWS-stamped connection metadata (unforgeable); fall back to a
+  // single shared bucket when absent (local/tests) rather than failing open
+  // per-request.
+  const key = event.requestContext?.http?.sourceIp ?? 'unknown';
+  const now = Date.now();
+  // Opportunistic sweep so the map can't grow unbounded over a warm
+  // container's life (one entry per distinct source IP).
+  if (rateBuckets.size > RATE_LIMIT_SWEEP_THRESHOLD) {
+    for (const [k, b] of rateBuckets) {
+      if (b.resetAt <= now) rateBuckets.delete(k);
+    }
+  }
+  const bucket = rateBuckets.get(key);
+  if (!bucket || bucket.resetAt <= now) {
+    rateBuckets.set(key, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+    return;
+  }
+  if (bucket.count >= RATE_LIMIT_MAX) {
+    throw new HttpishError(429, 'Too many requests. Please slow down and try again.');
+  }
+  bucket.count += 1;
+}
+
+/** Test hook — drops every in-memory rate-limit bucket so tests can run many
+ *  sequential requests from the same (absent) source IP without tripping. */
+export function __resetChatStreamRateLimitForTests(): void {
+  rateBuckets.clear();
+}
+
+/**
  * Authenticate + authorize the caller, mirroring middleware/auth.ts — except
  * the JWT is verified IN-HANDLER (signature, issuer, audience, expiry, and
  * token_use via aws-jwt-verify) because no API Gateway authorizer fronts the
@@ -104,6 +168,10 @@ class HttpishError extends Error {
 async function resolveUser(
   event: StreamRequestEvent
 ): Promise<{ userId: string; householdId: string }> {
+  // Rate-limit BEFORE any expensive work (JWT verify, membership read, Bedrock)
+  // so a flood is shed as cheaply as possible. Throws 429 when the per-IP
+  // bucket is exhausted.
+  enforceRateLimit(event);
   const authHeader = event.headers?.['authorization'] ?? event.headers?.['Authorization'];
   const token = typeof authHeader === 'string' ? authHeader.replace(/^Bearer\s+/i, '') : '';
   if (!token) {

--- a/backend/tests/unit/handlers/chatStreamHandler.test.ts
+++ b/backend/tests/unit/handlers/chatStreamHandler.test.ts
@@ -24,7 +24,11 @@ vi.mock('aws-jwt-verify', () => ({
 vi.mock('../../../src/services/householdService.js');
 vi.mock('../../../src/services/chat/index.js');
 
-import { streamRequestToSse, handler } from '../../../src/handlers/chat/streamHandler.js';
+import {
+  streamRequestToSse,
+  handler,
+  __resetChatStreamRateLimitForTests,
+} from '../../../src/handlers/chat/streamHandler.js';
 import { getMemberByUserId } from '../../../src/services/householdService.js';
 import { streamChatTurn } from '../../../src/services/chat/index.js';
 
@@ -68,6 +72,9 @@ afterAll(() => {
 beforeEach(() => {
   vi.clearAllMocks();
   metadataCalls.length = 0;
+  // Rate-limit buckets are module-level and per-warm-container; reset them so
+  // one test's requests don't count against the next.
+  __resetChatStreamRateLimitForTests();
 });
 
 const validClaims = {
@@ -187,6 +194,34 @@ describe('streamHandler auth (in-handler JWT verification)', () => {
     });
     expect(events.map((e) => e.type)).toEqual(['start', 'delta', 'done']);
     expect(stream.end).toHaveBeenCalled();
+  });
+
+  it('429s once the per-IP rate limit is exceeded, before verifying or streaming', async () => {
+    mockVerify.mockResolvedValue(validClaims);
+    vi.mocked(getMemberByUserId).mockResolvedValue({
+      userId: 'user-1',
+      role: 'member',
+    } as Awaited<ReturnType<typeof getMemberByUserId>>);
+    vi.mocked(streamChatTurn).mockImplementation(fakeTurn as unknown as typeof streamChatTurn);
+
+    const event = makeEvent({ requestContext: { http: { sourceIp: '203.0.113.7' } } });
+
+    // 60 requests/min/IP is the cap; the 61st from the same IP trips the limit.
+    for (let i = 0; i < 60; i++) {
+      const stream = makeStream();
+      await streamRequestToSse(event, stream);
+    }
+    const verifyCallsBefore = mockVerify.mock.calls.length;
+
+    const stream = makeStream();
+    await streamRequestToSse(event, stream);
+
+    expect(metadataCalls.at(-1)?.statusCode).toBe(429);
+    expect(JSON.parse(stream.chunks.join(''))).toEqual({
+      message: 'Too many requests. Please slow down and try again.',
+    });
+    // The rejected request short-circuits before JWT verification runs again.
+    expect(mockVerify.mock.calls.length).toBe(verifyCallsBefore);
   });
 
   it('buffered fallback handler also 401s with JSON {message} on a forged token', async () => {

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -136,6 +136,10 @@ module "monitoring" {
   api_endpoint          = module.api.api_gateway_endpoint
   monthly_budget_usd    = var.monthly_budget_usd
   lambda_dlq_name       = module.api.lambda_dlq_name
+  # Wired only when the email module is provisioned (domain set). No cycle:
+  # monitoring already depends on api (which depends on email), and email
+  # depends on nothing here.
+  email_forwarder_dlq_name = var.domain_name == "" ? "" : module.email[0].forwarder_dlq_name
 }
 
 # NOTE: the WAF (`modules/security`) was removed for cost (~$8-16/mo) — its

--- a/infrastructure/modules/api/main.tf
+++ b/infrastructure/modules/api/main.tf
@@ -1,3 +1,6 @@
+# Account id for scoping IAM resource ARNs (e.g. the SES send fallback below).
+data "aws_caller_identity" "current" {}
+
 # API Gateway
 resource "aws_apigatewayv2_api" "main" {
   name          = "${var.project_name}-api-${var.environment}"
@@ -135,15 +138,17 @@ resource "aws_iam_role_policy" "lambda" {
       },
       {
         # Reminder email via SES. Scoped to the verified domain identity when
-        # one is provisioned (prod); identity-less environments (dev/staging
-        # without a domain) keep "*", where SES can't send anyway because no
-        # identity is verified.
+        # one is provisioned (prod). Identity-less environments (dev/staging
+        # without a domain) can't send at all — no identity is verified — but
+        # rather than fall back to "*", scope to THIS account's SES identities
+        # so the grant can never apply outside the account even if one is later
+        # verified.
         Effect = "Allow"
         Action = [
           "ses:SendEmail",
           "ses:SendRawEmail"
         ]
-        Resource = var.ses_identity_arn == "" ? "*" : var.ses_identity_arn
+        Resource = var.ses_identity_arn == "" ? "arn:aws:ses:*:${data.aws_caller_identity.current.account_id}:identity/*" : var.ses_identity_arn
       },
       {
         # Reminder SMS via SNS. Resource "*" is REQUIRED by AWS here:

--- a/infrastructure/modules/auth/main.tf
+++ b/infrastructure/modules/auth/main.tf
@@ -19,11 +19,25 @@ resource "aws_cognito_user_pool" "main" {
   }
 
   password_policy {
-    minimum_length    = 8
+    # 12-char floor: with Threat Protection's compromised-credential checks
+    # already on, length is the cheapest remaining win against offline/guessing
+    # attacks. Still no required symbols — NIST 800-63B guidance favours length
+    # over composition rules, and the leaked-password check covers the weak ones.
+    minimum_length    = 12
     require_lowercase = true
     require_numbers   = true
     require_symbols   = false
     require_uppercase = true
+  }
+
+  # Optional TOTP (authenticator-app) MFA. OPTIONAL means users may enrol a
+  # software token but aren't forced to — non-breaking for existing accounts,
+  # while letting security-conscious household owners (who control the
+  # authorization attributes) harden their own login. SMS MFA is deliberately
+  # left off: it's the weaker factor and carries per-message cost.
+  mfa_configuration = "OPTIONAL"
+  software_token_mfa_configuration {
+    enabled = true
   }
 
   account_recovery_setting {

--- a/infrastructure/modules/cicd/main.tf
+++ b/infrastructure/modules/cicd/main.tf
@@ -206,14 +206,28 @@ resource "aws_iam_policy" "deploy" {
       },
       {
         # Lambdas fetch secrets at runtime; the deploy role itself only ever
-        # needs to read them (e.g. data sources / debugging), never write.
+        # needs to READ the project's own secrets (terraform data sources /
+        # debugging), never write and never read another project's secrets.
+        # Get/Describe support resource-level scoping, so pin them to the
+        # `family-greenhouse/*` prefix — without this the CI role could read
+        # every secret in the account.
         Sid    = "SecretsRead"
         Effect = "Allow"
         Action = [
           "secretsmanager:GetSecretValue",
           "secretsmanager:DescribeSecret",
-          "secretsmanager:ListSecrets",
         ]
+        Resource = [
+          "arn:aws:secretsmanager:*:${data.aws_caller_identity.current.account_id}:secret:${var.project_name}/*",
+        ]
+      },
+      {
+        # ListSecrets enumerates metadata only (no values) and does NOT support
+        # resource-level permissions — it can only be granted on "*". Split out
+        # so the value-reading actions above stay prefix-scoped.
+        Sid      = "SecretsList"
+        Effect   = "Allow"
+        Action   = ["secretsmanager:ListSecrets"]
         Resource = "*"
       },
     ]

--- a/infrastructure/modules/database/main.tf
+++ b/infrastructure/modules/database/main.tf
@@ -56,8 +56,14 @@ resource "aws_dynamodb_table" "main" {
     enabled        = true
   }
 
+  # Point-in-time recovery in every environment. Continuous backups are a few
+  # cents/month for a table this size, and the protection (recover from a bad
+  # migration, an errant batch delete, or a bug that corrupts rows) is worth it
+  # in staging too — staging increasingly holds real-shaped data used to
+  # validate releases, and "it's only staging" is exactly when an unrecoverable
+  # mistake hurts.
   point_in_time_recovery {
-    enabled = var.environment == "production"
+    enabled = true
   }
 
   server_side_encryption {

--- a/infrastructure/modules/email/inbound.tf
+++ b/infrastructure/modules/email/inbound.tf
@@ -96,6 +96,23 @@ resource "aws_s3_bucket_policy" "inbound_mail" {
 
 # --- Forwarder Lambda -------------------------------------------------------
 
+# Dead-letter queue for the async (Event-invoked) forwarder. Without it, a
+# forward that throws past Lambda's two automatic retries is dropped silently —
+# unacceptable for a path that carries security@ / abuse@ mail. Failed
+# invocations land here for inspection + redrive, and the depth alarm (in the
+# monitoring module, fed via the forwarder_dlq_name output) pages on any
+# message.
+resource "aws_sqs_queue" "forwarder_dlq" {
+  name = "${var.project_name}-mail-forwarder-dlq-${var.environment}"
+  # Max retention so a failure over a weekend is still redrivable on Monday.
+  message_retention_seconds = 1209600 # 14 days
+  sqs_managed_sse_enabled   = true
+
+  tags = {
+    Name = "${var.project_name}-mail-forwarder-dlq-${var.environment}"
+  }
+}
+
 data "archive_file" "forwarder" {
   type        = "zip"
   source_file = "${path.module}/lambda/forwarder.mjs"
@@ -131,6 +148,14 @@ resource "aws_iam_role_policy" "forwarder" {
         Resource = "${aws_s3_bucket.inbound_mail.arn}/*"
       },
       {
+        # Async DLQ delivery: Lambda uses the FUNCTION's execution role to send
+        # a failed invocation to the dead_letter_config target, so the role
+        # needs sqs:SendMessage on the forwarder DLQ.
+        Effect   = "Allow"
+        Action   = ["sqs:SendMessage"]
+        Resource = aws_sqs_queue.forwarder_dlq.arn
+      },
+      {
         # identity/* (account-scoped), not just the domain identity: while the
         # account is in the SES sandbox, sends are ALSO authorized against the
         # recipient's verified-identity ARN (the forward destination is a
@@ -153,6 +178,13 @@ resource "aws_lambda_function" "forwarder" {
   memory_size      = 256
   filename         = data.archive_file.forwarder.output_path
   source_code_hash = data.archive_file.forwarder.output_base64sha256
+
+  # Route invocations that exhaust Lambda's async retries to the DLQ instead of
+  # dropping them. The handler rethrows on any forward failure precisely so the
+  # message reaches this queue.
+  dead_letter_config {
+    target_arn = aws_sqs_queue.forwarder_dlq.arn
+  }
 
   environment {
     variables = {

--- a/infrastructure/modules/email/lambda/forwarder.mjs
+++ b/infrastructure/modules/email/lambda/forwarder.mjs
@@ -68,20 +68,50 @@ function rewrite(raw, originalRecipient) {
 export const handler = async (event) => {
   const record = event.Records?.[0]?.ses;
   if (!record) return { skipped: true };
-  const messageId = record.mail.messageId;
-  const recipient = record.receipt.recipients?.[0] ?? 'unknown@unknown';
+  const messageId = record.mail?.messageId;
+  const recipient = record.receipt?.recipients?.[0] ?? 'unknown@unknown';
 
-  const obj = await s3.send(new GetObjectCommand({ Bucket: BUCKET, Key: `${PREFIX}${messageId}` }));
-  const raw = await obj.Body.transformToString();
+  // SES stamps spam/virus scan verdicts on the receipt (the receipt rule sets
+  // scan_enabled = true). Refuse to relay anything that FAILED the virus or
+  // spam scan: this forwarder re-sends from our DKIM-aligned domain, so passing
+  // malware/phishing through would launder it under our domain's reputation
+  // straight into the maintainer's inbox. We gate ONLY on virus/spam — not
+  // DKIM/SPF/DMARC, which legitimately fail for plenty of forwarded list mail.
+  // A FAIL is an expected verdict, not a processing error, so we drop and
+  // return cleanly (no throw → no retry, no DLQ).
+  const spam = record.receipt?.spamVerdict?.status;
+  const virus = record.receipt?.virusVerdict?.status;
+  if (spam === 'FAIL' || virus === 'FAIL') {
+    console.log(
+      JSON.stringify({ msg: 'mail_dropped_scan_fail', messageId, recipient, spam, virus })
+    );
+    return { dropped: true, reason: 'scan_failed' };
+  }
 
-  await ses.send(
-    new SendRawEmailCommand({
-      Source: FROM_ADDRESS,
-      Destinations: [FORWARD_TO],
-      RawMessage: { Data: Buffer.from(rewrite(raw, recipient)) },
-    })
-  );
+  try {
+    const obj = await s3.send(
+      new GetObjectCommand({ Bucket: BUCKET, Key: `${PREFIX}${messageId}` })
+    );
+    const raw = await obj.Body.transformToString();
 
-  console.log(JSON.stringify({ msg: 'mail_forwarded', messageId, recipient, to: 'redacted' }));
-  return { forwarded: true, messageId };
+    await ses.send(
+      new SendRawEmailCommand({
+        Source: FROM_ADDRESS,
+        Destinations: [FORWARD_TO],
+        RawMessage: { Data: Buffer.from(rewrite(raw, recipient)) },
+      })
+    );
+
+    console.log(JSON.stringify({ msg: 'mail_forwarded', messageId, recipient, to: 'redacted' }));
+    return { forwarded: true, messageId };
+  } catch (err) {
+    // Log loudly AND rethrow. This Lambda is invoked asynchronously
+    // (invocation_type = Event), so a throw is what routes the message to the
+    // forwarder DLQ (and trips the depth alarm) for inspection + redrive.
+    // Swallowing the error here would silently lose security@/abuse@ mail.
+    console.error(
+      JSON.stringify({ msg: 'mail_forward_failed', messageId, recipient, error: err?.message })
+    );
+    throw err;
+  }
 };

--- a/infrastructure/modules/email/outputs.tf
+++ b/infrastructure/modules/email/outputs.tf
@@ -7,3 +7,8 @@ output "from_email_default" {
   description = "Sensible default sender address. Pin a friendly name in the caller."
   value       = "hello@${var.domain_name}"
 }
+
+output "forwarder_dlq_name" {
+  description = "SQS queue name of the inbound-mail forwarder dead-letter queue — feed into the monitoring module's depth alarm."
+  value       = aws_sqs_queue.forwarder_dlq.name
+}

--- a/infrastructure/modules/monitoring/main.tf
+++ b/infrastructure/modules/monitoring/main.tf
@@ -485,6 +485,36 @@ resource "aws_cloudwatch_metric_alarm" "lambda_dlq_depth" {
   }
 }
 
+# Inbound-mail forwarder DLQ depth. Any message here = a forward (security@ /
+# abuse@ / support@ mail) failed past its async retries and was dead-lettered —
+# silent loss of mail we explicitly want to see. Separate from lambda_dlq_depth
+# (the reminders DLQ) because the email module owns its own queue and is only
+# created when a domain is configured. treat_missing_data = notBreaching so a
+# normally-empty queue doesn't false-alarm.
+resource "aws_cloudwatch_metric_alarm" "email_forwarder_dlq_depth" {
+  count = var.email_forwarder_dlq_name == "" ? 0 : 1
+
+  alarm_name          = "${var.project_name}-mail-forwarder-dlq-not-empty-${var.environment}"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "ApproximateNumberOfMessagesVisible"
+  namespace           = "AWS/SQS"
+  period              = 300
+  statistic           = "Maximum"
+  threshold           = 0
+  alarm_description   = "Messages in the inbound-mail forwarder DLQ — a forward (security@/abuse@/support@) failed and was dead-lettered. Inspect + redrive."
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    QueueName = var.email_forwarder_dlq_name
+  }
+
+  tags = {
+    Name = "${var.project_name}-mail-forwarder-dlq-alarm-${var.environment}"
+  }
+}
+
 # Audit alarm: failed-login spike (possible credential stuffing / brute force).
 # A metric filter turns the structured audit log line (pino JSON,
 # `event: "auth.login.failure"`) on the auth Lambda's log group into a metric;

--- a/infrastructure/modules/monitoring/variables.tf
+++ b/infrastructure/modules/monitoring/variables.tf
@@ -53,3 +53,9 @@ variable "lambda_dlq_name" {
   type        = string
   default     = ""
 }
+
+variable "email_forwarder_dlq_name" {
+  description = "SQS queue name of the inbound-mail forwarder DLQ. Empty (no domain / email module not provisioned) disables the alarm."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
Follow-ups from a full-repo security review. No Critical/High exploitable issues were found; these are the actionable hardening items.

## Changes

**Mail forwarder resilience (`infrastructure/modules/email`)**
- Drop messages that FAIL the SES virus/spam scan instead of relaying attacker content from our DKIM-aligned domain into the maintainer's inbox.
- Wrap the forward in try/catch + rethrow so a failed async invocation reaches a **new SQS dead-letter queue** (14-day retention, SSE) instead of vanishing after Lambda's retries.
- Add the `dead_letter_config`, the `sqs:SendMessage` grant, and a **CloudWatch DLQ-depth alarm** (monitoring module) so dropped `security@`/`abuse@`/`support@` mail pages.

**Chat streaming Function URL rate limit (`backend/src/handlers/chat/streamHandler.ts`)**
- The Function URL has auth NONE and no API Gateway throttling; add an in-handler per-source-IP token bucket (60/min) checked **before** JWT verification, membership lookup, or any Bedrock call, so a reconnect flood can't monopolise the 15 reserved concurrent executions.
- Keyed on AWS-stamped `requestContext.http.sourceIp` (unforgeable); never reads `requestContext.authorizer`. New unit test covers the 429 path.

**Low-severity IAM / infra hardening**
- `cicd`: scope the deploy role's `secretsmanager` Get/Describe to `family-greenhouse/*` (was `*`, i.e. every secret in the account); `ListSecrets` stays on `*` (no resource-level form).
- `api`: scope the SES send IAM fallback (no verified identity) to this account's SES identities instead of `*`.
- `database`: enable DynamoDB **point-in-time recovery in all environments** (was production-only).
- `auth`: raise Cognito password floor 8→12 chars and add **OPTIONAL TOTP MFA** (non-breaking for existing accounts).

## Verification
- Backend: `tsc` clean, ESLint clean, **915/915 tests pass** (incl. new rate-limit test).
- Terraform: `terraform fmt -check` clean. (`validate` couldn't run in CI sandbox — provider registry is network-blocked there, unrelated to these changes.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014abKA3txbQXT7Xe9cpKN79

---
_Generated by [Claude Code](https://claude.ai/code/session_014abKA3txbQXT7Xe9cpKN79)_