### PR TITLE
fix(household): refresh token after joining so the new household claim applies

### DIFF
--- a/frontend/src/features/household/JoinHouseholdPage.tsx
+++ b/frontend/src/features/household/JoinHouseholdPage.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate, Link } from 'react-router-dom';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { useAuthStore } from '@/store/authStore';
 import { householdService } from '@/services/householdService';
+import { authService } from '@/services/authService';
 import { getErrorMessage } from '@/services/api';
 import { Button } from '@/components/Button';
 import { Card } from '@/components/Card';
@@ -30,10 +31,27 @@ export function JoinHouseholdPage() {
 
   const joinMutation = useMutation({
     mutationFn: () => householdService.joinWithInvite(inviteCode!),
-    onSuccess: (household) => {
+    onSuccess: async (household) => {
       track('household_joined');
       track('invite_accepted');
       setHousehold(household.id, 'member');
+      // joinHousehold just wrote our `custom:household_id` claim to Cognito,
+      // but the current token predates it — and requireHousehold returns a 403
+      // (not a 401), so the auth interceptor's refresh-on-401 never kicks in.
+      // Without refreshing here, the very next request (e.g. adding a plant)
+      // reaches the backend with no household context and fails with
+      // "User must belong to a household". Mirror HouseholdOnboarding's
+      // first-household flow and refresh now so the token carries the claim.
+      // Best-effort: if it fails, the interceptor still recovers on a 401.
+      const { refreshToken, setTokens } = useAuthStore.getState();
+      if (refreshToken) {
+        try {
+          const tokens = await authService.refreshToken(refreshToken);
+          setTokens(tokens.idToken, tokens.accessToken, tokens.refreshToken);
+        } catch {
+          // fall through — the interceptor's on-demand refresh catches up.
+        }
+      }
       navigate('/');
     },
     onError: (err) => {

--- a/frontend/tests/unit/features/JoinHouseholdPage.test.tsx
+++ b/frontend/tests/unit/features/JoinHouseholdPage.test.tsx
@@ -1,0 +1,94 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { JoinHouseholdPage } from '@/features/household/JoinHouseholdPage';
+import { useAuthStore } from '@/store/authStore';
+import { server } from '../../msw/server';
+
+const API = 'http://localhost:4000';
+
+function renderJoin(code: string) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[`/join/${code}`]}>
+        <Routes>
+          <Route path="/join/:inviteCode" element={<JoinHouseholdPage />} />
+          <Route path="/" element={<div>Home</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('JoinHouseholdPage', () => {
+  beforeEach(() => {
+    // Authenticated user with NO household yet, holding a token minted before
+    // the join (so it lacks the custom:household_id claim).
+    useAuthStore.setState({
+      isAuthenticated: true,
+      idToken: 'stale-id-token',
+      refreshToken: 'refresh-1',
+      user: {
+        id: 'u-briki',
+        email: 'briki@example.com',
+        householdId: null,
+        householdRole: null,
+      },
+    } as never);
+  });
+
+  it('refreshes the token after joining so the new household claim lands (the add-plant 403 fix)', async () => {
+    let refreshCalls = 0;
+    server.use(
+      http.get(`${API}/households/invites/code-1`, () =>
+        HttpResponse.json({ valid: true, household: { id: 'hh-9', name: 'The Brikis' } })
+      ),
+      http.post(`${API}/households/join/code-1`, () =>
+        HttpResponse.json({ id: 'hh-9', name: 'The Brikis' })
+      ),
+      http.post(`${API}/auth/refresh`, () => {
+        refreshCalls += 1;
+        return HttpResponse.json({
+          idToken: 'fresh-id-token',
+          accessToken: 'fresh-access',
+          refreshToken: 'refresh-2',
+        });
+      })
+    );
+
+    renderJoin('code-1');
+    await userEvent.click(await screen.findByRole('button', { name: /join household/i }));
+
+    // The fix: the token is refreshed, so the next request (e.g. POST /plants)
+    // carries the custom:household_id claim the join just wrote — instead of
+    // 403 "User must belong to a household".
+    await waitFor(() => expect(useAuthStore.getState().idToken).toBe('fresh-id-token'));
+    expect(refreshCalls).toBe(1);
+    expect(useAuthStore.getState().user?.householdId).toBe('hh-9');
+  });
+
+  it('still completes the join when the token refresh fails (best-effort)', async () => {
+    server.use(
+      http.get(`${API}/households/invites/code-2`, () =>
+        HttpResponse.json({ valid: true, household: { id: 'hh-7', name: 'Fallback House' } })
+      ),
+      http.post(`${API}/households/join/code-2`, () =>
+        HttpResponse.json({ id: 'hh-7', name: 'Fallback House' })
+      ),
+      http.post(`${API}/auth/refresh`, () =>
+        HttpResponse.json({ message: 'nope' }, { status: 401 })
+      )
+    );
+
+    renderJoin('code-2');
+    await userEvent.click(await screen.findByRole('button', { name: /join household/i }));
+
+    // Membership is recorded locally even if the refresh hiccups; the auth
+    // interceptor recovers on the next 401.
+    await waitFor(() => expect(useAuthStore.getState().user?.householdId).toBe('hh-7'));
+  });
+});


### PR DESCRIPTION
## Bug

A user who **joins** a household via an invite then immediately tries to **add a plant** gets `403 "User must belong to a household"`.

## Root cause

`joinHousehold` writes the user's `custom:household_id` claim to Cognito **server-side**, but `JoinHouseholdPage` never refreshed the local token — so the browser kept a token minted *before* the join, with no household claim. The next request reaches the backend with:
- no `custom:household_id` claim (stale token), **and**
- no `X-Household-Id` header (`activeHouseholdId` isn't set for a first/default household),

so `requireHousehold` 403s. And because it's a **403, not a 401**, the auth interceptor's refresh-on-401 never kicks in — the user stays stuck.

`HouseholdOnboarding`'s first-household branch already solves this by refreshing the token right after creating the household. The join flow simply omitted that step.

## Fix

After `setHousehold`, refresh the token (mirroring onboarding) so the very next request carries the new claim. Best-effort — if the refresh fails, the interceptor still recovers on the next 401.

```diff
 onSuccess: async (household) => {
   setHousehold(household.id, 'member');
+  const { refreshToken, setTokens } = useAuthStore.getState();
+  if (refreshToken) {
+    try {
+      const tokens = await authService.refreshToken(refreshToken);
+      setTokens(tokens.idToken, tokens.accessToken, tokens.refreshToken);
+    } catch { /* interceptor recovers on next 401 */ }
+  }
   navigate('/');
 }
```

## Tests

New `JoinHouseholdPage` suite: asserts the token is refreshed on a successful join (the fix), and that the join still completes if the refresh fails. Frontend **339 pass**, typecheck/lint/build clean.

> Frontend-only — no infra/terraform. Deploying just rebuilds + ships the SPA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)