### PR TITLE
fix(household): gate admin UI on the active household's role (multi-household bug)

### DIFF
--- a/frontend/src/features/household/HouseholdPage.tsx
+++ b/frontend/src/features/household/HouseholdPage.tsx
@@ -16,6 +16,7 @@ import { getErrorMessage } from '@/services/api';
 import clsx from 'clsx';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { useActiveHousehold } from '@/hooks/useActiveHousehold';
+import { useIsHouseholdAdmin } from '@/hooks/useActiveHouseholdRole';
 import { MemberVacation } from './MemberVacation';
 import { useVacationWindows } from './useVacationWindows';
 import { SitterLinksCard } from './SitterLinksCard';
@@ -83,7 +84,9 @@ export function HouseholdPage() {
     }
   };
 
-  const isAdmin = user?.householdRole === 'admin';
+  // Role of the ACTIVE household (not the stale Cognito-claim default role),
+  // so a multi-household user sees the correct admin controls after a switch.
+  const isAdmin = useIsHouseholdAdmin();
 
   // Vacation windows (care handoff) — one query for all member rows.
   const { data: vacationWindows } = useVacationWindows(householdId);

--- a/frontend/src/features/settings/ApiKeysSettings.tsx
+++ b/frontend/src/features/settings/ApiKeysSettings.tsx
@@ -16,8 +16,8 @@ import {
   SCOPE_LABELS,
   type ApiScope,
 } from '@/services/apiKeyService';
-import { useAuthStore } from '@/store/authStore';
 import { useActiveHouseholdId } from '@/hooks/useActiveHouseholdId';
