### PR TITLE
feat(billing): add lifetime plan (Garden one-time $149 Stripe payment)

### DIFF
--- a/backend/src/handlers/billing/handler.ts
+++ b/backend/src/handlers/billing/handler.ts
@@ -20,12 +20,18 @@ import { getPlan } from '../../models/plans.js';
 import { successResponse, cacheableResponse } from '../../utils/response.js';
 import { logger } from '../../utils/logger.js';
 
-const checkoutSchema = z.object({
-  planId: z.enum(['garden', 'greenhouse']),
-  // Billing cadence. Optional + defaulted so existing clients that send only
-  // `planId` keep getting a monthly subscription unchanged.
-  interval: z.enum(['month', 'year']).optional().default('month'),
-});
+const checkoutSchema = z
+  .object({
+    planId: z.enum(['garden', 'greenhouse']),
+    // Billing cadence. Optional + defaulted so existing clients that send only
+    // `planId` keep getting a monthly subscription unchanged. `lifetime` is a
+    // one-time payment offered on Garden only (enforced by the refine below).
+    interval: z.enum(['month', 'year', 'lifetime']).optional().default('month'),
+  })
+  .refine((v) => v.interval !== 'lifetime' || v.planId === 'garden', {
+    message: 'The lifetime plan is only available for the Garden tier.',
+    path: ['interval'],
+  });
 
 type CheckoutInput = z.infer<typeof checkoutSchema>;
 

--- a/backend/src/local-server.ts
+++ b/backend/src/local-server.ts
@@ -41,6 +41,7 @@ import {
 } from './models/schemas.js';
 import { TEMPLATES } from './models/taskTemplates.js';
 import { PLANS } from './models/plans.js';
+import { planSummary } from './services/billing.js';
 import { lookupToxicity } from './models/petToxicity.js';
 
 // Hard refusal to boot in production — this server has no real auth, no
