### PR TITLE
fix(notifications): count a reminder delivered only on a real send (HIGH)

### DIFF
--- a/backend/src/services/emailNotifier.ts
+++ b/backend/src/services/emailNotifier.ts
@@ -26,12 +26,16 @@ export interface EmailMessage {
  * `SES_FROM_EMAIL` isn't configured, which is the normal state for local dev
  * and unit tests. The dev experience is the same regardless of channel: you
  * see what would have gone out in the logs.
+ *
+ * Returns `true` only when a real send was attempted; a dry-run returns
+ * `false` so callers (the reminder fan-out) don't count an unconfigured
+ * channel as a delivery and silently burn the day's slot.
  */
-export async function sendEmail(msg: EmailMessage): Promise<void> {
+export async function sendEmail(msg: EmailMessage): Promise<boolean> {
   const from = process.env.SES_FROM_EMAIL;
   if (!from) {
     logger.info({ msg: 'email_dry_run', to: msg.to, subject: msg.subject }, 'email_dry_run');
-    return;
+    return false;
   }
   await ses().send(
     new SendEmailCommand({
@@ -43,4 +47,5 @@ export async function sendEmail(msg: EmailMessage): Promise<void> {
       },
     })
   );
+  return true;
 }

--- a/backend/src/services/notifier.ts
+++ b/backend/src/services/notifier.ts
@@ -47,20 +47,23 @@ export interface NotificationRecipient {
 }
 
 /**
- * Returns whether at least one browser-push delivery was actually attempted —
- * a configured send to an existing subscription, or (in dry-run) the logged
- * stand-in for one. `sendToUser` uses this to decide whether the user was
- * reachable on this channel. A user with no subscriptions returns false.
+ * Returns whether at least one browser-push notification was ACTUALLY
+ * delivered — a configured send that resolved without the browser dropping
+ * the subscription. A dry-run (VAPID unset), a user with no subscriptions, or
+ * a user all of whose subscriptions are stale (404/410) all return false, so
+ * `sendToUser` never counts an unconfigured or unreachable channel as a
+ * delivery and burns the day's reminder slot for nothing.
  */
 async function sendBrowserPush(userId: string, payload: NotificationPayload): Promise<boolean> {
   const subs = await pushSubscriptions.getUserSubscriptions(userId);
   if (subs.length === 0) return false;
   if (!ensureWebPushConfigured()) {
     logger.info({ userId, count: subs.length, payload, msg: 'push_dry_run' }, 'push_dry_run');
-    // Dry-run still counts as "reachable on browser push" — in a configured
-    // environment this would have delivered.
-    return true;
+    // Dry-run is NOT a delivery: nothing left the building, so don't let it
+    // claim the daily slot.
+    return false;
   }
+  let anyDelivered = false;
   await Promise.all(
     subs.map(async (sub) => {
       try {
@@ -68,6 +71,7 @@ async function sendBrowserPush(userId: string, payload: NotificationPayload): Pr
           { endpoint: sub.endpoint, keys: sub.keys },
           JSON.stringify(payload)
         );
+        anyDelivered = true;
       } catch (err) {
         const e = err as { statusCode?: number };
         // 404/410 means the browser dropped the subscription permanently.
@@ -79,7 +83,7 @@ async function sendBrowserPush(userId: string, payload: NotificationPayload): Pr
       }
     })
   );
-  return true;
+  return anyDelivered;
 }
 
 /**
@@ -87,8 +91,11 @@ async function sendBrowserPush(userId: string, payload: NotificationPayload): Pr
  * `services/reminders.ts`) keys off this so it only "burns the day" when the
  * user was actually reachable:
  *
- *   - `delivered` — at least one channel attempted a real send (browser push
- *     to an existing subscription, email, or SMS).
+ *   - `delivered` — at least one channel ACTUALLY sent (a browser push that
+ *     resolved, or an email/SMS that left the building). A dry-run on an
+ *     unconfigured channel (SES/VAPID/SNS not provisioned) does NOT count, so
+ *     the caller keeps retrying until a real send happens rather than burning
+ *     the day's slot on a notification nobody received.
  *   - `dndSuppressedOnly` — the user has email and/or SMS enabled but NOTHING
  *     delivered, and the only reason the loud channels were skipped is the DND
  *     window. This is the case H1 exists for: a DND user who relies on
@@ -122,16 +129,18 @@ export async function sendToUser(
   const inDnd = notificationPrefs.isInDndWindow(prefs);
 
   // Browser push runs first and synchronously resolves whether the user has a
-  // subscription, so we can fold its reachability into `delivered`.
+  // subscription, so we can fold its actual delivery into `delivered`.
   let delivered = false;
   if (prefs.browser) {
     delivered = (await sendBrowserPush(recipient.userId, payload)) || delivered;
   }
 
-  const work: Promise<void>[] = [];
+  // Each loud-channel send resolves to whether it ACTUALLY sent (false on a
+  // dry-run / unconfigured channel), so an enabled-but-unprovisioned SES/SNS
+  // never masquerades as a delivery.
+  const work: Promise<boolean>[] = [];
 
   if (prefs.email && !inDnd) {
-    delivered = true;
     work.push(
       emailNotifier
         .sendEmail({
@@ -139,9 +148,10 @@ export async function sendToUser(
           subject: payload.title,
           text: payload.url ? `${payload.body}\n\n${payload.url}` : payload.body,
         })
-        .catch((err) =>
-          logger.warn({ err, userId: recipient.userId, msg: 'email_failed' }, 'email_failed')
-        )
+        .catch((err) => {
+          logger.warn({ err, userId: recipient.userId, msg: 'email_failed' }, 'email_failed');
+          return false;
+        })
     );
   }
   if (prefs.sms && prefs.phone && !inDnd) {
@@ -154,13 +164,13 @@ export async function sendToUser(
         'sms_skipped_unverified'
       );
     } else {
-      delivered = true;
       work.push(
         smsNotifier
           .sendSms({ to: prefs.phone, text: `${payload.title}: ${payload.body}` })
-          .catch((err) =>
-            logger.warn({ err, userId: recipient.userId, msg: 'sms_failed' }, 'sms_failed')
-          )
+          .catch((err) => {
+            logger.warn({ err, userId: recipient.userId, msg: 'sms_failed' }, 'sms_failed');
+            return false;
+          })
       );
     }
   }
@@ -168,7 +178,8 @@ export async function sendToUser(
     logger.info({ userId: recipient.userId, msg: 'dnd_skipped' }, 'dnd_skipped');
   }
 
-  await Promise.all(work);
+  const loudResults = await Promise.all(work);
+  if (loudResults.some(Boolean)) delivered = true;
 
   // DND-suppressed-only: the user wants email/SMS, nothing actually went out,
   // and DND is the cause. (`delivered` already covers browser push delivering

--- a/backend/src/services/smsNotifier.ts
+++ b/backend/src/services/smsNotifier.ts
@@ -27,8 +27,12 @@ export interface SmsMessage {
  * explicit flag rather than inferring from credentials because SNS direct-
  * to-phone is not free and we don't want a misconfigured staging stack to
  * burn through real money on test runs.
+ *
+ * Returns `true` only when a real send was attempted; a dry-run returns
+ * `false` so the reminder fan-out doesn't treat an unconfigured channel as a
+ * delivery and burn the day's slot.
  */
-export async function sendSms(msg: SmsMessage): Promise<void> {
+export async function sendSms(msg: SmsMessage): Promise<boolean> {
   if (!E164.test(msg.to)) {
     throw new Error(`Phone number must be E.164 format, got: ${msg.to}`);
   }
@@ -37,7 +41,7 @@ export async function sendSms(msg: SmsMessage): Promise<void> {
 
   if (process.env.SMS_NOTIFICATIONS_ENABLED !== '1') {
     logger.info({ msg: 'sms_dry_run', to: msg.to, body: text }, 'sms_dry_run');
-    return;
+    return false;
   }
 
   await sns().send(
@@ -54,4 +58,5 @@ export async function sendSms(msg: SmsMessage): Promise<void> {
       },
     })
   );
+  return true;
 }

--- a/backend/tests/integration/notification-dispatch.test.ts
+++ b/backend/tests/integration/notification-dispatch.test.ts
@@ -418,15 +418,18 @@ describe('notification dispatch (end-to-end) — failure injection / chaos', () 
     // Must not throw despite the injected SES failure.
     const sent = await reminders.remindHousehold(householdId, new Date('2026-04-25T14:00:00Z'));
 
-    // SES was attempted for all three email-enabled members (one threw, two ok).
+    // SES was attempted for all three email-enabled members (Alpha threw, the
+    // other two succeeded).
     expect(sesSendMock).toHaveBeenCalledTimes(3);
     // Charlie's OTHER channels are unaffected by his failed email leg.
     expect(smsRecipients()).toEqual(['+15550000004']);
     expect(pushRecipientEndpoints()).toEqual(['https://push.example/charlie']);
-    // All three members are still counted as delivered: notifier.sendToUser
-    // marks `delivered` when it *attempts* a send (the catch only logs), so a
-    // throttled email does not roll the recipient back to undelivered.
-    expect(sent).toBe(3);
+    // Alpha's only channel (email) actually THREW, so he is NOT counted as
+    // delivered — his slot stays open and the next run retries him. (This is
+    // the corrected accounting: `delivered` tracks real sends, not attempts.)
+    // Bravo (email ok) and Charlie (email ok + sms + push) both delivered, and
+    // crucially one failure did not abort the batch for the others.
+    expect(sent).toBe(2);
   });
 
   it('isolates a thrown SMS send so the email of the same batch still goes out', async () => {

--- a/backend/tests/unit/services/notifierMatrix.test.ts
+++ b/backend/tests/unit/services/notifierMatrix.test.ts
@@ -294,3 +294,50 @@ describe('notifier.sendToUser — channel × DND × timezone matrix', () => {
     });
   }
 });
