### PR TITLE
fix(billing): live-price plan resolution, dedup-gated conversion, lifetime cadence

### DIFF
--- a/backend/src/services/billing.ts
+++ b/backend/src/services/billing.ts
@@ -268,13 +268,38 @@ function planIdFromMetadata(
  * Pull the billing cadence we stamp onto checkout-session and subscription
  * metadata at creation time (see createCheckoutSession). Enum-only — returns
  * undefined when absent or not one of our known values, so analytics never
- * carries free text. Lifetime (`mode: 'payment'`) checkouts carry no interval.
+ * carries free text. `lifetime` (`mode: 'payment'`) is a real cadence here:
+ * createCheckoutSession stamps it like the recurring ones, so the confirmed
+ * conversion event records one-time purchases with their true cadence.
  */
-function intervalFromEvent(event: Stripe.Event): 'month' | 'year' | undefined {
+function intervalFromEvent(event: Stripe.Event): 'month' | 'year' | 'lifetime' | undefined {
   const metadata = (event.data.object as unknown as { metadata?: Record<string, string> | null })
     .metadata;
   const raw = metadata?.interval;
-  return raw === 'month' || raw === 'year' ? raw : undefined;
+  return raw === 'month' || raw === 'year' || raw === 'lifetime' ? raw : undefined;
+}
+
+/**
+ * Reverse-map a live Stripe price id back to our planId via the per-tier price
+ * env vars. A plan change made in the Stripe billing portal swaps the
+ * subscription's price but never re-stamps OUR metadata, so resolving plan
+ * from the metadata alone would keep entitlement on the old tier. Deriving it
+ * from the price the subscription actually carries fixes that. Returns null
+ * when the price isn't one of ours (env unset — e.g. local/test — or a price
+ * we don't sell), so callers fall back to metadata.
+ */
+function planIdFromPriceId(priceId: string | null | undefined): PlanId | null {
+  if (!priceId) return null;
+  for (const plan of Object.values(PLANS)) {
+    for (const env of [
+      plan.stripePriceEnv,
+      plan.annualStripePriceEnv,
+      plan.lifetimeStripePriceEnv,
+    ]) {
+      if (env && process.env[env] === priceId) return plan.id;
+    }
+  }
+  return null;
 }
 
 export function deltaForStripeEvent(event: Stripe.Event): SubscriptionDelta | null {
@@ -332,7 +357,14 @@ export function deltaForStripeEvent(event: Stripe.Event): SubscriptionDelta | nu
       const sub = event.data.object;
       const householdId = (sub.metadata?.householdId as string | undefined) ?? '';
       if (!householdId) return null;
-      const planId = planIdFromMetadata(event, sub.metadata);
+      // Prefer the plan the subscription's LIVE price maps to over our
+      // one-time-stamped metadata: a portal-initiated plan switch changes the
+      // price but not the metadata, so trusting metadata would freeze the
+      // household on the old tier's caps. Fall back to metadata when the price
+      // isn't recognized (price envs unset, e.g. local/test).
+      const item = sub.items?.data?.[0];
+      const priceId = typeof item?.price === 'string' ? item.price : item?.price?.id;
+      const planId = planIdFromPriceId(priceId) ?? planIdFromMetadata(event, sub.metadata);
       if (!planId) return null;
       // current_period_end moved off the top-level Subscription object in
       // newer Stripe API versions and now lives on the subscription item.
@@ -505,6 +537,13 @@ export async function applyStripeEvent(event: Stripe.Event): Promise<void> {
   // `subscription.created` with status `trialing`, so this won't double-count
   // with `checkout.session.completed`, which we stamp `active`.)
   //
+  // Gated on `isNew`: a Stripe webhook REDELIVERY (at-least-once delivery /
+  // retries) re-runs this whole function, but the event ledger has already
+  // recorded this event id, so we skip the emit and never double-count the
+  // same conversion. (updateHouseholdSubscription's `<=` ordering guard lets
+  // an identical redelivery re-apply the idempotent write, so the ledger is
+  // what protects the analytics count here.)
+  //
   // Best-effort + fire-and-forget: `capture` never throws and we `void` its
   // promise, so an analytics outage can NEVER 5xx the webhook (which would make
   // Stripe retry an already-applied delivery).
@@ -512,6 +551,7 @@ export async function applyStripeEvent(event: Stripe.Event): Promise<void> {
     event.type === 'checkout.session.completed' || event.type === 'customer.subscription.created';
   const activatedPlan = delta.fields.planId;
   if (
+    isNew &&
     isActivationEvent &&
     activatedPlan &&
     activatedPlan !== 'seedling' &&

--- a/backend/src/utils/serverAnalytics.ts
+++ b/backend/src/utils/serverAnalytics.ts
@@ -34,8 +34,9 @@ export type ServerEventName = 'subscription_activated'; // Stripe webhook confir
 export interface ServerEventProps {
   /** Plan the household activated. */
   plan?: 'garden' | 'greenhouse';
-  /** Billing cadence stamped on the Stripe metadata at checkout. */
-  interval?: 'month' | 'year';
+  /** Billing cadence stamped on the Stripe metadata at checkout. `lifetime`
+   *  is the one-time Garden purchase. */
+  interval?: 'month' | 'year' | 'lifetime';
 }
 
 /**

--- a/backend/tests/unit/services/billing.test.ts
+++ b/backend/tests/unit/services/billing.test.ts
@@ -210,6 +210,50 @@ describe('deltaForStripeEvent', () => {
     } as unknown as Stripe.Event;
     expect(deltaForStripeEvent(event)).toBeNull();
   });
+
+  it('resolves planId from the LIVE subscription price (portal plan change), not stale metadata', async () => {
+    // A plan switch in the Stripe billing portal swaps the price but never
+    // re-stamps our metadata. Entitlement must follow the price the
+    // subscription now carries, or the household keeps the old tier's caps.
+    process.env.STRIPE_PRICE_ID_GREENHOUSE_ANNUAL = 'price_gh_annual';
+    try {
+      const { deltaForStripeEvent } = await import('../../../src/services/billing.js');
+      const delta = deltaForStripeEvent({
+        id: 'evt_portal_change',
+        type: 'customer.subscription.updated',
+        data: {
+          object: {
+            id: 'sub_1',
+            status: 'active',
+            metadata: { householdId: 'hh-1', planId: 'garden' }, // stale (original checkout)
+            items: {
+              data: [{ price: { id: 'price_gh_annual' }, current_period_end: 1_700_000_000 }],
+            },
+          },
+        },
+      } as unknown as Stripe.Event);
+      expect(delta?.fields.planId).toBe('greenhouse');
+    } finally {
+      delete process.env.STRIPE_PRICE_ID_GREENHOUSE_ANNUAL;
+    }
+  });
+
+  it('falls back to metadata planId when the subscription price is not one we sell (envs unset)', async () => {
+    const { deltaForStripeEvent } = await import('../../../src/services/billing.js');
+    const delta = deltaForStripeEvent({
+      id: 'evt_unknown_price',
+      type: 'customer.subscription.updated',
+      data: {
+        object: {
+          id: 'sub_1',
+          status: 'active',
+          metadata: { householdId: 'hh-1', planId: 'garden' },
+          items: { data: [{ price: { id: 'price_we_dont_recognize' } }] },
+        },
+      },
+    } as unknown as Stripe.Event);
+    expect(delta?.fields.planId).toBe('garden');
+  });
 });
 
 describe('recordStripeEventOnce / applyStripeEvent idempotency', () => {
@@ -530,7 +574,54 @@ describe('applyStripeEvent — confirmed-conversion analytics', () => {
     });
   });
 
-  it('omits interval when the Stripe metadata carries none (e.g. lifetime)', async () => {
+  it('records interval=lifetime for a one-time (mode=payment) Garden purchase', async () => {
+    const { dynamodb } = await import('../../../src/utils/dynamodb.js');
+    vi.mocked(dynamodb.send).mockResolvedValue({});
+    const { applyStripeEvent } = await import('../../../src/services/billing.js');
+    await applyStripeEvent({
+      id: 'evt_lifetime',
+      created: 1_700_000_000,
+      type: 'checkout.session.completed',
+      data: {
+        object: {
+          mode: 'payment',
+          payment_status: 'paid',
+          metadata: { householdId: 'hh-1', planId: 'garden', interval: 'lifetime' },
+          customer: 'cus_1',
+        },
+      },
+    } as unknown as Stripe.Event);
+    expect(captureMock).toHaveBeenCalledWith('hh-1', 'subscription_activated', {
+      plan: 'garden',
+      interval: 'lifetime',
+    });
+  });
+
+  it('does NOT re-emit subscription_activated on a webhook REDELIVERY (already-recorded event)', async () => {
+    const { dynamodb } = await import('../../../src/utils/dynamodb.js');
+    const conditionErr = Object.assign(new Error('exists'), {
+      name: 'ConditionalCheckFailedException',
+    });
+    // Apply re-runs (idempotent), but the ledger Put reports the event id was
+    // already recorded → isNew=false → the conversion is NOT counted again.
+    vi.mocked(dynamodb.send).mockResolvedValueOnce({}).mockRejectedValueOnce(conditionErr);
+    const { applyStripeEvent } = await import('../../../src/services/billing.js');
+    await applyStripeEvent({
+      id: 'evt_redelivered',
+      created: 1_700_000_000,
+      type: 'checkout.session.completed',
+      data: {
+        object: {
+          metadata: { householdId: 'hh-1', planId: 'garden', interval: 'year' },
+          customer: 'cus_1',
+          subscription: 'sub_1',
+        },
+      },
+    } as unknown as Stripe.Event);
+    expect(captureMock).not.toHaveBeenCalled();
+  });
+
+  it('omits interval when the Stripe metadata carries none', async () => {
     const { dynamodb } = await import('../../../src/utils/dynamodb.js');
     vi.mocked(dynamodb.send).mockResolvedValue({});
     const { applyStripeEvent } = await import('../../../src/services/billing.js');


### PR DESCRIPTION
Three Stripe-webhook correctness fixes from the ultra code-review.

### #2 (MEDIUM) — portal plan change didn't update entitlement
`customer.subscription.updated` resolved `planId` from `metadata.planId`, which is stamped once at checkout and never re-stamped. A plan switch in the Stripe billing portal swaps the price but leaves the metadata stale, so the household paid the new price while keeping the **old tier's caps** (or an upgrade never landed).

Fix: `planIdFromPriceId` reverse-maps the subscription's **live** `items[0].price.id` through the per-tier price envs; we prefer it and fall back to metadata only when the price isn't one we sell (envs unset — e.g. local/test, so existing behavior is preserved there).

### #8 (LOW) — webhook redelivery double-counted conversions
`subscription_activated` was emitted before the idempotency ledger was consulted and wasn't gated on it. Since `updateHouseholdSubscription`'s `<=` ordering guard lets an identical redelivery re-apply, a routine Stripe redelivery re-fired the conversion. Now gated on `isNew` (the event-id ledger): the idempotent write still re-applies, but the conversion is emitted only once.

### #10 (LOW) — lifetime purchases recorded with no cadence
A one-time Garden purchase stamps `metadata.interval='lifetime'`, but `intervalFromEvent` only recognized `month|year` and returned `undefined`, dropping the cadence on the **most valuable** conversions. `intervalFromEvent` and `ServerEventProps.interval` now include `'lifetime'`.

### Tests
New cases: price-derived `planId` on a portal change + fallback when the price is unknown; redelivery does **not** re-emit; a lifetime purchase records `interval=lifetime`. Backend **987 pass**, typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)