### PR TITLE
feat(analytics): emit server-confirmed subscription_activated from stripe webhook

### DIFF
--- a/backend/src/services/billing.ts
+++ b/backend/src/services/billing.ts
@@ -8,6 +8,7 @@ import { dynamodb, TABLE_NAME } from '../utils/dynamodb.js';
 import { logger } from '../utils/logger.js';
 import { Plan, PlanId, getPlan, isPlanId, PLANS } from '../models/plans.js';
 import { audit } from '../utils/auditLog.js';
+import { capture } from '../utils/serverAnalytics.js';
 
 let cachedClient: Stripe | null = null;
 
@@ -263,6 +264,19 @@ function planIdFromMetadata(
   return null;
 }
 
+/**
+ * Pull the billing cadence we stamp onto checkout-session and subscription
+ * metadata at creation time (see createCheckoutSession). Enum-only — returns
+ * undefined when absent or not one of our known values, so analytics never
+ * carries free text. Lifetime (`mode: 'payment'`) checkouts carry no interval.
+ */
+function intervalFromEvent(event: Stripe.Event): 'month' | 'year' | undefined {
+  const metadata = (event.data.object as unknown as { metadata?: Record<string, string> | null })
+    .metadata;
+  const raw = metadata?.interval;
+  return raw === 'month' || raw === 'year' ? raw : undefined;
+}
+
 export function deltaForStripeEvent(event: Stripe.Event): SubscriptionDelta | null {
   switch (event.type) {
     case 'checkout.session.completed': {
@@ -475,6 +489,42 @@ export async function applyStripeEvent(event: Stripe.Event): Promise<void> {
     householdId: delta.householdId,
     metadata: { stripeEventType: event.type, fields: delta.fields },
   });
+
+  // CONFIRMED conversion signal. The client fires `subscription_upgraded` at
+  // checkout START (intent); this is its server-confirmed counterpart, emitted
+  // once a household actually transitions to an ACTIVE paid plan (planId !=
+  // seedling + status active). The Stripe webhook is the source of truth for
+  // revenue.
+  //
+  // We restrict the emit to the ONE-TIME activation events — checkout
+  // completion and subscription creation — and deliberately exclude
+  // `customer.subscription.updated`. `updated` fires on every renewal, plan
+  // change, and metadata edit while a subscription stays `active`; emitting on
+  // it would re-fire `subscription_activated` repeatedly and inflate the
+  // conversion count. (Edge: a checkout that starts in a trial fires
+  // `subscription.created` with status `trialing`, so this won't double-count
+  // with `checkout.session.completed`, which we stamp `active`.)
+  //
+  // Best-effort + fire-and-forget: `capture` never throws and we `void` its
+  // promise, so an analytics outage can NEVER 5xx the webhook (which would make
+  // Stripe retry an already-applied delivery).
+  // NOTE: docs/analytics.md should be updated to list `subscription_activated`
+  // (server, confirmed) alongside `subscription_upgraded` (client, intent).
+  const isActivationEvent =
+    event.type === 'checkout.session.completed' ||
+    event.type === 'customer.subscription.created';
+  const activatedPlan = delta.fields.planId;
+  if (
+    isActivationEvent &&
+    activatedPlan &&
+    activatedPlan !== 'seedling' &&
+    delta.fields.status === 'active'
+  ) {
+    void capture(delta.householdId, 'subscription_activated', {
+      plan: activatedPlan,
+      interval: intervalFromEvent(event),
+    });
+  }
 }
 
 export function planSummary(plan: Plan): {

--- a/backend/src/utils/serverAnalytics.ts
+++ b/backend/src/utils/serverAnalytics.ts
@@ -1,0 +1,75 @@
+/**
+ * Server-side analytics shim. Posts product events to PostHog's `/capture/`
+ * endpoint directly — no SDK, mirroring the frontend shim
+ * (frontend/src/services/analytics.ts).
+ *
+ * Activation: set `POSTHOG_KEY` (a SERVER/project API key) and optionally
+ * `POSTHOG_HOST` (defaults to https://us.i.posthog.com). With the key unset
+ * every call short-circuits to a no-op — the dev/test default, so nothing
+ * leaks from local development or CI.
+ *
+ * This emitter exists to fire CONFIRMED revenue events from the trusted
+ * backend. The frontend `subscription_upgraded` event fires at checkout START
+ * (intent, not confirmation); the Stripe webhook is the source of truth for
+ * revenue, so it emits the confirmed counterpart `subscription_activated`.
+ *
+ * Privacy / safety:
+ *  - distinct_id is a stable household-scoped id (`household:<householdId>`)
+ *    and we attach `$groups: { household: <householdId> }`. We never send
+ *    email, names, plant names, or any free text.
+ *  - Event properties are limited to enum-like discriminators (plan id,
+ *    billing interval) — never user-supplied strings.
+ *  - The server has no browser Do-Not-Track signal to honor; activation is
+ *    purely key-gated.
+ *  - `capture()` NEVER throws to its caller (wrapped in try/catch). Analytics
+ *    failures must not affect the webhook — a thrown error there would 5xx and
+ *    make Stripe retry a delivery that actually succeeded.
+ */
+
+const HOST = process.env.POSTHOG_HOST || 'https://us.i.posthog.com';
+
+/** Server-side product events emitted from trusted backend paths. */
+export type ServerEventName = 'subscription_activated'; // Stripe webhook confirmed a paid plan is active.
+
+export interface ServerEventProps {
+  /** Plan the household activated. */
+  plan?: 'garden' | 'greenhouse';
+  /** Billing cadence stamped on the Stripe metadata at checkout. */
+  interval?: 'month' | 'year';
+}
+
+/**
+ * Best-effort capture. Resolves (never rejects) regardless of outcome:
+ * no-ops without a key, swallows network/serialization errors. Callers in
+ * critical paths (the webhook) can `void`-ignore this safely.
+ */
+export async function capture(
+  householdId: string,
+  event: ServerEventName,
+  properties: ServerEventProps = {}
+): Promise<void> {
+  // Read the key at call time (not module load) so tests can toggle it and
+  // so a redeploy that sets it takes effect without a cold-start dependency.
+  const key = process.env.POSTHOG_KEY;
+  if (!key || !householdId) return;
+  try {
+    await fetch(`${HOST}/capture/`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        api_key: key,
+        event,
+        distinct_id: `household:${householdId}`,
+        properties: {
+          ...properties,
+          $groups: { household: householdId },
+          $lib: 'family-greenhouse-server-shim',
+          $lib_version: '1.0.0',
+        },
+        timestamp: new Date().toISOString(),
+      }),
+    });
+  } catch {
+    // Never throw to the caller — analytics failures must not affect billing.
+  }
+}