+
+describe('notifier.sendToUser — `delivered` reflects ACTUAL send, not channel enablement', () => {
+  // Guards the bug where an enabled-but-unconfigured channel (SES/VAPID/SNS
+  // not provisioned → dry-run) reported delivered=true, which burned the
+  // user's daily reminder slot even though nothing was sent.
+  beforeEach(() => vi.setSystemTime(new Date('2026-04-25T14:00:00Z')));
+
+  it('email enabled but dry-run (sendEmail → false) → not delivered, not DND-suppressed', async () => {
+    const { sendToUser, emailMock } = await loadSendToUser({ email: true });
+    emailMock.mockResolvedValue(false); // SES unconfigured: logged, not sent
+    const result = await sendToUser(RECIPIENT, PAYLOAD);
+    expect(emailMock).toHaveBeenCalledTimes(1);
+    expect(result.delivered).toBe(false);
+    expect(result.dndSuppressedOnly).toBe(false);
+  });
+
+  it('email enabled and actually sent (sendEmail → true) → delivered', async () => {
+    const { sendToUser, emailMock } = await loadSendToUser({ email: true });
+    emailMock.mockResolvedValue(true);
+    const result = await sendToUser(RECIPIENT, PAYLOAD);
+    expect(result.delivered).toBe(true);
+  });
+
+  it('verified SMS that dry-runs (sendSms → false) → not delivered', async () => {
+    const { sendToUser, smsMock } = await loadSendToUser({
+      email: false,
+      sms: true,
+      phone: '+15551234567',
+      phoneVerified: true,
+    });
+    smsMock.mockResolvedValue(false);
+    const result = await sendToUser(RECIPIENT, PAYLOAD);
+    expect(smsMock).toHaveBeenCalledTimes(1);
+    expect(result.delivered).toBe(false);
+  });
+
+  it('email-only user inside DND → dndSuppressedOnly (retry next run), not delivered', async () => {
+    const { sendToUser } = await loadSendToUser({
+      email: true,
+      dndStart: '13:00',
+      dndEnd: '15:00',
+    });
+    const result = await sendToUser(RECIPIENT, PAYLOAD);
+    expect(result.delivered).toBe(false);
+    expect(result.dndSuppressedOnly).toBe(true);
+  });
+});


