### PR TITLE
fix(security): patch js-yaml DoS via npm override (alert #12)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4993,30 +4993,6 @@
         "tree-kill": "^1.2.1"
       }
     },
-    "node_modules/@lhci/utils/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/@lhci/utils/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/@middy/core": {
       "version": "7.6.7",
       "resolved": "https://registry.npmjs.org/@middy/core/-/core-7.6.7.tgz",
@@ -16952,13 +16928,6 @@
       "engines": {
         "node": ">= 10.x"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/stack-chain": {
       "version": "1.3.7",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "overrides": {
     "tmp": "^0.2.6",
     "esbuild": "0.28.1",
+    "js-yaml": "^4.2.0",
     "uuid": "^11.1.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",


### PR DESCRIPTION
## What

Patches the open moderate **Dependabot alert #12** — `js-yaml` quadratic-complexity DoS in merge-key handling ([GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68)).

## Why workspace `npm audit` missed it

The vulnerable `js-yaml@3.14.2` was nested under `@lhci/utils` (Lighthouse CI), which is a **root-tree** devDependency via `frontend`. Running `npm audit` inside the `backend`/`frontend` workspaces never traverses the root `@lhci/cli` subtree, so it stayed invisible there while GitHub's tree-wide scan flagged it.

## Why a 4.2.0 override is safe here

- The advisory's only patched version is **4.2.0** — there is no patched 3.x.
- `@lhci/utils` calls the v3-only `yaml.safeLoad` API, **but only when reading `.yml`/`.yaml` config files**. This repo's Lighthouse configs are `.cjs` (`frontend/lighthouserc.cjs`, `frontend/lighthouserc.mobile.cjs`), so that code path is never exercised.
- Verified: `lhci healthcheck` passes with js-yaml 4.2.0 (config found, Chrome found, healthcheck passed).
- `js-yaml` is the only v3 consumer in the whole tree; every other dependent already wants `^4.1.0`.

## Diff scope

- `package.json`: one `overrides` entry (`"js-yaml": "^4.2.0"`).
- `package-lock.json`: **surgical** — only the nested `js-yaml@3.14.2` + its `argparse@1.0.10`/`sprintf-js` subtree removed (31 lines). All cross-platform optional deps (`@esbuild/*`, `@rollup/rollup-*`) are preserved, so `npm ci` on Linux CI is unaffected. A naive full `npm install` regen on macOS strips those — deliberately avoided.

## Verification

- `npm audit` → **0 vulnerabilities** (was 3 moderate).
- `lhci healthcheck` → passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)