--- a/backend/tests/unit/services/billing.test.ts
+++ b/backend/tests/unit/services/billing.test.ts
@@ -47,6 +47,14 @@ vi.mock('../../../src/utils/dynamodb.js', () => ({
   TABLE_NAME: 'test-table',
 }));
 
+// Mock the server analytics emitter so we can assert the confirmed-conversion
+// event without hitting PostHog, and simulate it rejecting to prove the webhook
+// apply path swallows analytics failures.
+const { captureMock } = vi.hoisted(() => ({ captureMock: vi.fn() }));
+vi.mock('../../../src/utils/serverAnalytics.js', () => ({
+  capture: captureMock,
+}));
+
 describe('deltaForStripeEvent', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -431,6 +439,141 @@ describe('recordStripeEventOnce / applyStripeEvent idempotency', () => {
       input: { ExpressionAttributeValues: Record<string, unknown> };
     };
     expect(updateCmd.input.ExpressionAttributeValues[':planId']).toBe('seedling');
+  });
+});
+
+describe('applyStripeEvent — confirmed-conversion analytics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    captureMock.mockResolvedValue(undefined);
+  });
+
+  it('emits subscription_activated when a household transitions to an active paid plan', async () => {
+    const { dynamodb } = await import('../../../src/utils/dynamodb.js');
+    vi.mocked(dynamodb.send).mockResolvedValue({});
+    const { applyStripeEvent } = await import('../../../src/services/billing.js');
+    await applyStripeEvent({
+      id: 'evt_activate',
+      created: 1_700_000_000,
+      type: 'checkout.session.completed',
+      data: {
+        object: {
+          metadata: { householdId: 'hh-1', planId: 'garden', interval: 'year' },
+          customer: 'cus_1',
+          subscription: 'sub_1',
+        },
+      },
+    } as unknown as Stripe.Event);
+    expect(captureMock).toHaveBeenCalledTimes(1);
+    expect(captureMock).toHaveBeenCalledWith('hh-1', 'subscription_activated', {
+      plan: 'garden',
+      interval: 'year',
+    });
+  });
+
+  it('does NOT emit on a cancellation/downgrade to seedling', async () => {
+    const { dynamodb } = await import('../../../src/utils/dynamodb.js');
+    // Guard read (subscription matches) + Update + ledger Put.
+    vi.mocked(dynamodb.send)
+      .mockResolvedValueOnce({ Item: { planId: 'garden', stripeSubscriptionId: 'sub_live' } })
+      .mockResolvedValue({});
+    const { applyStripeEvent } = await import('../../../src/services/billing.js');
+    await applyStripeEvent({
+      id: 'evt_cancel',
+      created: 1_700_000_000,
+      type: 'customer.subscription.deleted',
+      data: {
+        object: { id: 'sub_live', metadata: { householdId: 'hh-1', planId: 'garden' } },
+      },
+    } as unknown as Stripe.Event);
+    expect(captureMock).not.toHaveBeenCalled();
+  });
+
+  it('does NOT re-emit on customer.subscription.updated (renewal/plan-change) to avoid inflating conversions', async () => {
+    const { dynamodb } = await import('../../../src/utils/dynamodb.js');
+    vi.mocked(dynamodb.send).mockResolvedValue({});
+    const { applyStripeEvent } = await import('../../../src/services/billing.js');
+    await applyStripeEvent({
+      id: 'evt_renewal',
+      created: 1_700_000_000,
+      type: 'customer.subscription.updated',
+      data: {
+        object: {
+          id: 'sub_1',
+          status: 'active',
+          metadata: { householdId: 'hh-1', planId: 'garden', interval: 'month' },
+        },
+      },
+    } as unknown as Stripe.Event);
+    expect(captureMock).not.toHaveBeenCalled();
+  });
+
+  it('emits on customer.subscription.created when it becomes active', async () => {
+    const { dynamodb } = await import('../../../src/utils/dynamodb.js');
+    vi.mocked(dynamodb.send).mockResolvedValue({});
+    const { applyStripeEvent } = await import('../../../src/services/billing.js');
+    await applyStripeEvent({
+      id: 'evt_created',
+      created: 1_700_000_000,
+      type: 'customer.subscription.created',
+      data: {
+        object: {
+          id: 'sub_1',
+          status: 'active',
+          metadata: { householdId: 'hh-1', planId: 'greenhouse', interval: 'month' },
+        },
+      },
+    } as unknown as Stripe.Event);
+    expect(captureMock).toHaveBeenCalledWith('hh-1', 'subscription_activated', {
+      plan: 'greenhouse',
+      interval: 'month',
+    });
+  });
+
+  it('omits interval when the Stripe metadata carries none (e.g. lifetime)', async () => {
+    const { dynamodb } = await import('../../../src/utils/dynamodb.js');
+    vi.mocked(dynamodb.send).mockResolvedValue({});
+    const { applyStripeEvent } = await import('../../../src/services/billing.js');
+    await applyStripeEvent({
+      id: 'evt_no_interval',
+      created: 1_700_000_000,
+      type: 'checkout.session.completed',
+      data: {
+        object: {
+          metadata: { householdId: 'hh-1', planId: 'greenhouse' },
+          customer: 'cus_1',
+          subscription: 'sub_1',
+        },
+      },
+    } as unknown as Stripe.Event);
+    expect(captureMock).toHaveBeenCalledWith('hh-1', 'subscription_activated', {
+      plan: 'greenhouse',
+      interval: undefined,
+    });
+  });
+
+  it('does NOT throw when the analytics emitter rejects (webhook must never 5xx on analytics)', async () => {
+    const { dynamodb } = await import('../../../src/utils/dynamodb.js');
+    vi.mocked(dynamodb.send).mockResolvedValue({});
+    // The emitter is best-effort + fire-and-forget; a rejected promise from it
+    // must not surface to the webhook (which would make Stripe retry).
+    captureMock.mockRejectedValue(new Error('posthog down'));
+    const { applyStripeEvent } = await import('../../../src/services/billing.js');
+    await expect(
+      applyStripeEvent({
+        id: 'evt_analytics_fail',
+        created: 1_700_000_000,
+        type: 'checkout.session.completed',
+        data: {
+          object: {
+            metadata: { householdId: 'hh-1', planId: 'garden', interval: 'month' },
+            customer: 'cus_1',
+            subscription: 'sub_1',
+          },
+        },
+      } as unknown as Stripe.Event)
+    ).resolves.toBeUndefined();
+    expect(captureMock).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/backend/tests/unit/utils/serverAnalytics.test.ts
+++ b/backend/tests/unit/utils/serverAnalytics.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+describe('serverAnalytics.capture', () => {
+  const originalKey = process.env.POSTHOG_KEY;
+  const originalHost = process.env.POSTHOG_HOST;
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    fetchSpy = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchSpy);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    if (originalKey === undefined) delete process.env.POSTHOG_KEY;
+    else process.env.POSTHOG_KEY = originalKey;
+    if (originalHost === undefined) delete process.env.POSTHOG_HOST;
+    else process.env.POSTHOG_HOST = originalHost;
+  });
+
+  it('no-ops (no fetch) when POSTHOG_KEY is unset', async () => {
+    delete process.env.POSTHOG_KEY;
+    const { capture } = await import('../../../src/utils/serverAnalytics.js');
+    await capture('hh-1', 'subscription_activated', { plan: 'garden', interval: 'year' });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when householdId is empty even with a key set', async () => {
+    process.env.POSTHOG_KEY = 'phc_test';
+    const { capture } = await import('../../../src/utils/serverAnalytics.js');
+    await capture('', 'subscription_activated', { plan: 'garden' });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('POSTs a household-scoped capture payload when the key is set', async () => {
+    process.env.POSTHOG_KEY = 'phc_test';
+    delete process.env.POSTHOG_HOST;
+    const { capture } = await import('../../../src/utils/serverAnalytics.js');
+    await capture('hh-1', 'subscription_activated', { plan: 'garden', interval: 'year' });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe('https://us.i.posthog.com/capture/');
+    const body = JSON.parse((init as { body: string }).body);
+    expect(body.api_key).toBe('phc_test');
+    expect(body.event).toBe('subscription_activated');
+    expect(body.distinct_id).toBe('household:hh-1');
+    expect(body.properties.plan).toBe('garden');
+    expect(body.properties.interval).toBe('year');
+    expect(body.properties.$groups).toEqual({ household: 'hh-1' });
+  });
+
+  it('honors POSTHOG_HOST override', async () => {
+    process.env.POSTHOG_KEY = 'phc_test';
+    process.env.POSTHOG_HOST = 'https://eu.posthog.test';
+    const { capture } = await import('../../../src/utils/serverAnalytics.js');
+    await capture('hh-1', 'subscription_activated');
+    expect(fetchSpy.mock.calls[0][0]).toBe('https://eu.posthog.test/capture/');
+  });
+
+  it('never rejects when fetch throws (analytics must not break billing)', async () => {
+    process.env.POSTHOG_KEY = 'phc_test';
+    fetchSpy.mockRejectedValue(new Error('network down'));
+    const { capture } = await import('../../../src/utils/serverAnalytics.js');
+    await expect(
+      capture('hh-1', 'subscription_activated', { plan: 'garden' })
+    ).resolves.toBeUndefined();
+  });
+});

--- a/infrastructure/modules/api/main.tf
+++ b/infrastructure/modules/api/main.tf
@@ -318,6 +318,11 @@ locals {
     GIT_SHA                   = var.git_sha
     CHAT_BUDGET_INPUT_TOKENS  = var.chat_budget_input_tokens
     CHAT_BUDGET_OUTPUT_TOKENS = var.chat_budget_output_tokens
+    # PostHog server-side analytics. Powers confirmed conversion events from
+    # the Stripe webhook (subscription_activated). Empty key = emitter no-ops,
+    # so nothing leaks from environments without a configured project key.
+    POSTHOG_KEY  = var.posthog_key
+    POSTHOG_HOST = var.posthog_host
   }
 }
 

