### PR TITLE
feat(analytics): add household group key to product events

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -36,16 +36,35 @@ The full set is the `EventName` union in `analytics.ts`. Each is a deliberate fu
 ## Privacy & data
 
 - **Distinct id** is the Cognito `sub` (UUID). We do not send email, name, plant names, or any household-identifying free text.
+- **Household group key** is the household UUID (see "Household group analytics" below). Like the distinct id, it's an opaque identifier, not free text — it can't be reversed to a person, home, or address, so it carries the same negligible privacy weight as the distinct id. "No household-identifying free text" rules out names and addresses, not a UUID grouping key.
 - **Event properties** are restricted to enums and bucketed counts. The TypeScript type makes it impossible to slip a free-form string in.
 - **Do Not Track** is honored — when `navigator.doNotTrack === '1'` every method short-circuits.
 - We use `fetch` with `keepalive: true` so events don't drop on navigation but also don't block the request that triggered them.
+
+## Household group analytics
+
+Product events are keyed by `distinct_id` = the user's Cognito sub. That's correct for per-user funnels, but it makes the collaborative core of the product — "does a household get a 2nd _active_ member?" — **unmeasurable**: `invite_sent` (fired by the admin) and `invite_accepted` (fired by the invitee) are different users, so nothing pairs them, and "active members per household" can't be counted across distinct ids.
+
+We fix this with PostHog [group analytics](https://posthog.com/docs/product-analytics/group-analytics). Every captured event carries a `$groups: { household: <uuid> }` key, and the GTM dataLayer payloads carry a plain `household` field:
+
+- `setActiveHousehold(id)` in `analytics.ts` sets the ambient household group. The `authStore` wires it: on login/session restore (the effective household = active id `??` the user's claim household), and whenever the switcher changes the active household. `reset()` (logout) clears it.
+- The first time a household is seen in a session, the shim sends a `$groupidentify` (`group_type: 'household'`, `group_key`: the id) so the group exists in the PostHog UI. It does **not** send any group properties (no names/addresses) — only the opaque key.
+- When no household is active, the `$groups` key is omitted entirely (no stray `{ household: null }`).
+
+What this unlocks in PostHog:
+
+- **Collaboration activation** — `invite_sent` → `invite_accepted` paired _at the household level_, and "households with ≥2 active members". This is the product's core differentiator and was previously impossible to chart.
+- **Per-household retention** — retention and stickiness computed over households, not just users, so a household where one member churns but another stays active reads as retained.
+- **Per-household cohorts** — slice any funnel by household size, plan, or members, to test the pricing-tier hypotheses in `docs/strategy-review.md`.
+
+Privacy: the group key is an opaque household UUID, exactly analogous to sending the Cognito sub as `distinct_id`. It is not PII and cannot be reversed to a person or address; see the Privacy & data bullet above.
 
 ## Funnels worth building in PostHog
 
 Once events flow, build these funnels in the PostHog UI:
 
 1. **Activation funnel**: `signup_completed` → `household_created (first)` → `plant_added (first)` → `task_completed (first)`. The drop-off between any two steps is your highest-leverage UX problem.
-2. **Collaboration funnel**: `household_created` → `invite_sent` → `invite_accepted`. Below 50% of households reaching `invite_sent` means the collaborative pitch isn't landing.
+2. **Collaboration funnel**: `household_created` → `invite_sent` → `invite_accepted`, set to aggregate by the `household` group (see "Household group analytics") so the admin's `invite_sent` and the invitee's `invite_accepted` pair across users. Below 50% of households reaching `invite_sent` means the collaborative pitch isn't landing.
 3. **Climate adoption**: `household_created` → `climate_location_set`. If <10%, the dashboard nudge needs work.
 4. **Upgrade intent**: `subscription_upgraded` from each tier. Pair with cohorts (>10 plants, >2 members) to test the pricing-tier hypotheses in `docs/strategy-review.md`.
 

--- a/frontend/src/services/analytics.test.ts
+++ b/frontend/src/services/analytics.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Unit tests for the household group-analytics wiring in the PostHog shim.
+ *
+ * The shim is mostly module state + `fetch`, so we mock global `fetch` and
+ * read back the JSON we would have POSTed to `/capture/`. We only assert on
+ * the household grouping behaviour — the rest of the shim is exercised
+ * elsewhere — namely:
+ *   - events carry `$groups.household` once a household is set,
+ *   - they OMIT it (no stray `{ household: null }`) when none is set,
+ *   - `reset()` clears the household.
+ *
+ * `VITE_POSTHOG_KEY` is stubbed on so the shim doesn't short-circuit, and
+ * DNT is forced off. Each test re-imports the module so the module-scoped
+ * `distinctId`/`activeHouseholdId` start clean.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const HOUSEHOLD_A = 'a0000000-0000-4000-8000-000000000001';
+const USER_A = 'u0000000-0000-4000-8000-000000000009';
+
+type CapturePayload = {
+  event: string;
+  distinct_id: string;
+  $groups?: { household?: string };
+  properties?: Record<string, unknown>;
+};
+
+/** All JSON bodies POSTed to a PostHog `/capture/` URL this test. */
+function captures(fetchMock: ReturnType<typeof vi.fn>): CapturePayload[] {
+  return fetchMock.mock.calls
+    .filter(([url]) => typeof url === 'string' && url.includes('/capture/'))
+    .map(([, init]) => JSON.parse((init as RequestInit).body as string) as CapturePayload);
+}
+
+/** Fresh module instance with a mocked fetch, returns the shim + the mock. */
+async function loadShim() {
+  vi.resetModules();
+  const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+  vi.stubGlobal('fetch', fetchMock);
+  const mod = await import('./analytics');
+  return { mod, fetchMock };
+}
+
+beforeEach(() => {
+  vi.stubEnv('VITE_POSTHOG_KEY', 'phc_test_key');
+  // Force Do-Not-Track off so isEnabled() is true.
+  Object.defineProperty(globalThis.navigator, 'doNotTrack', {
+    value: null,
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('household group analytics', () => {
+  it('omits $groups.household when no household is set', async () => {
+    const { mod, fetchMock } = await loadShim();
+    mod.identify(USER_A);
+    mod.track('plant_added', { ordinal: 'first' });
+    // Let the fire-and-forget send() microtask settle.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const events = captures(fetchMock);
+    expect(events.length).toBeGreaterThan(0);
+    for (const e of events) {
+      expect(e.$groups).toBeUndefined();
+    }
+  });
+
+  it('includes $groups.household on capture events once a household is set', async () => {
+    const { mod, fetchMock } = await loadShim();
+    mod.identify(USER_A);
+    mod.setActiveHousehold(HOUSEHOLD_A);
+    mod.track('invite_sent');
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const captured = captures(fetchMock).find((e) => e.event === 'invite_sent');
+    expect(captured).toBeDefined();
+    expect(captured?.$groups).toEqual({ household: HOUSEHOLD_A });
+  });
+
+  it('emits a $groupidentify the first time a household is set', async () => {
+    const { mod, fetchMock } = await loadShim();
+    mod.setActiveHousehold(HOUSEHOLD_A);
+    // Setting the same household again should NOT emit a second groupidentify.
+    mod.setActiveHousehold(HOUSEHOLD_A);
+    await Promise.resolve();
+
+    const groupIdentifies = captures(fetchMock).filter((e) => e.event === '$groupidentify');
+    expect(groupIdentifies).toHaveLength(1);
+    expect(groupIdentifies[0].properties).toMatchObject({
+      $group_type: 'household',
+      $group_key: HOUSEHOLD_A,
+    });
+  });
+
+  it('reset() clears the active household so later events omit $groups', async () => {
+    const { mod, fetchMock } = await loadShim();
+    mod.identify(USER_A);
+    mod.setActiveHousehold(HOUSEHOLD_A);
+    mod.reset();
+    // After reset we have no distinct id, so re-identify to allow a capture.
+    mod.identify(USER_A);
+    mod.track('task_completed');
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const captured = captures(fetchMock).find((e) => e.event === 'task_completed');
+    expect(captured).toBeDefined();
+    expect(captured?.$groups).toBeUndefined();
+  });
+
+  it('setActiveHousehold(null) detaches the group from subsequent events', async () => {
+    const { mod, fetchMock } = await loadShim();
+    mod.identify(USER_A);
+    mod.setActiveHousehold(HOUSEHOLD_A);
+    mod.setActiveHousehold(null);
+    mod.track('plant_added');
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const captured = captures(fetchMock).find((e) => e.event === 'plant_added');
+    expect(captured).toBeDefined();
+    expect(captured?.$groups).toBeUndefined();
+  });
+});

--- a/frontend/src/services/analytics.ts
+++ b/frontend/src/services/analytics.ts
@@ -17,6 +17,15 @@
  * Privacy:
  *  - We send the user's Cognito sub as the `distinct_id`. We do not send
  *    email, name, plant names, or any household-identifying free text.
+ *  - We attach a `household` GROUP key (`$groups.household`) to every event
+ *    when a household is active — an opaque UUID, exactly analogous to the
+ *    Cognito-sub distinct_id. "No household-identifying free text" means no
+ *    names/addresses; a UUID grouping key can't be reversed to a person,
+ *    home, or address, so it carries the same (negligible) privacy weight
+ *    as the distinct_id and is fine to send. It's what makes the
+ *    collaboration funnel (does a household get a 2nd active member?)
+ *    measurable across different users — see `setActiveHousehold` and
+ *    docs/analytics.md.
  *  - Event properties are limited to enum-like discriminators (e.g. plan
  *    id, member count buckets) — never user-supplied strings.
  *  - The shim respects browser Do-Not-Track when `navigator.doNotTrack`
@@ -147,6 +156,55 @@ export function registerSuperProperties(props: Record<string, string>): void {
   superProps = { ...superProps, ...props };
 }
 
+/**
+ * Active household — the PostHog group key (`$groups.household`) attached to
+ * every event. Set by `setActiveHousehold`, cleared by `reset` (logout). An
+ * opaque UUID, never free text (see the Privacy block above). This is the
+ * shared key that lets PostHog pair events across DIFFERENT users in the same
+ * household — `invite_sent` (admin) → `invite_accepted` (invitee), or "count
+ * distinct active members" — which the per-user `distinct_id` alone cannot do.
+ */
+let activeHouseholdId: string | null = null;
+
+/** Households we've already `$groupidentify`-ed this session, so we only emit
+ *  the group-identify event once per household rather than on every switch. */
+const groupIdentified = new Set<string>();
+
+/**
+ * Pin subsequent events to a household group. Call on login/session restore
+ * and whenever the active household changes (the household switcher). Pass
+ * `null` to detach (e.g. a user with no household yet). The id is the opaque
+ * household UUID — never a name or address.
+ *
+ * On the first time we see a given household this session we emit a PostHog
+ * `$groupidentify` so the group exists in the UI; subsequent calls just swap
+ * the ambient key.
+ */
+export function setActiveHousehold(householdId: string | null): void {
+  activeHouseholdId = householdId;
+  if (!householdId) return;
+  if (!isEnabled() || groupIdentified.has(householdId)) return;
+  groupIdentified.add(householdId);
+  void fetch(`${HOST}/capture/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      api_key: KEY,
+      event: '$groupidentify',
+      // `$groupidentify` is keyed by the group itself; PostHog ignores the
+      // distinct_id here but the field is required, so reuse the household id.
+      distinct_id: householdId,
+      properties: {
+        $group_type: 'household',
+        $group_key: householdId,
+        $group_set: {},
+      },
+      timestamp: new Date().toISOString(),
+    }),
+    keepalive: true,
+  }).catch(() => {});
+}
+
 function isEnabled(): boolean {
   if (!KEY) return false;
   if (typeof navigator !== 'undefined' && navigator.doNotTrack === '1') return false;
@@ -155,9 +213,15 @@ function isEnabled(): boolean {
 
 async function send(event: EventName, properties: Record<string, unknown>): Promise<void> {
   const withSuper = { ...superProps, ...properties };
+  // The household group key rides on both rails: `$groups.household` for
+  // PostHog group analytics, and a plain `household` field on the GTM
+  // dataLayer payload (GTM has no notion of PostHog groups).
+  const dataLayerProps = activeHouseholdId
+    ? { ...withSuper, household: activeHouseholdId }
+    : withSuper;
   // GTM dataLayer push runs whether or not PostHog is configured — they're
   // independent rails. The DNT check is inside pushToDataLayer.
-  pushToDataLayer(event, withSuper);
+  pushToDataLayer(event, dataLayerProps);
   if (!isEnabled() || !distinctId) return;
   try {
     await fetch(`${HOST}/capture/`, {
@@ -167,6 +231,10 @@ async function send(event: EventName, properties: Record<string, unknown>): Prom
         api_key: KEY,
         event,
         distinct_id: distinctId,
+        // Attach the household group so this event is countable per-household
+        // across users (collaboration funnel). Omitted entirely when no
+        // household is active so we never send a stray `{ household: null }`.
+        ...(activeHouseholdId ? { $groups: { household: activeHouseholdId } } : {}),
         properties: {
           ...withSuper,
           $lib: 'family-greenhouse-shim',
@@ -190,7 +258,12 @@ export function identify(userId: string, traits?: { plan?: EventProps['plan'] })
   // Initialize GTM once we have a known user — keeps an anonymous landing-
   // page visitor from triggering the script load until they're logged in.
   ensureGtm();
-  pushToDataLayer('user_identified', { userId, ...superProps, ...(traits ?? {}) });
+  pushToDataLayer('user_identified', {
+    userId,
+    ...superProps,
+    ...(traits ?? {}),
+    ...(activeHouseholdId ? { household: activeHouseholdId } : {}),
+  });
   if (!isEnabled()) return;
   void fetch(`${HOST}/capture/`, {
     method: 'POST',
@@ -199,6 +272,9 @@ export function identify(userId: string, traits?: { plan?: EventProps['plan'] })
       api_key: KEY,
       event: '$identify',
       distinct_id: userId,
+      // Tie the person to their household group as well, so the $identify
+      // itself is attributable per-household.
+      ...(activeHouseholdId ? { $groups: { household: activeHouseholdId } } : {}),
       // Persist the experiment assignment (and any other super-props) on the
       // person so the eventual signup is attributable to the variant seen.
       properties: { $set: { ...superProps, ...(traits ?? {}) } },
@@ -214,6 +290,9 @@ export function identify(userId: string, traits?: { plan?: EventProps['plan'] })
 export function reset(): void {
   distinctId = null;
   superProps = {};
+  activeHouseholdId = null;
+  // Allow a re-login to re-`$groupidentify`; cheap and keeps logout total.
+  groupIdentified.clear();
 }
 
 export function track(event: EventName, props: EventProps = {}): void {

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -19,7 +19,7 @@
  */
 import { create } from 'zustand';
 import { persist, createJSONStorage, StateStorage } from 'zustand/middleware';
-import { identify, reset as resetAnalytics } from '@/services/analytics';
+import { identify, reset as resetAnalytics, setActiveHousehold } from '@/services/analytics';
 
 export interface User {
   id: string;
@@ -142,13 +142,21 @@ export const useAuthStore = create<AuthState>()(
       isLoading: true,
       activeHouseholdId: null,
 
-      setActiveHouseholdId: (activeHouseholdId) => set({ activeHouseholdId }),
+      setActiveHouseholdId: (activeHouseholdId) => {
+        set({ activeHouseholdId });
+        // Keep the analytics group key in lockstep with the effective active
+        // household so every captured event is attributed to the household the
+        // requests are actually scoped to (see useActiveHouseholdId).
+        setActiveHousehold(activeHouseholdId ?? get().user?.householdId ?? null);
+      },
 
       setUser: (user) => {
         if (user) {
           // Pin analytics to the Cognito sub. Safe to call on every set;
           // the underlying shim is idempotent and does nothing without
-          // VITE_POSTHOG_KEY configured.
+          // VITE_POSTHOG_KEY configured. Set the household group BEFORE
+          // identify so the $identify event carries `$groups.household`.
+          setActiveHousehold(get().activeHouseholdId ?? user.householdId ?? null);
           identify(user.id);
         } else {
           resetAnalytics();
@@ -167,10 +175,14 @@ export const useAuthStore = create<AuthState>()(
           refreshToken,
         }),
 
-      setHousehold: (householdId, role) =>
+      setHousehold: (householdId, role) => {
         set((state) => ({
           user: state.user ? { ...state.user, householdId, householdRole: role } : null,
-        })),
+        }));
+        // A user who just got their first household (onboarding) has no
+        // explicit active id yet — fall back to the new claim household.
+        setActiveHousehold(get().activeHouseholdId ?? householdId);
+      },
 
       logout: () => {
         resetAnalytics();
@@ -242,6 +254,10 @@ export const useAuthStore = create<AuthState>()(
           } else {
             // Token is valid, update user data
             const userData = await response.json();
+            // Session restore: re-establish the analytics household group from
+            // the persisted active id (or the user's claim household) so events
+            // captured before the user touches the switcher are still grouped.
+            setActiveHousehold(get().activeHouseholdId ?? userData?.householdId ?? null);
             set({
               user: userData,
               isAuthenticated: true,

--- a/frontend/tests/unit/components/HouseholdSwitcher.test.tsx
+++ b/frontend/tests/unit/components/HouseholdSwitcher.test.tsx
@@ -8,7 +8,13 @@ import { useAuthStore } from '@/store/authStore';
 import * as householdService from '@/services/householdService';
 import type { Membership } from '@/services/householdService';
 
-vi.mock('@/services/analytics', () => ({ track: vi.fn() }));
+vi.mock('@/services/analytics', () => ({
+  track: vi.fn(),
+  // authStore.setActiveHouseholdId now pins the analytics household group.
+  setActiveHousehold: vi.fn(),
+  identify: vi.fn(),
+  reset: vi.fn(),
+}));
 
 const navigateSpy = vi.fn();
 vi.mock('react-router-dom', async () => {


### PR DESCRIPTION
## Problem

Product events (`frontend/src/services/analytics.ts`) carry `distinct_id` = the user's Cognito sub but no household grouping key. The collaboration funnel — the app's core differentiator, "does a household get a 2nd ACTIVE member?" — was **unmeasurable** in PostHog: `invite_sent` (admin) and `invite_accepted` (invitee) are different users, so nothing pairs them, and "active members per household" can't be counted across distinct ids.

## Fix

PostHog **group analytics** keyed on the household UUID:

- Module-scoped `activeHouseholdId` + exported `setActiveHousehold(id | null)` in the shim.
- `$groups: { household: <id> }` on every `/capture/` and `$identify` payload (omitted entirely when no household is active — no stray `{ household: null }`).
- Plain `household` field pushed onto the GTM dataLayer payloads.
- A once-per-session `$groupidentify` (`group_type: 'household'`) so the group shows in the PostHog UI; no group properties (no names/addresses).
- Cleared in `reset()` (logout).
- Wired through `authStore`: login (`setUser`), session restore (`verifySession`), the switcher (`setActiveHouseholdId`), and onboarding (`setHousehold`).

## Privacy

The group key is an opaque household UUID — not PII, can't be reversed to a person/home/address — exactly analogous to sending the Cognito sub as `distinct_id`. Documented in the file's privacy block and `docs/analytics.md`.

## Verification

`npm run typecheck && npm run lint && npm run test && npm run build` all pass (327 frontend tests, incl. the new `analytics.test.ts` asserting `$groups.household` presence/absence and `reset()` clearing). No Playwright e2e: analytics is a fire-and-forget network shim with no UI and no live PostHog in the sandbox — the unit test + build/types are the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014abKA3txbQXT7Xe9cpKN79

---
_Generated by [Claude Code](https://claude.ai/code/session_014abKA3txbQXT7Xe9cpKN79)_