+import { useIsHouseholdAdmin } from '@/hooks/useActiveHouseholdRole';
 import { getErrorMessage } from '@/services/api';
 
 /**
@@ -31,7 +31,8 @@ import { getErrorMessage } from '@/services/api';
  */
 export function ApiKeysSettings() {
   const { t } = useTranslation();
-  const isAdmin = useAuthStore((s) => s.user?.householdRole === 'admin');
+  // Active household's role, not the stale Cognito-claim default role.
+  const isAdmin = useIsHouseholdAdmin();
   const householdId = useActiveHouseholdId();
   const queryClient = useQueryClient();
   const [label, setLabel] = useState('');

--- a/frontend/src/features/settings/BillingSettings.tsx
+++ b/frontend/src/features/settings/BillingSettings.tsx
@@ -12,8 +12,8 @@ import {
   PlanUsage,
 } from '@/services/billingService';
 import { getErrorMessage } from '@/services/api';
-import { useAuthStore } from '@/store/authStore';
 import { useActiveHouseholdId } from '@/hooks/useActiveHouseholdId';
+import { useIsHouseholdAdmin } from '@/hooks/useActiveHouseholdRole';
 import { Card, CardHeader } from '@/components/Card';
 import { Button } from '@/components/Button';
 import { Alert } from '@/components/Alert';
@@ -23,8 +23,8 @@ import clsx from 'clsx';
 
 export function BillingSettings() {
   const { t } = useTranslation();
-  const user = useAuthStore((state) => state.user);
-  const isAdmin = user?.householdRole === 'admin';
+  // Active household's role, not the stale Cognito-claim default role.
+  const isAdmin = useIsHouseholdAdmin();
   const [searchParams] = useSearchParams();
   const [notice, setNotice] = useState<string | null>(null);
   // Default to annual: it's the better value for the user and retains far

--- a/frontend/src/hooks/useActiveHouseholdRole.ts
+++ b/frontend/src/hooks/useActiveHouseholdRole.ts
@@ -1,0 +1,38 @@
+import { useQuery } from '@tanstack/react-query';
+import { useAuthStore } from '@/store/authStore';
+import { listMyHouseholds } from '@/services/householdService';
+import { useActiveHouseholdId } from './useActiveHouseholdId';
+
+/**
+ * The caller's role IN THE ACTIVE household — the authoritative source for
+ * admin gating.
+ *
+ * `user.householdRole` is ONLY the Cognito-claim DEFAULT household's role, so
+ * after switching to another household (where the user may be a plain member)
+ * it is wrong: admin-only controls would render for a non-admin and the
+ * resulting mutation 403s (a 403 the auth interceptor can't recover from), or
+ * an actual admin of a non-default household loses their controls. The backend
+ * resolves role from the membership row of the active household; the per-
+ * household roles the client has live in the `/me/households` list.
+ *
+ * Falls back to the claim role while that list loads (correct for the default
+ * household and avoids an admin-UI flicker); the list is staleTime-cached and
+ * loaded app-wide by the HouseholdSwitcher.
+ */
+export function useActiveHouseholdRole(): 'admin' | 'member' | null {
+  const activeId = useActiveHouseholdId();
+  const claimRole = useAuthStore((s) => s.user?.householdRole ?? null);
+  const enabled = useAuthStore((s) => !!s.user);
+  const { data: memberships } = useQuery({
+    queryKey: ['me', 'households'],
+    queryFn: listMyHouseholds,
+    enabled,
+    staleTime: 60_000,
+  });
+  return memberships?.find((m) => m.householdId === activeId)?.role ?? claimRole;
+}
+
+/** True iff the caller is an admin of the ACTIVE household. */
+export function useIsHouseholdAdmin(): boolean {
+  return useActiveHouseholdRole() === 'admin';
+}

--- a/frontend/tests/unit/hooks/useActiveHouseholdRole.test.tsx
+++ b/frontend/tests/unit/hooks/useActiveHouseholdRole.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { ReactNode } from 'react';
+import { http, HttpResponse } from 'msw';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useIsHouseholdAdmin } from '@/hooks/useActiveHouseholdRole';
+import { useAuthStore } from '@/store/authStore';
+import { server } from '../../msw/server';
+
+const API = 'http://localhost:4000';
+
+function makeWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
+}
+
+describe('useIsHouseholdAdmin', () => {
+  beforeEach(() => {
+    // Claim DEFAULT household role is 'admin'; the user is a plain member of a
+    // second household.
+    useAuthStore.setState({
+      isAuthenticated: true,
+      user: { id: 'u1', email: 'a@b.com', householdId: 'hh-default', householdRole: 'admin' },
+      activeHouseholdId: null,
+    } as never);
+    server.use(
+      http.get(`${API}/me/households`, () =>
+        HttpResponse.json([
+          { householdId: 'hh-default', name: 'Default', role: 'admin' },
+          { householdId: 'hh-other', name: 'Other', role: 'member' },
+        ])
+      )
+    );
+  });
+
+  it('is true for the default household where the user is admin', async () => {
+    const { result } = renderHook(() => useIsHouseholdAdmin(), { wrapper: makeWrapper() });
+    await waitFor(() => expect(result.current).toBe(true));
+  });
+
+  it('is FALSE after switching to a household where the user is only a member (the bug)', async () => {
+    useAuthStore.setState({ activeHouseholdId: 'hh-other' } as never);
+    const { result } = renderHook(() => useIsHouseholdAdmin(), { wrapper: makeWrapper() });
+    // The claim default role is 'admin', but the ACTIVE household role is
+    // 'member' — admin controls must NOT render (else the mutation 403s).
+    await waitFor(() => expect(result.current).toBe(false));
+  });
+});


### PR DESCRIPTION
## Bug (audit HIGH #1)

`isAdmin` was `user.householdRole === 'admin'`, but `user.householdRole` is only the **Cognito-claim DEFAULT** household's role. For a multi-household user, after switching households the role is stale:
- a plain **member** of the active household sees admin-only controls (invite, remove member, change role, sitter links, location, "manage subscription", API keys) → clicking one **403s** (a 403 the auth interceptor can't recover from);
- an actual **admin** of a non-default household loses those controls.

## Fix

New `useActiveHouseholdRole` / `useIsHouseholdAdmin` hooks resolve the caller's role **in the active household** from the authoritative `/me/households` list (the same membership the backend authorizes against), falling back to the claim role only while that list loads. `HouseholdPage`, `BillingSettings`, and `ApiKeysSettings` now use it — uniform gating that follows the active household and survives rehydrate (a persisted `activeHouseholdId` no longer desyncs from the claim role).

## Test

`useIsHouseholdAdmin` is `true` for the default (admin) household and **`false`** after switching to a member-role household. Frontend **341 tests** + build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)