### PR DESCRIPTION
## The bug (from the ultra code-review, finding #1 — HIGH)

`notifier.sendToUser` set `delivered = true` whenever a channel was **enabled**, not when it actually **sent**. In production today SES/VAPID/SNS are unprovisioned, so every channel dry-run-logs and returns — yet the default user (email on) was marked delivered, `reminders.ts` burned the day's slot, and the user **silently received nothing**: no error, no DLQ, no alarm, and no retry until the next UTC day. Daily care reminders (the retention-defining feature) were effectively 100% non-delivering.

## Fix

Delivery accounting now reflects what actually left the building:
- `emailNotifier.sendEmail` / `smsNotifier.sendSms` return a **boolean** — `false` on a dry-run (unconfigured), `true` on a real send.
- `notifier.sendBrowserPush` returns `false` on dry-run, and `true` only when at least one push actually resolved (a user whose subscriptions are all stale 404/410 → `false`).
- `sendToUser` derives `delivered` from those results, so an enabled-but-unprovisioned channel no longer masquerades as a delivery. When nothing sends, the slot is left unclaimed and the next run retries.

The `void → boolean` return change is non-breaking (all other callers ignore the return).

## Tests

- New `notifierMatrix` cases: `delivered` tracks real sends — dry-run (`sendEmail → false`) and DND-suppressed → **not** delivered; real send → delivered.
- Updated the dispatch-chaos integration case: a throttled/throwing email is no longer counted as delivered (the failing recipient retries next run), while the other two still go out — proving one failure doesn't abort the batch.
- Backend: **987 tests pass**, typecheck + lint clean.

> Operational tie-in: this is the bug behind the still-unset `POSTHOG_KEY`/SES/VAPID secrets — once those are provisioned, delivery + slot-claiming work correctly; until then, users are correctly retried instead of silently skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)