### PR TITLE
fix(frontend): dashboard plant refresh, surfaced errors, upload cancellation

### DIFF
--- a/frontend/src/features/dashboard/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/DashboardPage.tsx
@@ -116,6 +116,10 @@ export function DashboardPage() {
     mutationFn: (taskId: string) => taskService.completeTask(taskId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['tasks', householdId] });
+      // Completing a task advances the plant's care state; refresh plants too
+      // (TasksPage already invalidates both) so the dashboard plant grid and
+      // each plant card's derived care status don't go stale.
+      queryClient.invalidateQueries({ queryKey: ['plants', householdId] });
       toast.success('Task completed');
     },
     onError: (err) => toast.error(getErrorMessage(err)),

--- a/frontend/src/features/household/MemberVacation.tsx
+++ b/frontend/src/features/household/MemberVacation.tsx
@@ -69,6 +69,10 @@ export function MemberVacation({
       invalidate();
       setFormOpen(false);
     },
+    // Without this a rejected setVacation (e.g. endDate before startDate, or a
+    // non-admin setting cover for someone else → 403) failed silently: the form
+    // just stayed open with no feedback. Mirror cancelMutation's toast.
+    onError: (err) => toast.error(getErrorMessage(err)),
   });
 
   const cancelMutation = useMutation({

--- a/frontend/src/features/plants/PlantImageUpload.tsx
+++ b/frontend/src/features/plants/PlantImageUpload.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { plantService } from '@/services/plantService';
 import { getErrorMessage } from '@/services/api';
@@ -19,9 +19,18 @@ export function PlantImageUpload({ plantId }: PlantImageUploadProps) {
   const householdId = useActiveHouseholdId();
   const [error, setError] = useState<string | null>(null);
   const [progress, setProgress] = useState(0);
+  // Cancels an in-flight upload when the component unmounts (navigating away
+  // mid-upload) so the PUT is aborted and the confirm step never fires for an
+  // abandoned upload.
+  const abortRef = useRef<AbortController | null>(null);
+  useEffect(() => () => abortRef.current?.abort(), []);
 
   const upload = useMutation({
     mutationFn: async (file: File) => {
+      abortRef.current?.abort(); // cancel any prior in-flight upload
+      const controller = new AbortController();
+      abortRef.current = controller;
+      const { signal } = controller;
       // Downscale client-side (max 1600px long edge, WebP ~0.8 with JPEG
       // fallback). If the canvas pipeline fails we degrade gracefully and
       // upload the original — the 5 MiB guard below applies to whichever
@@ -36,7 +45,9 @@ export function PlantImageUpload({ plantId }: PlantImageUploadProps) {
       // must use the exact same Content-Type header (backend contract).
       const contentType = blob.type || file.type;
       const { uploadUrl, imageUrl } = await plantService.getImageUploadUrl(plantId, contentType);
-      await plantService.uploadImage(uploadUrl, blob, contentType, setProgress);
+      await plantService.uploadImage(uploadUrl, blob, contentType, setProgress, signal);
+      // Don't confirm an upload the user already navigated away from.
+      if (signal.aborted) throw new DOMException('Upload aborted', 'AbortError');
       await plantService.confirmImageUpload(plantId, imageUrl);
       return imageUrl;
     },
@@ -46,6 +57,9 @@ export function PlantImageUpload({ plantId }: PlantImageUploadProps) {
       setProgress(0);
     },
     onError: (err) => {
+      // A cancelled upload (unmount, or a newer upload superseding this one)
+      // isn't a failure to surface.
+      if (err instanceof DOMException && err.name === 'AbortError') return;
       setError(getErrorMessage(err));
       setProgress(0);
     },

--- a/frontend/src/features/settings/ApiKeysSettings.tsx
+++ b/frontend/src/features/settings/ApiKeysSettings.tsx
@@ -75,6 +75,10 @@ export function ApiKeysSettings() {
       queryClient.invalidateQueries({ queryKey: ['api-keys', householdId] });
       setRevokeId(null);
     },
+    // Without this a failed revoke (500/network) left the dialog open with only
+    // a cleared spinner and no message — the key stayed listed and the user
+    // assumed it worked. Close the dialog and surface the error below.
+    onError: () => setRevokeId(null),
   });
 
   const handleCopy = async () => {
@@ -187,6 +191,11 @@ export function ApiKeysSettings() {
             description="Revoking is immediate — clients using the key will start getting 401 on the next request."
           />
         </div>
+        {revokeMutation.isError && (
+          <Alert variant="error" className="mx-6 mt-4">
+            {getErrorMessage(revokeMutation.error)}
+          </Alert>
+        )}
         {!keysQuery.data || keysQuery.data.length === 0 ? (
           <p className="p-6 text-sm text-gray-600">No keys yet.</p>
         ) : (

--- a/frontend/src/services/plantService.ts
+++ b/frontend/src/services/plantService.ts
@@ -220,12 +220,17 @@ export const plantService = {
     uploadUrl: string,
     blob: Blob,
     contentType: string,
-    onProgress?: (fraction: number) => void
+    onProgress?: (fraction: number) => void,
+    signal?: AbortSignal
   ): Promise<void> {
     // We use XMLHttpRequest rather than fetch because fetch lacks built-in
     // upload-progress events; if the user is uploading a multi-megabyte image
     // over a slow connection we want to show a progress bar.
     await new Promise<void>((resolve, reject) => {
+      if (signal?.aborted) {
+        reject(new DOMException('Upload aborted', 'AbortError'));
+        return;
+      }
       const xhr = new XMLHttpRequest();
       xhr.open('PUT', uploadUrl);
       // Must match the contentType the presign request was made with.
@@ -240,6 +245,10 @@ export const plantService = {
         else reject(new Error(`Upload failed with status ${xhr.status}`));
       };
       xhr.onerror = () => reject(new Error('Network error during upload'));
+      // Abort the in-flight PUT when the caller cancels (e.g. unmount) so an
+      // abandoned upload doesn't run to completion and confirm server-side.
+      xhr.onabort = () => reject(new DOMException('Upload aborted', 'AbortError'));
+      signal?.addEventListener('abort', () => xhr.abort(), { once: true });
       xhr.send(blob);
     });
   },


### PR DESCRIPTION
Frontend UX/correctness batch from the audit: **#7** dashboard task-complete now invalidates `['plants',hh]` too (was stale); **#12** `setVacation` + API-key **revoke** now surface errors (were silent); **#14** `PlantImageUpload` aborts the in-flight PUT on unmount and skips confirm for an abandoned upload. **#13** left as-is (intended seed-silently design; the upcoming feed already includes all overdue tasks). typecheck/lint/339 tests/build pass.