### PR TITLE
fix(infra): least-priv chat-stream role, byte-safe forwarder, cognito email guard

### DIFF
--- a/infrastructure/modules/api/main.tf
+++ b/infrastructure/modules/api/main.tf
@@ -399,9 +399,93 @@ resource "aws_lambda_permission" "api_gateway" {
 # Bundle: backend `dist/chat-stream.js` (src/handlers/chat/streamHandler.ts,
 # an explicit esbuild entry). CD zips it as `handler.mjs` exactly like the
 # other bundles, hence the same "handler.handler" handler string.
+# Dedicated, least-privilege execution role for the PUBLIC streaming-chat
+# Function URL (authorization_type = NONE). The sync fleet's shared role grants
+# the union of every backend privilege — secretsmanager:GetSecretValue,
+# cognito-idp:AdminUpdateUserAttributes, SES, SNS, S3 — none of which the chat
+# path uses (it touches only DynamoDB + Bedrock; climate caches in DDB and
+# calls OpenWeather over HTTPS). Putting the most internet-exposed component on
+# that shared role meant a flaw in its hand-rolled JWT/SSE path (before the
+# in-handler 401) could exfiltrate secrets or escalate household roles. This
+# role carries ONLY what chat actually needs, so that blast radius is gone.
+resource "aws_iam_role" "chat_stream" {
+  name = "${var.project_name}-chat-stream-${var.environment}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action    = "sts:AssumeRole"
+        Effect    = "Allow"
+        Principal = { Service = "lambda.amazonaws.com" }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "chat_stream" {
+  name = "${var.project_name}-chat-stream-policy-${var.environment}"
+  role = aws_iam_role.chat_stream.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"]
+        Resource = "arn:aws:logs:*:*:*"
+      },
+      {
+        # Conversation persistence + the read/write tools (plants, tasks,
+        # household, climate cache). Same table+indexes scope as the fleet.
+        Effect = "Allow"
+        Action = [
+          "dynamodb:GetItem",
+          "dynamodb:PutItem",
+          "dynamodb:UpdateItem",
+          "dynamodb:DeleteItem",
+          "dynamodb:Query",
+          "dynamodb:Scan"
+        ]
+        Resource = [
+          var.dynamodb_table_arn,
+          "${var.dynamodb_table_arn}/index/*"
+        ]
+      },
+      {
+        # Bedrock for the model turn + RAG corpus embedding. Same dual
+        # foundation-model + inference-profile ARN shape as the fleet policy.
+        Effect = "Allow"
+        Action = [
+          "bedrock:InvokeModel",
+          "bedrock:InvokeModelWithResponseStream",
+        ]
+        Resource = [
+          "arn:aws:bedrock:*::foundation-model/anthropic.claude-*",
+          "arn:aws:bedrock:*::foundation-model/amazon.titan-embed-*",
+          "arn:aws:bedrock:*:*:inference-profile/us.anthropic.claude-*",
+          "arn:aws:bedrock:*:*:inference-profile/global.anthropic.claude-*",
+        ]
+      },
+      {
+        # dead_letter_config target for failed async invocations.
+        Effect   = "Allow"
+        Action   = ["sqs:SendMessage"]
+        Resource = aws_sqs_queue.lambda_dlq.arn
+      }
+    ]
+  })
+}
+
+# Active tracing needs the same X-Ray write grant as the fleet role.
+resource "aws_iam_role_policy_attachment" "chat_stream_xray" {
+  role       = aws_iam_role.chat_stream.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
+}
+
 resource "aws_lambda_function" "chat_stream" {
   function_name = "${var.project_name}-chat-stream-${var.environment}"
-  role          = aws_iam_role.lambda.arn
+  role          = aws_iam_role.chat_stream.arn
   handler       = "handler.handler"
   runtime       = "nodejs20.x"
   # Same sizing rationale as the sync `chat` member of the fleet above: up to

--- a/infrastructure/modules/auth/main.tf
+++ b/infrastructure/modules/auth/main.tf
@@ -105,6 +105,18 @@ resource "aws_cognito_user_pool" "main" {
   tags = {
     Name = "${var.project_name}-user-pool-${var.environment}"
   }
+
+  lifecycle {
+    # DEVELOPER email mode (triggered by providing an SES identity) REQUIRES a
+    # from_email_address, but the two are wired from independent variables — so
+    # setting a domain without a from-address yields from_email_address = null
+    # and Cognito rejects the apply with an opaque InvalidParameter. Catch it at
+    # plan time with an actionable message instead.
+    precondition {
+      condition     = var.email_identity_arn == "" || var.email_from_address != ""
+      error_message = "email_from_address is required when an SES identity (email_identity_arn / domain_name) is set: DEVELOPER email mode has no usable sender without it."
+    }
+  }
 }
 
 resource "aws_cognito_user_pool_client" "main" {

--- a/infrastructure/modules/email/lambda/forwarder.mjs
+++ b/infrastructure/modules/email/lambda/forwarder.mjs
@@ -24,12 +24,28 @@ const FROM_ADDRESS = process.env.FROM_ADDRESS;
 
 const STRIP = /^(return-path|sender|dkim-signature|message-id):/i;
 
-function rewrite(raw, originalRecipient) {
-  const sep = raw.indexOf('\r\n\r\n') !== -1 ? '\r\n\r\n' : '\n\n';
-  const splitAt = raw.indexOf(sep);
-  const headerBlock = splitAt === -1 ? raw : raw.slice(0, splitAt);
-  const body = splitAt === -1 ? '' : raw.slice(splitAt);
-  const eol = sep === '\r\n\r\n' ? '\r\n' : '\n';
+export function rewrite(rawBytes, originalRecipient) {
+  // Split header/body on the RAW BYTES and leave the body untouched. Reading
+  // the whole message as a UTF-8 string and re-encoding it (the old approach)
+  // corrupted any non-UTF-8 octets — 8-bit MIME, Content-Transfer-Encoding:
+  // binary, legacy-charset bodies, binary attachment parts — turning them into
+  // U+FFFD before SendRawEmail. Only the (ASCII, RFC 5322) header block is
+  // decoded and rewritten; the body bytes forward verbatim.
+  const crlf = Buffer.from('\r\n\r\n');
+  let splitAt = rawBytes.indexOf(crlf);
+  let sepLen = 4;
+  if (splitAt === -1) {
+    splitAt = rawBytes.indexOf(Buffer.from('\n\n'));
+    sepLen = 2;
+  }
+  const headerBytes = splitAt === -1 ? rawBytes : rawBytes.subarray(0, splitAt);
+  const bodyBytes = splitAt === -1 ? Buffer.alloc(0) : rawBytes.subarray(splitAt + sepLen);
+  const eol = sepLen === 4 ? '\r\n' : '\n';
+  const sep = sepLen === 4 ? '\r\n\r\n' : '\n\n';
+
+  // latin1 is a lossless 1:1 byte<->char mapping, and headers are ASCII, so
+  // decoding/encoding the header block this way never alters a byte.
+  const headerBlock = headerBytes.toString('latin1');
 
   // Unfold continuation lines so each logical header is one element.
   const lines = headerBlock.split(eol);
@@ -62,7 +78,7 @@ function rewrite(raw, originalRecipient) {
   if (from) kept.push(`Reply-To: ${from}`);
   kept.push(`X-Forwarded-For-Mailbox: ${originalRecipient}`);
 
-  return kept.join(eol) + body;
+  return Buffer.concat([Buffer.from(kept.join(eol) + sep, 'latin1'), bodyBytes]);
 }
 
 export const handler = async (event) => {
@@ -92,13 +108,14 @@ export const handler = async (event) => {
     const obj = await s3.send(
       new GetObjectCommand({ Bucket: BUCKET, Key: `${PREFIX}${messageId}` })
     );
-    const raw = await obj.Body.transformToString();
+    // Read the raw MIME as BYTES, not a UTF-8 string — see rewrite().
+    const rawBytes = Buffer.from(await obj.Body.transformToByteArray());
 
     await ses.send(
       new SendRawEmailCommand({
         Source: FROM_ADDRESS,
         Destinations: [FORWARD_TO],
-        RawMessage: { Data: Buffer.from(rewrite(raw, recipient)) },
+        RawMessage: { Data: rewrite(rawBytes, recipient) },
       })
     );
 


### PR DESCRIPTION
Three infrastructure fixes from the ultra code-review.

### #3 (MEDIUM) — least-privilege role for the public chat Function URL
The streaming-chat Function URL (`authorization_type = NONE`, auth done in-handler) ran on the **shared fleet IAM role**, which grants the union of every backend privilege — `secretsmanager:GetSecretValue`, `cognito-idp:AdminUpdateUserAttributes`, SES, SNS, S3. A flaw in its hand-rolled JWT/SSE path (before the 401) could have exfiltrated secrets or escalated household roles.

Gave `chat-stream` a **dedicated role** scoped to exactly what it uses: DynamoDB (table+indexes) + Bedrock + logs + the DLQ + X-Ray. Verified the entire chat tool path (`list_household_plants`, `list_upcoming_tasks`, `get_household_climate`, `search_care_knowledge`, `propose_reminder_task`) reaches only DynamoDB + Bedrock — climate caches in DDB and calls OpenWeather over HTTPS; no S3/secrets/cognito/SES/SNS.

### #4 (MEDIUM) — byte-safe mail forwarder
The SES inbound forwarder read raw MIME with `transformToString()` (UTF-8) and re-encoded with `Buffer.from()` (UTF-8), corrupting any non-UTF-8 octet (8-bit MIME, binary CTE, legacy-charset bodies, binary attachments) before `SendRawEmail`. Now it reads **bytes** (`transformToByteArray`), decodes only the ASCII header block (latin1, lossless) for header surgery, and forwards the body **verbatim**.

Verified: a body with invalid-UTF-8 octets forwards **byte-identical** (the old path mangled it), while DKIM is still stripped and From/Reply-To rewritten. `rewrite` is exported to make it testable.

### #5 (MEDIUM) — Cognito DEVELOPER-mode email guard
DEVELOPER email mode (triggered by an SES identity) **requires** `from_email_address`, but the two are wired from independent variables — a domain without a from-address yields `from_email_address = null` and an opaque apply failure. Added a resource **precondition** that fails the plan with an actionable message.

### Verification
`terraform validate` ✓, `terraform fmt -check` ✓, `node --check forwarder.mjs` ✓.

> Note: #3 rewires `chat-stream`'s execution role and #4 changes the forwarder bundle — both apply on the next prod deploy. chat-stream is currently feature-flag-gated off, so #3 is a latent-risk hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)