@@ -2781,17 +2782,10 @@ app.get('/species/:id/guide', authMiddleware, (req, res) => {
 
 app.get('/billing/plans', (_req, res) => {
   res.set('Cache-Control', 'public, max-age=300');
-  // Same projection as billing.planSummary (never leak stripePriceEnv).
-  res.json(
-    Object.values(PLANS).map((p) => ({
-      id: p.id,
-      name: p.name,
-      description: p.description,
-      monthlyPrice: p.monthlyPrice,
-      maxPlants: p.maxPlants,
-      maxMembers: p.maxMembers,
-    }))
-  );
+  // Reuse the production projection so the dev server can't drift from the
+  // real /billing/plans contract (annualPrice, lifetimePrice, …) and never
+  // leaks stripePriceEnv.
+  res.json(Object.values(PLANS).map(planSummary));
 });
 
 app.get('/billing/me', authMiddleware, requireHousehold, (req, res) => {

--- a/backend/src/models/plans.ts
+++ b/backend/src/models/plans.ts
@@ -24,6 +24,14 @@ export interface Plan {
   /** Env var name where the Stripe ANNUAL price ID lives. Paired with
    *  `annualPrice`; absent on the free tier. */
   annualStripePriceEnv?: string;
+  /** Lifetime price in dollars for a one-time payment that grants this tier's
+   *  entitlement permanently. Modeled as a one-time billing interval on the
+   *  existing tier (NOT a new planId), so entitlement resolution and the
+   *  3-plan catalog stay unchanged. Only the Garden tier offers one. */
+  lifetimePrice?: number;
+  /** Env var name where the Stripe LIFETIME (one-time) price ID lives. Paired
+   *  with `lifetimePrice`; absent on tiers without a lifetime option. */
+  lifetimeStripePriceEnv?: string;
 }
 
 export const PLANS: Record<PlanId, Plan> = {
@@ -43,10 +51,14 @@ export const PLANS: Record<PlanId, Plan> = {
     // ~33% off 12× monthly ($59.88) — "$3.33/mo billed yearly". Sits in the
     // competitive annual band ($30–48) the market actually pays at.
     annualPrice: 39.99,
+    // One-time payment that grants Garden permanently. Stored as planId='garden'
+    // with no subscription — entitlement resolves off planId alone.
+    lifetimePrice: 149,
     maxPlants: 500,
     maxMembers: 6,
     stripePriceEnv: 'STRIPE_PRICE_ID_GARDEN',
     annualStripePriceEnv: 'STRIPE_PRICE_ID_GARDEN_ANNUAL',
+    lifetimeStripePriceEnv: 'STRIPE_PRICE_ID_GARDEN_LIFETIME',
   },
   greenhouse: {
     id: 'greenhouse',

--- a/backend/src/services/billing.ts
+++ b/backend/src/services/billing.ts
@@ -64,13 +64,20 @@ export async function getHouseholdSubscription(
  *
  * Returns `true` when the write was applied, `false` when it was skipped as
  * out-of-order.
+ *
+ * A field set to `null` is REMOVEd from the row (vs `undefined`, which is
+ * simply not written). This is how a lifetime grant clears a household's
+ * stale `stripeSubscriptionId`/`currentPeriodEnd` — a one-time purchase has
+ * no subscription, so leaving the old id behind would make the row claim a
+ * phantom subscription.
  */
 export async function updateHouseholdSubscription(
   householdId: string,
-  fields: Partial<HouseholdSubscription>,
+  fields: Partial<Record<keyof HouseholdSubscription, unknown>>,
   stripeEventCreated?: number
 ): Promise<boolean> {
-  const expressions: string[] = [];
+  const setExpressions: string[] = [];
+  const removeExpressions: string[] = [];
   const names: Record<string, string> = {};
   const values: Record<string, unknown> = {};
 
@@ -85,15 +92,20 @@ export async function updateHouseholdSubscription(
   for (const [key, value] of Object.entries(fields)) {
     if (value === undefined) continue;
     const attr = map[key as keyof HouseholdSubscription];
-    expressions.push(`#${attr} = :${attr}`);
     names[`#${attr}`] = attr;
-    values[`:${attr}`] = value;
+    if (value === null) {
+      // Explicit clear → REMOVE the attribute entirely.
+      removeExpressions.push(`#${attr}`);
+    } else {
+      setExpressions.push(`#${attr} = :${attr}`);
+      values[`:${attr}`] = value;
+    }
   }
-  if (expressions.length === 0) return true;
+  if (setExpressions.length === 0 && removeExpressions.length === 0) return true;
 
   let conditionExpression: string | undefined;
   if (typeof stripeEventCreated === 'number') {
-    expressions.push('#lastStripeEventCreated = :lastStripeEventCreated');
+    setExpressions.push('#lastStripeEventCreated = :lastStripeEventCreated');
     names['#lastStripeEventCreated'] = 'lastStripeEventCreated';
     values[':lastStripeEventCreated'] = stripeEventCreated;
     // <= (not <) so two events minted in the same second still both apply;
@@ -102,14 +114,18 @@ export async function updateHouseholdSubscription(
       'attribute_not_exists(lastStripeEventCreated) OR lastStripeEventCreated <= :lastStripeEventCreated';
   }
 
+  const clauses: string[] = [];
+  if (setExpressions.length > 0) clauses.push(`SET ${setExpressions.join(', ')}`);
+  if (removeExpressions.length > 0) clauses.push(`REMOVE ${removeExpressions.join(', ')}`);
+
   try {
     await dynamodb.send(
       new UpdateCommand({
         TableName: TABLE_NAME,
         Key: { PK: `HOUSEHOLD#${householdId}`, SK: 'METADATA' },
-        UpdateExpression: `SET ${expressions.join(', ')}`,
+        UpdateExpression: clauses.join(' '),
         ExpressionAttributeNames: names,
-        ExpressionAttributeValues: values,
+        ExpressionAttributeValues: Object.keys(values).length > 0 ? values : undefined,
         ConditionExpression: conditionExpression,
       })
     );
@@ -135,8 +151,12 @@ export interface CheckoutSessionResult {
  * is sold at either cadence — only the Stripe price and the headline number
  * differ — so the entire webhook/entitlement path stays cadence-agnostic and
  * resolves access off `planId` alone.
+ *
+ * `lifetime` is a one-time payment (Stripe `mode:'payment'`) rather than a
+ * recurring subscription — it grants the same `planId` permanently with no
+ * subscription to renew or cancel. Only the Garden tier offers it.
  */
-export type BillingInterval = 'month' | 'year';
+export type BillingInterval = 'month' | 'year' | 'lifetime';
 
 export async function createCheckoutSession(args: {
   householdId: string;
@@ -148,7 +168,12 @@ export async function createCheckoutSession(args: {
 }): Promise<CheckoutSessionResult> {
   const plan = getPlan(args.planId);
   const interval: BillingInterval = args.interval ?? 'month';
-  const priceEnv = interval === 'year' ? plan.annualStripePriceEnv : plan.stripePriceEnv;
+  const priceEnv =
+    interval === 'lifetime'
+      ? plan.lifetimeStripePriceEnv
+      : interval === 'year'
+        ? plan.annualStripePriceEnv
+        : plan.stripePriceEnv;
   if (!priceEnv) throw new Error(`Plan ${plan.id} is not billable ${interval}ly`);
   const priceId = process.env[priceEnv];
   if (!priceId) throw new Error(`Missing ${priceEnv} for plan ${plan.id}`);
@@ -158,8 +183,11 @@ export async function createCheckoutSession(args: {
   // `interval` is stamped onto metadata for analytics/debugging only —
   // entitlement is resolved from `planId`, never the cadence.
   const metadata = { householdId: args.householdId, planId: plan.id, interval };
-  const session = await stripe.checkout.sessions.create({
-    mode: 'subscription',
+
+  // Lifetime is a one-time charge: Stripe `mode:'payment'` with NO
+  // subscription_data/trial. Month/year stay recurring subscriptions exactly
+  // as before. The webhook branches on `session.mode` to mirror this split.
+  const common = {
     customer: sub.stripeCustomerId,
     customer_email: sub.stripeCustomerId ? undefined : args.customerEmail,
     line_items: [{ price: priceId, quantity: 1 }],
@@ -167,11 +195,18 @@ export async function createCheckoutSession(args: {
     cancel_url: args.cancelUrl,
     client_reference_id: args.householdId,
     metadata,
-    subscription_data: {
-      metadata,
-      trial_period_days: 14,
-    },
-  });
+  };
+  const session =
+    interval === 'lifetime'
+      ? await stripe.checkout.sessions.create({ mode: 'payment', ...common })
+      : await stripe.checkout.sessions.create({
+          mode: 'subscription',
+          ...common,
+          subscription_data: {
+            metadata,
+            trial_period_days: 14,
+          },
+        });
   if (!session.url) throw new Error('Stripe did not return a checkout URL');
   return { url: session.url };
 }
@@ -199,7 +234,13 @@ export async function createPortalSession(
  */
 export interface SubscriptionDelta {
   householdId: string;
-  fields: Partial<HouseholdSubscription>;
+  // `null` on stripeSubscriptionId/currentPeriodEnd means "clear this attribute"
+  // (REMOVE) — used by a lifetime grant to wipe a prior subscription's stale
+  // ids. Other fields keep their normal types.
+  fields: Partial<Omit<HouseholdSubscription, 'stripeSubscriptionId' | 'currentPeriodEnd'>> & {
+    stripeSubscriptionId?: string | null;
+    currentPeriodEnd?: string | null;
+  };
 }
 
 /**
@@ -230,12 +271,40 @@ export function deltaForStripeEvent(event: Stripe.Event): SubscriptionDelta | nu
       if (!householdId) return null;
       const planId = planIdFromMetadata(event, session.metadata);
       if (!planId) return null;
+      const stripeCustomerId =
+        typeof session.customer === 'string' ? session.customer : session.customer?.id;
+      // Be defensive reading `mode`/`payment_status` — cast the object.
+      const mode = (session as unknown as { mode?: string }).mode;
+      const paymentStatus = (session as unknown as { payment_status?: string }).payment_status;
+      if (mode === 'payment') {
+        // Lifetime one-time purchase. Only grant entitlement once Stripe says
+        // the charge is paid; deferred/async payment methods complete later.
+        // No subscription is created, so we CLEAR any stale stripeSubscriptionId
+        // and currentPeriodEnd (a prior subscriber upgrading to lifetime would
+        // otherwise leave a phantom subscription on the row — and a later
+        // subscription.deleted for that old sub would wrongly downgrade this
+        // now-permanent household). `applyStripeEvent` also cancels the old
+        // Stripe subscription so no such events ever fire. Entitlement is
+        // permanent and resolves off planId alone.
+        if (paymentStatus !== 'paid') return null;
+        return {
+          householdId,
+          fields: {
+            planId,
+            stripeCustomerId,
+            status: 'active',
+            stripeSubscriptionId: null,
+            currentPeriodEnd: null,
+          },
+        };
+      }
+      // mode==='subscription' (or undefined → treat as subscription for
+      // back-compat with the existing recurring checkout flow).
       return {
         householdId,
         fields: {
           planId,
-          stripeCustomerId:
-            typeof session.customer === 'string' ? session.customer : session.customer?.id,
+          stripeCustomerId,
           stripeSubscriptionId:
             typeof session.subscription === 'string'
               ? session.subscription
@@ -321,6 +390,45 @@ export async function applyStripeEvent(event: Stripe.Event): Promise<void> {
   const delta = deltaForStripeEvent(event);
   if (!delta) return;
 
+  // Guard a lifetime household against a stale `subscription.deleted` wiping
+  // its permanent grant. A lifetime purchase CLEARS the stored
+  // stripeSubscriptionId (and cancels the old sub below); if a deletion then
+  // arrives for a subscription this household no longer references — or for a
+  // household with no subscription on file at all — it must NOT downgrade to
+  // seedling. (created/updated are not guarded: they re-assert a subscription
+  // id, so they only ever move the row toward a consistent subscribed state,
+  // and the out-of-order `event.created` guard already protects them.)
+  if (event.type === 'customer.subscription.deleted') {
+    const deletedSubId = (event.data.object as unknown as { id?: string }).id;
+    const current = await getHouseholdSubscription(delta.householdId);
+    if (!current.stripeSubscriptionId || current.stripeSubscriptionId !== deletedSubId) {
+      logger.info(
+        {
+          stripeEventId: event.id,
+          type: event.type,
+          householdId: delta.householdId,
+          deletedSubscriptionId: deletedSubId ?? null,
+          householdSubscriptionId: current.stripeSubscriptionId ?? null,
+        },
+        'stripe_event_subscription_mismatch_skipped'
+      );
+      return;
+    }
+  }
+
+  // A paid lifetime checkout clears the stored subscription id (delta sets it
+  // to null). Capture the prior id BEFORE the apply wipes it, so we can cancel
+  // the now-orphaned Stripe subscription afterwards — otherwise it keeps
+  // billing and later emits deleted/updated events.
+  const isLifetimeGrant =
+    event.type === 'checkout.session.completed' &&
+    (event.data.object as unknown as { mode?: string }).mode === 'payment' &&
+    delta.fields.stripeSubscriptionId === null;
+  let priorSubscriptionId: string | undefined;
+  if (isLifetimeGrant) {
+    priorSubscriptionId = (await getHouseholdSubscription(delta.householdId)).stripeSubscriptionId;
+  }
+
   // Apply FIRST, record SECOND. If the apply throws, we return 5xx to Stripe
   // without having touched the ledger, so Stripe's retry gets a clean run.
   // (The old record-first order permanently skipped an event whose apply
@@ -333,6 +441,25 @@ export async function applyStripeEvent(event: Stripe.Event): Promise<void> {
       'stripe_event_out_of_order_skipped'
     );
     return;
+  }
+
+  if (priorSubscriptionId) {
+    // Best-effort: a failure here must not 5xx the webhook (the entitlement is
+    // already granted). Worst case the old sub keeps billing, but the mismatch
+    // guard above stops its events from revoking the lifetime grant.
+    try {
+      const stripe = await getStripe();
+      await stripe.subscriptions.cancel(priorSubscriptionId);
+      logger.info(
+        { householdId: delta.householdId, subscriptionId: priorSubscriptionId },
+        'lifetime_grant_canceled_prior_subscription'
+      );
+    } catch (err) {
+      logger.error(
+        { err, householdId: delta.householdId, subscriptionId: priorSubscriptionId },
+        'lifetime_grant_cancel_prior_subscription_failed'
+      );
+    }
   }
 
   const isNew = await recordStripeEventOnce(event.id);
@@ -356,6 +483,7 @@ export function planSummary(plan: Plan): {
   description: string;
   monthlyPrice: number;
   annualPrice: number | null;
+  lifetimePrice: number | null;
   maxPlants: number;
   maxMembers: number;
 } {
@@ -367,6 +495,8 @@ export function planSummary(plan: Plan): {
     // null (not undefined) so it survives JSON serialization as an explicit
     // "no annual option" signal the client can branch on.
     annualPrice: plan.annualPrice ?? null,
+    // Same null-not-undefined contract: null means "no lifetime option".
+    lifetimePrice: plan.lifetimePrice ?? null,
     maxPlants: plan.maxPlants,
     maxMembers: plan.maxMembers,
   };

--- a/backend/tests/unit/handlers/billing.test.ts
+++ b/backend/tests/unit/handlers/billing.test.ts
@@ -258,6 +258,47 @@ describe('billing handler', () => {
       );
     });
 
+    it('passes interval=lifetime through to the checkout session for Garden', async () => {
+      const billing = await import('../../../src/services/billing.js');
+      const { checkout } = await import('../../../src/handlers/billing/handler.js');
+
+      vi.mocked(billing.createCheckoutSession).mockResolvedValueOnce({
+        url: 'https://checkout.stripe.test/lifetime',
+      });
+
+      const res = (await checkout(
+        buildEvent({
+          body: JSON.stringify({ planId: 'garden', interval: 'lifetime' }),
+          headers: { 'content-type': 'application/json' },
+        }),
+        ctx,
+        () => {}
+      )) as APIGatewayProxyResult;
+
+      expect(res.statusCode).toBe(200);
+      expect(billing.createCheckoutSession).toHaveBeenCalledWith(
+        expect.objectContaining({ planId: 'garden', interval: 'lifetime' })
+      );
+    });
+
+    it('rejects interval=lifetime for a non-Garden tier (Greenhouse) with a 400', async () => {
+      const billing = await import('../../../src/services/billing.js');
+      const { checkout } = await import('../../../src/handlers/billing/handler.js');
+
+      const res = (await checkout(
+        buildEvent({
+          body: JSON.stringify({ planId: 'greenhouse', interval: 'lifetime' }),
+          headers: { 'content-type': 'application/json' },
+        }),
+        ctx,
+        () => {}
+      )) as APIGatewayProxyResult;
+
+      expect(res.statusCode).toBe(400);
+      // The lifetime refine must reject before any Stripe call is attempted.
+      expect(billing.createCheckoutSession).not.toHaveBeenCalled();
+    });
+
     it('rejects an unknown billing interval at the validation layer', async () => {
       const { checkout } = await import('../../../src/handlers/billing/handler.js');
       const res = (await checkout(

--- a/backend/tests/unit/models/plans.test.ts
+++ b/backend/tests/unit/models/plans.test.ts
@@ -27,6 +27,15 @@ describe('plan catalog', () => {
     expect(PLANS.greenhouse.annualStripePriceEnv).toBe('STRIPE_PRICE_ID_GREENHOUSE_ANNUAL');
   });
 
+  it('Garden alone carries a lifetime price + lifetime Stripe price env; other tiers have neither', () => {
+    expect(PLANS.garden.lifetimePrice).toBe(149);
+    expect(PLANS.garden.lifetimeStripePriceEnv).toBe('STRIPE_PRICE_ID_GARDEN_LIFETIME');
+    expect(PLANS.seedling.lifetimePrice).toBeUndefined();
+    expect(PLANS.seedling.lifetimeStripePriceEnv).toBeUndefined();
+    expect(PLANS.greenhouse.lifetimePrice).toBeUndefined();
+    expect(PLANS.greenhouse.lifetimeStripePriceEnv).toBeUndefined();
+  });
+
   it('annual price is a genuine discount vs 12x the monthly price', () => {
     for (const id of ['garden', 'greenhouse'] as const) {
       const plan = PLANS[id];

--- a/backend/tests/unit/services/billing.test.ts
+++ b/backend/tests/unit/services/billing.test.ts
@@ -5,10 +5,16 @@ import type Stripe from 'stripe';
 // createCheckoutSession can be exercised without a network/key. `sessionsCreate`
 // is hoisted (vi.mock factories run before module init) and shared so tests can
 // assert what was sent to Stripe.
-const { sessionsCreate } = vi.hoisted(() => ({ sessionsCreate: vi.fn() }));
+const { sessionsCreate, subscriptionsCancel } = vi.hoisted(() => ({
+  sessionsCreate: vi.fn(),
+  subscriptionsCancel: vi.fn(),
+}));
 vi.mock('stripe', () => ({
   default: vi.fn(function () {
-    return { checkout: { sessions: { create: sessionsCreate } } };
+    return {
+      checkout: { sessions: { create: sessionsCreate } },
+      subscriptions: { cancel: subscriptionsCancel },
+    };
   }),
 }));
 
@@ -60,6 +66,74 @@ describe('deltaForStripeEvent', () => {
     } as unknown as Stripe.Event;
     const delta = deltaForStripeEvent(event);
     expect(delta).toEqual({
+      householdId: 'hh-1',
+      fields: {
+        planId: 'garden',
+        stripeCustomerId: 'cus_123',
+        stripeSubscriptionId: 'sub_456',
+        status: 'active',
+      },
+    });
+  });
+
+  it('grants Garden permanently on a paid lifetime (mode=payment) checkout — no subscription id', async () => {
+    const { deltaForStripeEvent } = await import('../../../src/services/billing.js');
+    const event = {
+      type: 'checkout.session.completed',
+      data: {
+        object: {
+          mode: 'payment',
+          payment_status: 'paid',
+          metadata: { householdId: 'hh-1', planId: 'garden', interval: 'lifetime' },
+          customer: 'cus_123',
+        },
+      },
+    } as unknown as Stripe.Event;
+    const delta = deltaForStripeEvent(event);
+    expect(delta).toEqual({
+      householdId: 'hh-1',
+      fields: {
+        planId: 'garden',
+        stripeCustomerId: 'cus_123',
+        status: 'active',
+        // Explicitly cleared (REMOVE) so a prior subscriber's stale ids don't
+        // linger and a later subscription.deleted can't revoke the grant.
+        stripeSubscriptionId: null,
+        currentPeriodEnd: null,
+      },
+    });
+  });
+
+  it('does NOT grant entitlement on an unpaid lifetime (mode=payment) checkout', async () => {
+    const { deltaForStripeEvent } = await import('../../../src/services/billing.js');
+    const event = {
+      type: 'checkout.session.completed',
+      data: {
+        object: {
+          mode: 'payment',
+          payment_status: 'unpaid',
+          metadata: { householdId: 'hh-1', planId: 'garden', interval: 'lifetime' },
+          customer: 'cus_123',
+        },
+      },
+    } as unknown as Stripe.Event;
+    expect(deltaForStripeEvent(event)).toBeNull();
+  });
+
+  it('treats a checkout.session.completed with mode=subscription as before (subscription id retained)', async () => {
+    const { deltaForStripeEvent } = await import('../../../src/services/billing.js');
+    const event = {
+      type: 'checkout.session.completed',
+      data: {
+        object: {
+          mode: 'subscription',
+          metadata: { householdId: 'hh-1', planId: 'garden' },
+          customer: 'cus_123',
+          subscription: 'sub_456',
+        },
+      },
+    } as unknown as Stripe.Event;
+    expect(deltaForStripeEvent(event)).toEqual({
       householdId: 'hh-1',
       fields: {
         planId: 'garden',
@@ -272,6 +346,92 @@ describe('recordStripeEventOnce / applyStripeEvent idempotency', () => {
     );
     expect(cmd.input.ExpressionAttributeValues[':lastStripeEventCreated']).toBe(1_700_000_123);
   });
+
+  it('REMOVEs an attribute when its field is null (lifetime clears stale subscription ids)', async () => {
+    const { dynamodb } = await import('../../../src/utils/dynamodb.js');
+    vi.mocked(dynamodb.send).mockResolvedValue({});
+    const { updateHouseholdSubscription } = await import('../../../src/services/billing.js');
+    await updateHouseholdSubscription('hh-1', {
+      planId: 'garden',
+      status: 'active',
+      stripeSubscriptionId: null,
+      currentPeriodEnd: null,
+    });
+    const cmd = vi.mocked(dynamodb.send).mock.calls[0][0] as unknown as {
+      input: { UpdateExpression: string; ExpressionAttributeNames: Record<string, string> };
+    };
+    expect(cmd.input.UpdateExpression).toMatch(/^SET .*\bREMOVE\b/);
+    expect(cmd.input.UpdateExpression).toContain('REMOVE #stripeSubscriptionId');
+    expect(cmd.input.UpdateExpression).toContain('#subscriptionCurrentPeriodEnd');
+    // SET side keeps the non-null fields.
+    expect(cmd.input.UpdateExpression).toContain('#planId = :planId');
+  });
+
+  it('cancels the prior Stripe subscription when a lifetime payment grants Garden', async () => {
+    const { dynamodb } = await import('../../../src/utils/dynamodb.js');
+    process.env.STRIPE_SECRET_KEY = 'sk_test_dummy';
+    // 1st send: pre-apply getHouseholdSubscription read → prior sub on file.
+    // 2nd send: the household Update. 3rd send: the dedupe ledger Put.
+    vi.mocked(dynamodb.send)
+      .mockResolvedValueOnce({ Item: { stripeSubscriptionId: 'sub_old', planId: 'garden' } })
+      .mockResolvedValue({});
+    subscriptionsCancel.mockResolvedValueOnce({});
+    const { applyStripeEvent } = await import('../../../src/services/billing.js');
+    await applyStripeEvent({
+      id: 'evt_lifetime',
+      created: 1_700_000_000,
+      type: 'checkout.session.completed',
+      data: {
+        object: {
+          mode: 'payment',
+          payment_status: 'paid',
+          metadata: { householdId: 'hh-1', planId: 'garden', interval: 'lifetime' },
+          customer: 'cus_1',
+        },
+      },
+    } as unknown as Stripe.Event);
+    expect(subscriptionsCancel).toHaveBeenCalledWith('sub_old');
+  });
+
+  it('does NOT downgrade a lifetime household on a subscription.deleted for an unknown sub', async () => {
+    const { dynamodb } = await import('../../../src/utils/dynamodb.js');
+    // Pre-apply read: the lifetime grant cleared the sub id (none on file).
+    vi.mocked(dynamodb.send).mockResolvedValueOnce({ Item: { planId: 'garden' } });
+    const { applyStripeEvent } = await import('../../../src/services/billing.js');
+    await applyStripeEvent({
+      id: 'evt_del_orphan',
+      created: 1_700_000_000,
+      type: 'customer.subscription.deleted',
+      data: {
+        object: { id: 'sub_old', metadata: { householdId: 'hh-1', planId: 'garden' } },
+      },
+    } as unknown as Stripe.Event);
+    // Only the guard read ran — no Update (no downgrade), no ledger Put.
+    expect(vi.mocked(dynamodb.send)).toHaveBeenCalledTimes(1);
+  });
+
+  it('still downgrades to seedling when subscription.deleted matches the stored sub id', async () => {
+    const { dynamodb } = await import('../../../src/utils/dynamodb.js');
+    // Pre-apply read: household still references this very subscription.
+    vi.mocked(dynamodb.send)
+      .mockResolvedValueOnce({ Item: { planId: 'garden', stripeSubscriptionId: 'sub_live' } })
+      .mockResolvedValue({});
+    const { applyStripeEvent } = await import('../../../src/services/billing.js');
+    await applyStripeEvent({
+      id: 'evt_del_match',
+      created: 1_700_000_000,
+      type: 'customer.subscription.deleted',
+      data: {
+        object: { id: 'sub_live', metadata: { householdId: 'hh-1', planId: 'greenhouse' } },
+      },
+    } as unknown as Stripe.Event);
+    // Guard read + Update (downgrade) + ledger Put.
+    expect(vi.mocked(dynamodb.send)).toHaveBeenCalledTimes(3);
+    const updateCmd = vi.mocked(dynamodb.send).mock.calls[1][0] as unknown as {
+      input: { ExpressionAttributeValues: Record<string, unknown> };
+    };
+    expect(updateCmd.input.ExpressionAttributeValues[':planId']).toBe('seedling');
+  });
 });
 
 describe('planSummary', () => {
@@ -282,6 +442,14 @@ describe('planSummary', () => {
     expect(planSummary(PLANS.garden).annualPrice).toBe(39.99);
     expect(planSummary(PLANS.greenhouse).annualPrice).toBe(79.99);
   });
+
+  it('exposes lifetimePrice (149 for Garden, null for tiers without a lifetime option)', async () => {
+    const { planSummary } = await import('../../../src/services/billing.js');
+    const { PLANS } = await import('../../../src/models/plans.js');
+    expect(planSummary(PLANS.garden).lifetimePrice).toBe(149);
+    expect(planSummary(PLANS.seedling).lifetimePrice).toBeNull();
+    expect(planSummary(PLANS.greenhouse).lifetimePrice).toBeNull();
+  });
 });
 
 describe('createCheckoutSession — interval resolves the Stripe price', () => {
@@ -290,10 +458,11 @@ describe('createCheckoutSession — interval resolves the Stripe price', () => {
     process.env.STRIPE_SECRET_KEY = 'sk_test_dummy';
     process.env.STRIPE_PRICE_ID_GARDEN = 'price_garden_monthly';
     process.env.STRIPE_PRICE_ID_GARDEN_ANNUAL = 'price_garden_annual';
+    process.env.STRIPE_PRICE_ID_GARDEN_LIFETIME = 'price_garden_lifetime';
     sessionsCreate.mockResolvedValue({ url: 'https://checkout.stripe.test/cs' });
   });
 
-  async function runCheckout(interval?: 'month' | 'year') {
+  async function runCheckout(interval?: 'month' | 'year' | 'lifetime') {
     const { dynamodb } = await import('../../../src/utils/dynamodb.js');
     // getHouseholdSubscription → no existing customer.
     vi.mocked(dynamodb.send).mockResolvedValueOnce({ Item: undefined });
@@ -333,6 +502,24 @@ describe('createCheckoutSession — interval resolves the Stripe price', () => {
     delete process.env.STRIPE_PRICE_ID_GARDEN_ANNUAL;
     await expect(runCheckout('year')).rejects.toThrow('Missing STRIPE_PRICE_ID_GARDEN_ANNUAL');
     expect(sessionsCreate).not.toHaveBeenCalled();
+  });
+
+  it('uses mode=payment + the lifetime price id and sends NO subscription_data when interval=lifetime', async () => {
+    await runCheckout('lifetime');
+    expect(sessionsCreate).toHaveBeenCalledTimes(1);
+    const arg = sessionsCreate.mock.calls[0][0] as Record<string, unknown>;
+    expect(arg.mode).toBe('payment');
+    expect(arg.line_items).toEqual([{ price: 'price_garden_lifetime', quantity: 1 }]);
+    expect(arg.metadata).toMatchObject({ planId: 'garden', interval: 'lifetime' });
+    // A one-time payment must NOT carry subscription_data / a trial.
+    expect(arg.subscription_data).toBeUndefined();
+  });
+
+  it('keeps mode=subscription (with subscription_data) for the monthly/annual cadences', async () => {
+    await runCheckout('month');
+    const arg = sessionsCreate.mock.calls[0][0] as Record<string, unknown>;
+    expect(arg.mode).toBe('subscription');
+    expect(arg.subscription_data).toMatchObject({ trial_period_days: 14 });
   });
 });
 

--- a/frontend/src/features/pricing/PricingGrid.tsx
+++ b/frontend/src/features/pricing/PricingGrid.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/Button';
 import { PRICING_PLANS } from './plans';
 import { IS_BETA, BETA_NOTICE } from '@/lib/betaMode';
 
-type Interval = 'monthly' | 'annual';
+type Interval = 'monthly' | 'annual' | 'lifetime';
 
 /**
  * Three-card pricing grid, shared by the LandingPage anchor section and
@@ -35,7 +35,7 @@ export function PricingGrid() {
           aria-label="Billing interval"
           className="inline-flex rounded-full bg-gray-100 p-1"
         >
-          {(['monthly', 'annual'] as Interval[]).map((opt) => (
+          {(['monthly', 'annual', 'lifetime'] as Interval[]).map((opt) => (
             <button
               key={opt}
               type="button"
@@ -52,7 +52,7 @@ export function PricingGrid() {
           ))}
         </div>
         <span className="rounded-full bg-primary-50 px-2.5 py-1 text-xs font-medium text-primary-700">
-          Save ~33% yearly
+          {interval === 'lifetime' ? 'Garden only · pay once' : 'Save ~33% yearly'}
         </span>
       </div>
       <div className="mx-auto mt-12 grid max-w-lg grid-cols-1 gap-8 md:max-w-none md:grid-cols-3 md:gap-6 lg:gap-8">
@@ -84,10 +84,20 @@ export function PricingGrid() {
             </p>
             {(() => {
               // Free tier shows a single label; paid tiers show the price for
-              // the selected cadence (falling back to monthly if a tier somehow
-              // lacks an annual point).
+              // the selected cadence. Lifetime is Garden-only, so other tiers
+              // fall back to annual; annual itself falls back to monthly if a
+              // tier somehow lacks an annual point.
               const point =
-                interval === 'annual' ? (plan.annual ?? plan.monthly) : plan.monthly;
+                interval === 'lifetime'
+                  ? (plan.lifetime ?? plan.annual ?? plan.monthly)
+                  : interval === 'annual'
+                    ? (plan.annual ?? plan.monthly)
+                    : plan.monthly;
+              // Lifetime is Garden-only. For a paid tier without a lifetime
+              // point we fall back to its annual price, but say so explicitly
+              // so the annual figure isn't mistaken for a lifetime deal.
+              const lifetimeUnavailable =
+                interval === 'lifetime' && !plan.lifetime && !plan.freeLabel;
               return (
                 <div className="mt-6">
                   <div className="flex items-baseline gap-1">
@@ -110,15 +120,26 @@ export function PricingGrid() {
                       </span>
                     )}
                   </div>
-                  {point?.note && (
+                  {lifetimeUnavailable ? (
                     <p
                       className={clsx(
                         'mt-1 text-xs',
-                        plan.highlighted ? 'text-primary-100' : 'text-primary-700'
+                        plan.highlighted ? 'text-primary-100' : 'text-gray-500'
                       )}
                     >
-                      {point.note}
+                      No lifetime option — annual price shown
                     </p>
+                  ) : (
+                    point?.note && (
+                      <p
+                        className={clsx(
+                          'mt-1 text-xs',
+                          plan.highlighted ? 'text-primary-100' : 'text-primary-700'
+                        )}
+                      >
+                        {point.note}
+                      </p>
+                    )
                   )}
                 </div>
               );

--- a/frontend/src/features/pricing/plans.ts
+++ b/frontend/src/features/pricing/plans.ts
@@ -11,7 +11,7 @@ export interface PricePoint {
   price: string;
   /** Cadence suffix, e.g. "/month" or "/year". */
   period: string;
-  /** Optional sub-line, e.g. "$3.33/mo · save 33%". Annual only. */
+  /** Optional sub-line, e.g. "$3.33/mo · save 33%". Annual/lifetime only. */
   note?: string;
 }
 
@@ -21,6 +21,10 @@ export interface PricingPlan {
   freeLabel?: string;
   monthly?: PricePoint;
   annual?: PricePoint;
+  /** One-time lifetime price. Only the Garden tier offers one; other tiers
+   *  leave it undefined and fall back to annual when the Lifetime cadence is
+   *  selected. */
+  lifetime?: PricePoint;
   description: string;
   features: string[];
   cta: string;
@@ -46,6 +50,7 @@ export const PRICING_PLANS: PricingPlan[] = [
     name: 'Garden',
     monthly: { price: '$4.99', period: '/month' },
     annual: { price: '$39.99', period: '/year', note: '$3.33/mo · save 33%' },
+    lifetime: { price: '$149', period: 'once', note: 'Pay once · keep Garden forever' },
     description: 'For growing families',
     features: [
       'Unlimited plants',

--- a/frontend/src/features/settings/BillingSettings.tsx
+++ b/frontend/src/features/settings/BillingSettings.tsx
@@ -138,29 +138,37 @@ export function BillingSettings() {
       <BillingIntervalToggle value={interval} onChange={setInterval} />
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4 lg:grid-cols-3">
-        {plans.map((plan) => (
-          <PlanCard
-            key={plan.id}
-            plan={plan}
-            interval={interval}
-            current={plan.id === currentPlanId}
-            isAdmin={isAdmin}
-            beta={IS_BETA}
-            onSelect={(id) => {
-              if (id === 'seedling') return;
-              checkout.mutate({ planId: id, interval });
-            }}
-            isLoading={checkout.isPending && checkout.variables?.planId === plan.id}
-          />
-        ))}
+        {plans.map((plan) => {
+          // Lifetime is Garden-only. For every other tier, the Lifetime cadence
+          // falls back to Annual so the card stays priced and checkout never
+          // sends interval='lifetime' for a tier the backend would reject.
+          const effectiveInterval: BillingInterval =
+            interval === 'lifetime' && plan.lifetimePrice == null ? 'year' : interval;
+          return (
+            <PlanCard
+              key={plan.id}
+              plan={plan}
+              interval={effectiveInterval}
+              current={plan.id === currentPlanId}
+              isAdmin={isAdmin}
+              beta={IS_BETA}
+              onSelect={(id) => {
+                if (id === 'seedling') return;
+                checkout.mutate({ planId: id, interval: effectiveInterval });
+              }}
+              isLoading={checkout.isPending && checkout.variables?.planId === plan.id}
+            />
+          );
+        })}
       </div>
     </div>
   );
 }
 
 /**
- * Monthly/Annual segmented toggle. Annual is the cadence we want chosen, so it
- * carries the "Save ~33%" nudge.
+ * Monthly/Annual/Lifetime segmented toggle. Annual is the cadence we want
+ * chosen, so it carries the "Save ~33%" nudge. Lifetime is a one-time payment
+ * offered on Garden only — picking it leaves non-Garden cards on Annual.
  */
 function BillingIntervalToggle({
   value,
@@ -172,6 +180,7 @@ function BillingIntervalToggle({
   const options: { id: BillingInterval; label: string }[] = [
     { id: 'month', label: 'Monthly' },
     { id: 'year', label: 'Annual' },
+    { id: 'lifetime', label: 'Lifetime' },
   ];
   return (
     <div className="flex items-center justify-center gap-3">
@@ -197,7 +206,7 @@ function BillingIntervalToggle({
         ))}
       </div>
       <span className="rounded-full bg-primary-50 px-2.5 py-1 text-xs font-medium text-primary-700">
-        Save ~33% yearly
+        {value === 'lifetime' ? 'Garden only · pay once' : 'Save ~33% yearly'}
       </span>
     </div>
   );
@@ -261,6 +270,10 @@ interface PlanCardProps {
 function PlanCard({ plan, interval, current, isAdmin, beta, onSelect, isLoading }: PlanCardProps) {
   // Free tier: no price line variants. Annual tiers show the yearly headline
   // plus an effective "/mo billed yearly" and the savings vs 12× monthly.
+  // Lifetime is a one-time charge — "$149 once" — shown only on the tier that
+  // offers one (Garden). The parent already falls non-Garden cards back to
+  // 'year', so `lifetime` here implies a non-null lifetimePrice.
+  const lifetime = interval === 'lifetime' && plan.lifetimePrice != null;
   const annual = interval === 'year' && plan.annualPrice != null;
   const savingsPct =
     plan.annualPrice != null && plan.monthlyPrice > 0
@@ -274,6 +287,14 @@ function PlanCard({ plan, interval, current, isAdmin, beta, onSelect, isLoading 
       <p className="mt-1 text-sm text-gray-500">{plan.description}</p>
       {plan.monthlyPrice === 0 ? (
         <p className="mt-4 text-3xl font-bold">Free</p>
+      ) : lifetime ? (
+        <div className="mt-4">
+          <p className="text-3xl font-bold">
+            ${plan.lifetimePrice!.toFixed(0)}
+            <span className="text-base font-normal text-gray-500"> once</span>
+          </p>
+          <p className="mt-1 text-sm text-gray-500">One-time payment · keep Garden forever</p>
+        </div>
       ) : annual ? (
         <div className="mt-4">
           <p className="text-3xl font-bold">

--- a/frontend/src/services/analytics.ts
+++ b/frontend/src/services/analytics.ts
@@ -113,8 +113,9 @@ export interface EventProps {
   memberCount?: '1' | '2-5' | '6+';
   /** For `subscription_upgraded` — bucketed price. */
   upgradeTo?: 'garden' | 'greenhouse';
-  /** For `subscription_upgraded` — billing cadence the user chose at checkout. */
-  interval?: 'month' | 'year';
+  /** For `subscription_upgraded` — billing cadence the user chose at checkout.
+   *  `lifetime` is a one-time payment rather than a recurring cadence. */
+  interval?: 'month' | 'year' | 'lifetime';
   /** Free-form context only when it's an enum or a count, never a name. */
   context?: string;
   /** For `experiment_viewed` — which experiment and assigned variant. */

--- a/frontend/src/services/billingService.ts
+++ b/frontend/src/services/billingService.ts
@@ -3,8 +3,9 @@ import { track } from './analytics';
 
 export type PlanId = 'seedling' | 'garden' | 'greenhouse';
 
-/** Billing cadence sent to /billing/checkout. */
-export type BillingInterval = 'month' | 'year';
+/** Billing cadence sent to /billing/checkout. `lifetime` is a one-time payment
+ *  (Garden tier only). */
+export type BillingInterval = 'month' | 'year' | 'lifetime';
 
 export interface Plan {
   id: PlanId;
@@ -14,6 +15,9 @@ export interface Plan {
   /** Yearly price in dollars, or null when the tier has no annual option
    *  (free tier). */
   annualPrice: number | null;
+  /** One-time lifetime price in dollars, or null when the tier has no lifetime
+   *  option (only Garden offers one). */
+  lifetimePrice: number | null;
   maxPlants: number;
   maxMembers: number;
 }

--- a/frontend/tests/unit/features/BillingSettings.test.tsx
+++ b/frontend/tests/unit/features/BillingSettings.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BillingSettings } from '@/features/settings/BillingSettings';
@@ -36,6 +36,8 @@ const PLANS: Plan[] = [
     name: 'Seedling',
     description: 'Free',
     monthlyPrice: 0,
+    annualPrice: null,
+    lifetimePrice: null,
     maxPlants: 10,
     maxMembers: 1,
   },
@@ -44,6 +46,8 @@ const PLANS: Plan[] = [
     name: 'Garden',
     description: 'Families',
     monthlyPrice: 4.99,
+    annualPrice: 39.99,
+    lifetimePrice: 149,
     maxPlants: 500,
     maxMembers: 6,
   },
@@ -52,6 +56,8 @@ const PLANS: Plan[] = [
     name: 'Greenhouse',
     description: 'Serious',
     monthlyPrice: 9.99,
+    annualPrice: 79.99,
+    lifetimePrice: null,
     maxPlants: 5000,
     maxMembers: 50,
   },
@@ -148,5 +154,23 @@ describe('BillingSettings', () => {
     });
     expect(screen.getByText('Over your plan limit')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Manage subscription' })).not.toBeInTheDocument();
+  });
+
+  it('shows the Lifetime cadence as "$149 once" on Garden only, leaving Greenhouse on its annual price', async () => {
+    await renderBilling({ planId: 'seedling' });
+    // Default cadence is Annual — Garden shows its yearly headline, no lifetime.
+    expect(screen.queryByText('once')).not.toBeInTheDocument();
+
+    // Switch to the Lifetime cadence.
+    fireEvent.click(screen.getByRole('radio', { name: 'Lifetime' }));
+
+    // Garden (the only lifetime tier) now shows the one-time price.
+    expect(screen.getByText('$149')).toBeInTheDocument();
+    expect(screen.getByText('once')).toBeInTheDocument();
+    expect(screen.getByText(/keep Garden forever/)).toBeInTheDocument();
+    // Greenhouse has no lifetime — it falls back to its annual price, not "once".
+    expect(screen.getByText('$79.99')).toBeInTheDocument();
+    // The nudge reflects the Garden-only constraint.
+    expect(screen.getByText(/Garden only/)).toBeInTheDocument();
   });
 });

--- a/infrastructure/modules/api/main.tf
+++ b/infrastructure/modules/api/main.tf
@@ -287,6 +287,7 @@ locals {
     STRIPE_WEBHOOK_SECRET             = var.stripe_webhook_secret
     STRIPE_PRICE_ID_GARDEN            = var.stripe_price_id_garden
     STRIPE_PRICE_ID_GARDEN_ANNUAL     = var.stripe_price_id_garden_annual
+    STRIPE_PRICE_ID_GARDEN_LIFETIME   = var.stripe_price_id_garden_lifetime
     STRIPE_PRICE_ID_GREENHOUSE        = var.stripe_price_id_greenhouse
     STRIPE_PRICE_ID_GREENHOUSE_ANNUAL = var.stripe_price_id_greenhouse_annual
     SES_FROM_EMAIL                    = var.ses_from_email

--- a/infrastructure/modules/api/variables.tf
+++ b/infrastructure/modules/api/variables.tf
@@ -91,6 +91,12 @@ variable "stripe_price_id_garden_annual" {
   default     = ""
 }
 
+variable "stripe_price_id_garden_lifetime" {
+  description = "Stripe price ID for the Garden tier LIFETIME one-time payment ($149). Required for /billing/checkout with interval=lifetime."
+  type        = string
+  default     = ""
+}
+
 variable "stripe_price_id_greenhouse" {
   description = "Stripe price ID for the Greenhouse tier MONTHLY ($9.99/mo). Required for /billing/checkout monthly."
   type        = string


### PR DESCRIPTION
## Summary

Adds a **Lifetime** option to billing: a Stripe one-time payment (`mode:'payment'`) for **$149** that grants **Garden**-tier entitlement permanently.

Per the design decision, lifetime is modeled as a one-time **billing interval on the existing Garden tier**, not a new `planId`. A lifetime purchase stores `planId='garden'` permanently with no subscription, so entitlement resolution and the 3-plan catalog stay unchanged.

## Backend
- `models/plans.ts`: Garden gains `lifetimePrice` (149) and `lifetimeStripePriceEnv` (`STRIPE_PRICE_ID_GARDEN_LIFETIME`). No new `PlanId`.
- `services/billing.ts`:
  - `BillingInterval` extended to `'month' | 'year' | 'lifetime'`.
  - `createCheckoutSession`: `interval==='lifetime'` → `mode:'payment'` (no `subscription_data`/trial), price from `lifetimeStripePriceEnv`; month/year stay `mode:'subscription'`. Metadata `{householdId, planId, interval}` still stamped.
  - `deltaForStripeEvent` (`checkout.session.completed`): branches on `session.mode`. `payment` requires `payment_status==='paid'`, returns `{planId, stripeCustomerId, status:'active'}` with **no** `stripeSubscriptionId`/`currentPeriodEnd`; `subscription` (or undefined → back-compat) unchanged.
- `handlers/billing/handler.ts`: checkout schema accepts `'lifetime'`, refined to Garden-only (clear 400 otherwise).

### Webhook-interaction hardening (from review)
A lifetime purchase by an **existing subscriber** could previously be silently revoked. Fixed:
- The lifetime grant **clears** the stale `stripeSubscriptionId`/`currentPeriodEnd` (`updateHouseholdSubscription` now supports `null` → DynamoDB `REMOVE`).
- `applyStripeEvent` **cancels the prior Stripe subscription** when a lifetime payment completes (best-effort; never 5xxs the webhook).
- `customer.subscription.deleted` is **guarded**: it no longer downgrades a household whose stored subscription id doesn't match the deleted sub (or who has no sub on file), so a lifetime grant can't be revoked. `created`/`updated` are unaffected.

## Frontend
- `billingService.ts` / `analytics.ts`: `'lifetime'` interval; `Plan.lifetimePrice`.
- `BillingSettings.tsx`: Lifetime toggle; Garden card shows "$149 once" and checkout sends `{planId:'garden', interval:'lifetime'}`. Non-Garden tiers fall back to Annual.
- `pricing/plans.ts` + `PricingGrid.tsx`: lifetime price point for Garden; non-Garden tiers show "No lifetime option — annual price shown".
- `local-server.ts` `/billing/plans` now reuses `planSummary` (also fixes pre-existing `annualPrice` drift).

## Infra
- `STRIPE_PRICE_ID_GARDEN_LIFETIME` env var, default `""` (beta-gated, nothing charges). `terraform fmt` clean.

## Verification
- Backend: `typecheck` + `lint` clean; **936 vitest tests pass** (incl. integration).
- Frontend: `typecheck` + `lint` clean; **322 tests pass**; `build` succeeds.
- Terraform: `fmt -check -recursive` clean (`validate` blocked on provider download — network-blocked, expected).
- Playwright: browser install blocked in sandbox (apt repos forbidden); no billing-specific e2e specs exist. Relied on unit/integration + build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014abKA3txbQXT7Xe9cpKN79

---
_Generated by [Claude Code](https://claude.ai/code/session_014abKA3txbQXT7Xe9cpKN79)_