### PR TITLE
fix(chat): order messages by an atomic per-conversation sequence

### DIFF
--- a/backend/src/services/chat/persistence.ts
+++ b/backend/src/services/chat/persistence.ts
@@ -30,30 +30,55 @@ function yearMonth(d: Date = new Date()): string {
 }
 
 // Tool turns write several messages back-to-back, often within the same
-// millisecond — a bare-timestamp SK silently overwrites the earlier write.
-// Suffix the SK with a per-process monotonic counter (zero-padded so
-// lexicographic SK order matches write order within an instance) plus a uuid
-// fragment for uniqueness across Lambda instances. The timestamp still leads,
-// so cross-turn ordering is unchanged and `begins_with` prefix queries still
-// match.
-let messageSeq = 0;
-
-function messageSortKey(message: ChatMessageRecord): string {
-  messageSeq = (messageSeq + 1) % 1_000_000;
-  const seq = String(messageSeq).padStart(6, '0');
-  return `CHAT#${message.conversationId}#MSG#${message.timestamp}#${seq}${uuid().slice(0, 8)}`;
+// millisecond, so the SK needs a tie-breaker that preserves write order.
+//
+// A per-PROCESS counter (the previous approach) could not: two concurrent
+// turns on the SAME conversation, served by different Lambda containers in the
+// same millisecond, each counted from their own independent base, so the
+// merged SK order was effectively random at the tie-break level — which could
+// interleave a tool_use and its tool_result and make the replayed history
+// invalid (Bedrock rejects a tool_use not immediately followed by its result).
+//
+// Instead, draw a CONVERSATION-scoped monotonic sequence from a DynamoDB
+// atomic counter: every message gets a globally ordered position within its
+// conversation regardless of which container wrote it. The timestamp still
+// leads the SK for readability and the `begins_with` prefix query; the
+// zero-padded sequence is the authoritative tie-breaker.
+async function nextConversationSeq(householdId: string, conversationId: string): Promise<number> {
+  const res = await dynamodb.send(
+    new UpdateCommand({
+      TableName: TABLE_NAME,
+      Key: { PK: `HOUSEHOLD#${householdId}`, SK: `CHAT#${conversationId}#SEQ` },
+      // SET-then-ADD is one valid UpdateExpression; ADD on a missing attribute
+      // starts from 0, so the first message gets seq 1.
+      UpdateExpression: 'SET entityType = :et, #ttl = :ttl ADD #seq :one',
+      ExpressionAttributeNames: { '#seq': 'seq', '#ttl': 'ttl' },
+      ExpressionAttributeValues: {
+        ':one': 1,
+        ':et': 'ChatSeq',
+        ':ttl': Math.floor(Date.now() / 1000) + CONVERSATION_TTL_SECONDS,
+      },
+      ReturnValues: 'UPDATED_NEW',
+    })
+  );
+  return (res.Attributes?.seq as number | undefined) ?? 0;
 }
 
 export async function appendMessage(
   householdId: string,
   message: ChatMessageRecord
 ): Promise<void> {
+  const seq = await nextConversationSeq(householdId, message.conversationId);
+  // 12 digits orders correctly past any realistic per-conversation message
+  // count. The `#SEQ` counter row's SK never matches the `#MSG#` prefix, so
+  // getConversation's begins_with query excludes it.
+  const sk = `CHAT#${message.conversationId}#MSG#${message.timestamp}#${String(seq).padStart(12, '0')}`;
   await dynamodb.send(
     new PutCommand({
       TableName: TABLE_NAME,
       Item: {
         PK: `HOUSEHOLD#${householdId}`,
-        SK: messageSortKey(message),
+        SK: sk,
         entityType: 'ChatMessage',
         ...message,
         ttl: Math.floor(Date.now() / 1000) + CONVERSATION_TTL_SECONDS,

--- a/backend/tests/unit/services/chatPersistence.test.ts
+++ b/backend/tests/unit/services/chatPersistence.test.ts
@@ -38,21 +38,38 @@ import { dynamodb } from '../../../src/utils/dynamodb.js';
 import { appendMessage, getConversation } from '../../../src/services/chat/persistence.js';
 import type { ChatMessageRecord } from '../../../src/services/chat/types.js';
 
-type CapturedPut = { input: { Item: Record<string, unknown> & { SK: string } } };
+type CapturedCmd = { kind: string; input: { Item: Record<string, unknown> & { SK: string } } };
 
-function sentItems(): CapturedPut['input']['Item'][] {
+// appendMessage now issues an atomic-counter UpdateCommand before the message
+// PutCommand, so filter to the Put (message) writes.
+function sentItems(): CapturedCmd['input']['Item'][] {
   return vi
     .mocked(dynamodb.send)
-    .mock.calls.map((c) => (c[0] as unknown as CapturedPut).input.Item);
+    .mock.calls.map((c) => c[0] as unknown as CapturedCmd)
+    .filter((cmd) => cmd.kind === 'Put')
+    .map((cmd) => cmd.input.Item);
+}
+
+// Default send mock: the conversation-seq UpdateCommand returns a monotonically
+// increasing seq; message PutCommands resolve empty.
+function mockSendWithSeq(): void {
+  let seq = 0;
+  vi.mocked(dynamodb.send).mockImplementation(
+    (cmd) =>
+      Promise.resolve(
+        (cmd as unknown as CapturedCmd).kind === 'Update' ? { Attributes: { seq: ++seq } } : {}
+      ) as never
+  );
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockSendWithSeq();
 });
 
 describe('chat message persistence', () => {
   it('writes same-millisecond messages under distinct SKs that preserve write order', async () => {
-    vi.mocked(dynamodb.send).mockResolvedValue({} as never);
+    // beforeEach feeds the conversation-seq UpdateCommand a monotonic value.
     const ts = '2026-06-11T12:00:00.000Z';
     const mk = (
       role: ChatMessageRecord['role'],
@@ -79,6 +96,39 @@ describe('chat message persistence', () => {
     for (const sk of sks) {
       expect(sk.startsWith(`CHAT#c1#MSG#${ts}#`)).toBe(true);
     }
+  });
+
+  it('draws the SK tie-breaker from an atomic per-conversation counter (cross-container safe)', async () => {
+    // The sequence comes from DynamoDB (ADD on CHAT#<conv>#SEQ), not a
+    // per-process counter, so concurrent turns from different Lambda containers
+    // on the same conversation share one globally-ordered sequence.
+    await appendMessage('hh-1', {
+      conversationId: 'c9',
+      timestamp: '2026-06-11T12:00:00.000Z',
+      role: 'user',
+      content: [{ type: 'text', text: 'hi' }],
+    });
+
+    const update = vi
+      .mocked(dynamodb.send)
+      .mock.calls.map(
+        (c) =>
+          c[0] as unknown as {
+            kind: string;
+            input: {
+              Key: { SK: string };
+              UpdateExpression: string;
+              ReturnValues: string;
+            };
+          }
+      )
+      .find((c) => c.kind === 'Update');
+    expect(update).toBeDefined();
+    expect(update!.input.Key.SK).toBe('CHAT#c9#SEQ');
+    expect(update!.input.UpdateExpression).toContain('ADD #seq :one');
+    expect(update!.input.ReturnValues).toBe('UPDATED_NEW');
+    // The message SK embeds the returned seq (1), zero-padded to 12 digits.
+    expect(sentItems()[0].SK).toBe('CHAT#c9#MSG#2026-06-11T12:00:00.000Z#000000000001');
   });
 
   it('round-trips tool_result content blocks through appendMessage → getConversation', async () => {


### PR DESCRIPTION
## #7 (LOW-MEDIUM) — chat message ordering race

Chat message sort keys broke intra-millisecond ties with a **per-process** counter (+ random suffix). Two concurrent turns on the **same conversation**, served by different Lambda containers in the same millisecond, each counted from their own independent base — so the merged SK order was effectively random at the tie-break level. That could interleave a `tool_use` and its `tool_result`, and Bedrock rejects a replayed history where a `tool_use` isn't immediately followed by its result (`ValidationException`), poisoning the conversation's next turn.

## Fix

Draw the tie-breaker from a **DynamoDB atomic counter scoped to the conversation** (`ADD` on `CHAT#<conv>#SEQ`, `ReturnValues: UPDATED_NEW`), so every message gets a globally monotonic position regardless of which container wrote it. The timestamp still leads the SK (readability + the `begins_with` prefix query); the zero-padded sequence is the authoritative tie-breaker. The `#SEQ` counter row carries the same 30-day TTL and never matches the `#MSG#` prefix, so `getConversation` excludes it.

Cost is one small `UpdateItem` per message on the chat path (already doing multi-second Bedrock calls) — negligible.

## Tests

- New case asserts the atomic-counter `UpdateCommand` (`ADD #seq`, `UPDATED_NEW`, `CHAT#<conv>#SEQ` key) and the seq-derived SK.
- The existing same-millisecond ordering test now exercises the shared sequence.
- Backend **984 pass**, typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)