### PR TITLE
test(data): validate petToxicity + taskTemplates static assets

### DIFF
--- a/backend/tests/unit/models/petToxicity.test.ts
+++ b/backend/tests/unit/models/petToxicity.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest';
+import {
+  PET_TOXICITY,
+  normalizeName,
+  lookupToxicity,
+  type PetToxicityEntry,
+} from '../../../src/models/petToxicity.js';
+
+const VERDICTS = ['toxic', 'non-toxic'] as const;
+
+describe('pet toxicity catalog integrity', () => {
+  it('ships at least one entry', () => {
+    expect(PET_TOXICITY.length).toBeGreaterThan(0);
+  });
+
+  it('every entry has all required fields present and non-empty', () => {
+    for (const e of PET_TOXICITY) {
+      expect(typeof e.slug, `${e.slug}: slug`).toBe('string');
+      expect(e.slug.length, `${e.slug}: slug non-empty`).toBeGreaterThan(0);
+      expect(e.commonName?.trim().length, `${e.slug}: commonName`).toBeGreaterThan(0);
+      expect(e.scientificName?.trim().length, `${e.slug}: scientificName`).toBeGreaterThan(0);
+      expect(Array.isArray(e.aliases), `${e.slug}: aliases is array`).toBe(true);
+      expect(e.note?.trim().length, `${e.slug}: note`).toBeGreaterThan(0);
+    }
+  });
+
+  it('every slug is unique', () => {
+    const slugs = PET_TOXICITY.map((e) => e.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  it('every slug is kebab-case and url-safe', () => {
+    for (const e of PET_TOXICITY) {
+      expect(e.slug, `${e.slug}: kebab-case`).toMatch(/^[a-z0-9]+(-[a-z0-9]+)*$/);
+    }
+  });
+
+  it('no two entries share a scientific name (case-insensitive)', () => {
+    const sci = PET_TOXICITY.map((e) => e.scientificName.toLowerCase());
+    const dups = sci.filter((s, i) => sci.indexOf(s) !== i);
+    expect(dups, `duplicate scientific names: ${[...new Set(dups)].join(', ')}`).toEqual([]);
+  });
+
+  it('cats and dogs verdicts are valid enum members', () => {
+    for (const e of PET_TOXICITY) {
+      expect(VERDICTS, `${e.slug}: cats`).toContain(e.cats);
+      expect(VERDICTS, `${e.slug}: dogs`).toContain(e.dogs);
+    }
+  });
+
+  it('aliases are non-empty strings with no exact (raw) duplicates', () => {
+    // Catch true copy-paste dupes. We dedupe on the raw (trimmed, lowercased)
+    // string — NOT the normalized form — because the catalog intentionally
+    // lists punctuation/spelling variants (e.g. "devil's ivy" + "devils ivy")
+    // that the matcher's normalizeName folds together at query time.
+    for (const e of PET_TOXICITY) {
+      for (const alias of e.aliases) {
+        expect(typeof alias, `${e.slug}: alias type`).toBe('string');
+        expect(alias.trim().length, `${e.slug}: alias non-empty`).toBeGreaterThan(0);
+      }
+      const raw = e.aliases.map((a) => a.trim().toLowerCase());
+      expect(new Set(raw).size, `${e.slug}: exact duplicate aliases`).toBe(raw.length);
+    }
+  });
+
+  it('no normalized name collides across two different entries', () => {
+    // The matcher indexes commonName + scientificName + aliases. If the same
+    // normalized token maps to two different slugs, an "exact" lookup becomes
+    // ambiguous — flag it so we notice before shipping a confusing answer.
+    const seen = new Map<string, string>();
+    for (const e of PET_TOXICITY) {
+      const names = [e.commonName, e.scientificName, ...e.aliases].map(normalizeName);
+      for (const n of names) {
+        const prior = seen.get(n);
+        if (prior && prior !== e.slug) {
+          throw new Error(`normalized name "${n}" maps to both "${prior}" and "${e.slug}"`);
+        }
+        seen.set(n, e.slug);
+      }
+    }
+  });
+
+  it('the note (the harm-sensitive field) is substantive, not a stub', () => {
+    // The note is what a worried pet owner reads. Guard against an accidental
+    // one-word placeholder while leaving room for honest brevity.
+    for (const e of PET_TOXICITY) {
+      expect(e.note.length, `${e.slug}: note too short`).toBeGreaterThanOrEqual(20);
+    }
+  });
+
+  it('a fully-toxic entry never calls itself non-toxic in its own note', () => {
+    // Liability guard: an entry marked toxic must not contain reassuring
+    // "non-toxic to cats and dogs" prose. This catches a verdict/prose
+    // contradiction without re-litigating the (ASPCA-grounded) verdict itself.
+    for (const e of PET_TOXICITY) {
+      if (e.cats === 'toxic' && e.dogs === 'toxic') {
+        expect(
+          e.note.toLowerCase().includes('non-toxic to cats and dogs'),
+          `${e.slug}: toxic entry claims non-toxic in its note`
+        ).toBe(false);
+      }
+    }
+  });
+});
+
+describe('normalizeName', () => {
+  it('lowercases, strips punctuation, and collapses whitespace', () => {
+    expect(normalizeName('Snake-Plant!')).toBe('snake plant');
+    expect(normalizeName('  Devil’s   Ivy  ')).toBe('devils ivy');
+    expect(normalizeName("Mother-in-law's tongue")).toBe('mother in laws tongue');
+  });
+});
+
+describe('lookupToxicity', () => {
+  it('resolves an exact common name to its entry', () => {
+    const [hit] = lookupToxicity('pothos');
+    expect(hit?.slug).toBe('pothos');
+    expect(hit?.cats).toBe('toxic');
+  });
+
+  it('resolves via alias and scientific name', () => {
+    expect(lookupToxicity('devil’s ivy')[0]?.slug).toBe('pothos');
+    expect(lookupToxicity('Epipremnum aureum')[0]?.slug).toBe('pothos');
+  });
+
+  it('flags the dangerous true lily as toxic to cats', () => {
+    // "lilium" is unique to the true-lily entry (the genus-level scientific
+    // name); a bare "lily" substring-matches peace lily / daylily too.
+    const [hit] = lookupToxicity('lilium');
+    expect(hit?.slug).toBe('lily');
+    expect(hit?.cats).toBe('toxic');
+  });
+
+  it('returns the dangerous true lily somewhere in the results for a bare "lily" query', () => {
+    const slugs = lookupToxicity('lily', 10).map((m) => m.slug);
+    expect(slugs).toContain('lily');
+  });
+
+  it('returns nothing for sub-2-char or unknown queries', () => {
+    expect(lookupToxicity('a')).toEqual([]);
+    expect(lookupToxicity('zzzznotaplant')).toEqual([]);
+  });
+
+  it('honors the result limit', () => {
+    expect(lookupToxicity('plant', 2).length).toBeLessThanOrEqual(2);
+  });
+
+  it('never returns a match shape with missing verdicts', () => {
+    for (const m of lookupToxicity('lily', 5)) {
+      expect(VERDICTS).toContain(m.cats);
+      expect(VERDICTS).toContain(m.dogs);
+      expect(m.note.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// Type-only guard: keeps the exported entry type exercised by the suite.
+const _typeCheck: PetToxicityEntry | undefined = PET_TOXICITY[0];
+void _typeCheck;

--- a/backend/tests/unit/models/taskTemplates.test.ts
+++ b/backend/tests/unit/models/taskTemplates.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { TEMPLATES, suggestTemplate } from '../../../src/models/taskTemplates.js';
-import { taskTypeEnum } from '../../../src/models/schemas.js';
+import { taskTypeEnum, createTaskSchema } from '../../../src/models/schemas.js';
 
 describe('task template catalog', () => {
   it('every template has a stable, unique, url-safe id', () => {
@@ -73,6 +73,49 @@ describe('task template catalog', () => {
         expect(kw.trim().length).toBeGreaterThan(0);
       }
     }
+  });
+
+  it('has no duplicate suitsKeywords within a template', () => {
+    // Dupes are harmless to matching but inflate a keyword's score and signal
+    // a copy-paste slip when contributing.
+    for (const tpl of TEMPLATES) {
+      const seen = new Set(tpl.suitsKeywords);
+      expect(seen.size, `${tpl.id}: duplicate suitsKeywords`).toBe(tpl.suitsKeywords.length);
+    }
+  });
+
+  it('every built-in (non-custom) task validates against createTaskSchema bounds', () => {
+    // Cross-check each template task against the real request schema so the
+    // catalog can never drift from the contract the API enforces. We map
+    // `frequencyDays` → the schema's `frequency` field and supply the
+    // schema-required plantId. Custom tasks and the deliberate orchid repot
+    // (730d, see the frequency test below) are exercised separately.
+    const PLACEHOLDER_PLANT_ID = '00000000-0000-4000-8000-000000000000';
+    for (const tpl of TEMPLATES) {
+      for (const task of tpl.tasks) {
+        if (task.type === 'custom' || task.frequencyDays > 365) continue;
+        const parsed = createTaskSchema.safeParse({
+          plantId: PLACEHOLDER_PLANT_ID,
+          type: task.type,
+          frequency: task.frequencyDays,
+          notes: task.notes,
+        });
+        expect(parsed.success, `${tpl.id}/${task.type}: fails createTaskSchema`).toBe(true);
+      }
+    }
+  });
+
+  it('the only frequency that exceeds the 365-day createTaskSchema cap is the orchid repot', () => {
+    // The template-apply path intentionally bypasses createTaskSchema, so the
+    // orchid "repot every 2 years" (730d) is allowed. This test pins that down:
+    // if a NEW over-cap frequency sneaks in, it must be a conscious decision,
+    // not an accident. Tighten or update this guard when that happens.
+    const overCap = TEMPLATES.flatMap((tpl) =>
+      tpl.tasks
+        .filter((task) => task.frequencyDays > 365)
+        .map((task) => `${tpl.id}/${task.type}@${task.frequencyDays}`)
+    );
+    expect(overCap).toEqual(['orchid/repot@730']);
   });
 });
 


### PR DESCRIPTION
## What

Audits and locks down two shipped backend static-data assets with validation tests. Test-only change — **no data was modified** because the audit surfaced no structural or determination bugs.

### `backend/src/models/petToxicity.ts` (had NO test)
New `petToxicity.test.ts` asserts:
- unique slugs, kebab-case/url-safe
- no duplicate scientific names (case-insensitive)
- every entry has all required fields, non-empty
- `cats`/`dogs` are valid `'toxic' | 'non-toxic'` enum members
- no exact-duplicate aliases within an entry
- no cross-entry normalized-name collision (an ambiguous-lookup guard)
- a substantive (non-stub) `note`
- **liability guard**: a fully-toxic entry never calls itself "non-toxic to cats and dogs" in its own note
- `normalizeName` / `lookupToxicity` behavior (exact, alias, scientific-name, limit, sub-2-char rejection)

### `backend/src/models/taskTemplates.ts`
Extended `taskTemplates.test.ts`:
- every built-in (non-custom, ≤365d) task validates against the real `createTaskSchema` (catches catalog/contract drift)
- no duplicate `suitsKeywords` within a template
- pins the single intentional over-cap frequency: orchid `repot @ 730d` (deliberately bypasses the schema's 365-day create-task cap via the template-apply path) — a new over-cap entry now fails loudly

## Audit findings (no fixes needed)

- **petToxicity**: 19 entries, structurally clean. No duplicate slugs/scientific names, no invalid enums, no missing fields, no verdict/prose contradictions. All ASPCA-grounded toxic-vs-safe determinations and symptom text **left untouched** (liability-sensitive).
- Two *intentional* redundancies confirmed (not bugs): pothos lists both `"devil's ivy"` and `"devils ivy"` (punctuation variants the matcher folds), and several entries repeat their scientific name as a searchable alias. Tests permit these by deduping on raw strings, not normalized form.
- **taskTemplates**: 6 templates, structurally clean. No duplicate ids, all task types valid, all custom tasks carry a `customType`, notes within the 500-char cap.
- **Static species catalog**: located at `frontend/src/utils/species.ts` (~317 entries) — it's a **frontend** asset, outside this unit's backend file set, so it was not modified here. Per the unit instructions, focused on petToxicity + taskTemplates. (Candidate for a separate frontend validation task.)

## Verification
`backend`: `npm run typecheck` passes, `npm run lint` passes, `npx vitest run` passes (79 files / 965 tests, incl. the new/extended 32 model tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014abKA3txbQXT7Xe9cpKN79

---
_Generated by [Claude Code](https://claude.ai/code/session_014abKA3txbQXT7Xe9cpKN79)_