### PR TITLE
fix(frontend): authoritative first-plant ordinal + DST-safe day counts

### DIFF
--- a/frontend/src/features/analytics/AnalyticsPage.tsx
+++ b/frontend/src/features/analytics/AnalyticsPage.tsx
@@ -8,6 +8,7 @@ import { Card, CardHeader } from '@/components/Card';
 import { PageHeader } from '@/components/PageHeader';
 import { LoadingSpinner } from '@/components/LoadingSpinner';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
+import { calendarDaysBetween } from '@/utils/date';
 import clsx from 'clsx';
 
 /**
@@ -47,11 +48,10 @@ function isOverdue(nextDue: string, now = new Date()): boolean {
 }
 
 function daysOverdue(nextDue: string, now = new Date()): number {
-  const due = new Date(nextDue);
-  const today = new Date(now);
-  today.setHours(0, 0, 0, 0);
-  due.setHours(0, 0, 0, 0);
-  return Math.floor((today.getTime() - due.getTime()) / (24 * 60 * 60 * 1000));
+  // Calendar days between the due date and today, DST-safe (raw local-midnight
+  // subtraction loses a day across a spring-forward boundary). Callers only
+  // pass overdue tasks, so this is >= 1; clamp defensively anyway.
+  return Math.max(0, calendarDaysBetween(new Date(nextDue), now));
 }
 export function AnalyticsPage() {
   useDocumentTitle('Analytics');

--- a/frontend/src/features/plants/AddPlantPage.tsx
+++ b/frontend/src/features/plants/AddPlantPage.tsx
@@ -164,6 +164,27 @@ export function AddPlantPage() {
 
   const mutation = useMutation({
     mutationFn: async (data: AddPlantFormData) => {
+      // Discriminate the first-plant activation event from subsequent adds
+      // using the AUTHORITATIVE pre-create list, not just whatever happens to
+      // be in cache. A deep-link or "Propagate cutting" entry to /plants/new
+      // never loaded the Plants list, so reading getQueryData alone would
+      // mislabel an existing user's Nth plant as their first and inflate the
+      // funnel. Use the cache when warm; only the cold paths fetch. Best-effort
+      // — analytics must never block plant creation.
+      let wasFirstPlant = false;
+      try {
+        const priorPlants =
+          queryClient.getQueryData<unknown[]>(['plants', householdId]) ??
+          ((await queryClient.ensureQueryData({
+            queryKey: ['plants', householdId],
+            queryFn: () => plantService.getPlants('active'),
+          })) as unknown[]);
+        wasFirstPlant = priorPlants.length === 0;
+      } catch {
+        // Unknown (list fetch failed) → keep the safe default (false) rather
+        // than risk over-counting 'first'. Analytics never blocks creation.
+      }
+
       const tags = (data.tags ?? '')
         .split(',')
         .map((t) => t.trim())
@@ -211,15 +232,10 @@ export function AddPlantPage() {
           // Silent failure is intentional — plant is already saved.
         }
       }
-      return plant;
+      return { plant, wasFirstPlant };
     },
-    onSuccess: (plant) => {
-      // Read pre-create plants from cache to discriminate the first-plant
-      // event (a critical funnel step) from subsequent ones.
-      const existing = queryClient.getQueryData(['plants', householdId]) as unknown[] | undefined;
-      track('plant_added', {
-        ordinal: existing && existing.length > 0 ? 'subsequent' : 'first',
-      });
+    onSuccess: ({ plant, wasFirstPlant }) => {
+      track('plant_added', { ordinal: wasFirstPlant ? 'first' : 'subsequent' });
       queryClient.invalidateQueries({ queryKey: ['plants', householdId] });
       toast.success(`${plant.name} added`);
       navigate(`/plants/${plant.id}`);

--- a/frontend/src/i18n/format.ts
+++ b/frontend/src/i18n/format.ts
@@ -7,6 +7,7 @@
 // accept a `locale` override so tests can pin a specific locale.
 
 import i18n from './index';
+import { calendarDaysBetween } from '@/utils/date';
 
 function activeLocale(override?: string): string {
   return override || i18n.language || 'en';
@@ -45,11 +46,9 @@ export function formatCurrency(amountInDollars: number, currency = 'USD', locale
 
 export function formatRelativeDay(date: string | Date, locale?: string): string {
   const d = typeof date === 'string' ? new Date(date) : date;
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
-  const target = new Date(d);
-  target.setHours(0, 0, 0, 0);
-  const diffDays = Math.round((target.getTime() - today.getTime()) / 86400000);
+  // DST-safe day delta (raw local-midnight subtraction drifts across a DST
+  // transition); positive = future ("in N days"), negative = past.
+  const diffDays = calendarDaysBetween(new Date(), d);
   const rtf = new Intl.RelativeTimeFormat(activeLocale(locale), { numeric: 'auto' });
   return rtf.format(diffDays, 'day');
 }


### PR DESCRIPTION
Two frontend correctness fixes from the ultra code-review.

### #6 (MEDIUM) — first-plant analytics mislabel
`AddPlantPage` derived the `plant_added` `ordinal` (first vs subsequent) from `queryClient.getQueryData(['plants', householdId])`, which returns `undefined` whenever the Plants list was never fetched this session — a direct deep link/bookmark to `/plants/new`, or **"Propagate cutting"** from a deep-linked plant detail page (which uses a different per-plant query key). That mislabeled an existing user's Nth plant as their **first**, inflating the activation funnel.

Fix: the pre-create count now comes from the **authoritative** list — the cache when warm, otherwise one `ensureQueryData` fetch. Wrapped in try/catch so the analytics read can never block plant creation (on failure it defaults to `subsequent`, never over-counting `first`).

### #9 (LOW) — DST off-by-one in day counts
`AnalyticsPage.daysOverdue` and `i18n/format.formatRelativeDay` computed a day delta with raw local-midnight subtraction + ms division. Across a DST transition a 23h "spring-forward" gap floors to 0, dropping a day in "N days overdue" / "in N days" labels. Both now delegate to the existing **DST-safe `calendarDaysBetween`** helper (re-anchors to UTC noon), which already has dedicated coverage in `date.dst.test.ts` — so the fix inherits that coverage.

### Verification
Frontend: typecheck, lint, **337 tests**, build all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)