--- a/infrastructure/modules/api/variables.tf
+++ b/infrastructure/modules/api/variables.tf
@@ -226,3 +226,20 @@ variable "chat_budget_output_tokens" {
   type        = string
   default     = ""
 }
+
+# --- PostHog (server-side product analytics) ---
+# Server PostHog key powers confirmed conversion events emitted from the Stripe
+# webhook (e.g. subscription_activated). Empty = the server analytics emitter
+# no-ops, so nothing leaks from non-configured environments.
+variable "posthog_key" {
+  description = "PostHog project API key for server-side analytics. Empty disables the server emitter (no-op)."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "posthog_host" {
+  description = "PostHog ingestion host for server-side analytics. Empty lets the code default (https://us.i.posthog.com) apply."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## What

Closes the revenue-attribution loop: adds a server-side analytics signal for when a subscription actually becomes **active**, the confirmed counterpart to the client's `subscription_upgraded` (which fires at checkout START — intent, not confirmation).

## Changes

- **`backend/src/utils/serverAnalytics.ts`** (new) — a ~30-line server PostHog emitter. POSTs to `${POSTHOG_HOST||'https://us.i.posthog.com'}/capture/` with `POSTHOG_KEY`. No-ops when the key is unset (mirrors the frontend shim). `distinct_id` is household-scoped (`household:<id>`) with `$groups: { household }`. Enum-only props (plan, interval) — no PII/free text. Never throws to the caller.
- **`backend/src/services/billing.ts`** — `applyStripeEvent` emits `subscription_activated` `{ plan, interval? }` after a confirming delta is applied (non-seedling plan + status active). Best-effort + fire-and-forget (`void capture(...)`), so it can **never** 5xx the webhook (which would make Stripe retry). Restricted to the one-time activation events (`checkout.session.completed`, `customer.subscription.created`); `customer.subscription.updated` is excluded so renewals/plan-changes don't inflate the conversion count. Interval is read from the Stripe metadata already stamped at checkout.
- **infra** — `POSTHOG_KEY` / `POSTHOG_HOST` added to `variables.tf` (default `""`) and wired into the api Lambda env in `main.tf`, same pattern as the `STRIPE_*` vars. `terraform fmt` clean.
- **tests** — new `serverAnalytics.test.ts` (no-op without key, household-scoped payload, host override, never-rejects) plus a new describe block in `billing.test.ts` (emits on confirming event, swallows emitter rejection, does not emit on cancel, does not re-emit on `subscription.updated`, emits on `subscription.created`).

## Verification

- `backend`: `npm run typecheck`, `npm run lint`, `npx vitest run` — full suite green (954 tests, incl. the webhook/integration paths).
- `infrastructure`: `terraform fmt -check -recursive` clean (`validate` is network-blocked, expected).

## Follow-up

`docs/analytics.md` is owned by another unit this batch, so it was not edited here. It should later note `subscription_activated` (server, confirmed) alongside `subscription_upgraded` (client, intent). The new server event is documented in code comments in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014abKA3txbQXT7Xe9cpKN79

---
_Generated by [Claude Code](https://claude.ai/code/session_014abKA3txbQXT7Xe9cpKN79)_