### PR TITLE
fix(auth): confirm-email routes to sign-in, preserves invite redirect

### DIFF
--- a/frontend/src/features/auth/ConfirmEmailPage.tsx
+++ b/frontend/src/features/auth/ConfirmEmailPage.tsx
@@ -3,7 +3,6 @@ import { useNavigate, useLocation, Link } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
-import { useAuthStore } from '@/store/authStore';
 import { authService } from '@/services/authService';
 import { track } from '@/services/analytics';
 import { getErrorMessage } from '@/services/api';
@@ -23,13 +22,12 @@ export function ConfirmEmailPage() {
   useDocumentTitle('Confirm email');
   const navigate = useNavigate();
   const location = useLocation();
-  const { setUser, setTokens } = useAuthStore();
   const [error, setError] = useState<string | null>(null);
   const [info, setInfo] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [isResending, setIsResending] = useState(false);
 
-  const email = (location.state as { email?: string })?.email;
+  const { email, redirect } = (location.state as { email?: string; redirect?: string }) ?? {};
 
   const {
     register,
@@ -64,14 +62,19 @@ export function ConfirmEmailPage() {
     setIsLoading(true);
 
     try {
-      const response = await authService.confirmEmail({
-        email,
-        code: data.code,
-      });
-      setTokens(response.idToken, response.accessToken, response.refreshToken);
-      setUser(response.user);
+      // Cognito's confirmSignUp returns no tokens — the user must sign in
+      // afterward. (The old code read undefined tokens off this response and
+      // wrote a half-authenticated session, then bounced off /onboarding's
+      // ProtectedRoute back to /login anyway.) Send them to /login with their
+      // email prefilled, carrying any post-auth redirect (e.g. /join/CODE) so
+      // an invite-accept flow resumes after they sign in.
+      await authService.confirmEmail({ email, code: data.code });
       track('signup_completed');
-      navigate('/onboarding');
+      const safeRedirect =
+        redirect?.startsWith('/') && !redirect.startsWith('//') ? redirect : null;
+      navigate(safeRedirect ? `/login?redirect=${encodeURIComponent(safeRedirect)}` : '/login', {
+        state: { email, justConfirmed: true },
+      });
     } catch (err) {
       setError(getErrorMessage(err));
     } finally {

--- a/frontend/src/features/auth/LoginPage.tsx
+++ b/frontend/src/features/auth/LoginPage.tsx
@@ -47,12 +47,18 @@ export function LoginPage() {
     '/dashboard';
   const loginSchema = useMemo(() => makeLoginSchema(t), [t]);
 
+  // After email confirmation the confirm page sends the user here with their
+  // email + a justConfirmed flag (Cognito confirmSignUp issues no tokens, so a
+  // sign-in is required). Prefill the email and show a success notice.
+  const confirmState = location.state as { email?: string; justConfirmed?: boolean } | null;
+
   const {
     register,
     handleSubmit,
     formState: { errors },
   } = useForm<LoginFormData>({
     resolver: zodResolver(loginSchema),
+    defaultValues: { email: confirmState?.email ?? '' },
   });
 
   const onSubmit = async (data: LoginFormData) => {
@@ -87,6 +93,11 @@ export function LoginPage() {
       {error && (
         <Alert variant="error" className="mb-6">
           {error}
+        </Alert>
+      )}
+      {confirmState?.justConfirmed && !error && (
+        <Alert variant="success" className="mb-6">
+          Email confirmed — sign in to finish setting up your greenhouse.
         </Alert>
       )}
 

--- a/frontend/src/features/auth/RegisterPage.tsx
+++ b/frontend/src/features/auth/RegisterPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -33,6 +33,10 @@ type RegisterFormData = z.infer<typeof registerSchema>;
 export function RegisterPage() {
   useDocumentTitle('Sign up');
   const navigate = useNavigate();
+  // Preserve a post-auth redirect (e.g. /join/CODE from a shared invite) across
+  // register → confirm → login so an invite-accept flow resumes after signup.
+  const [searchParams] = useSearchParams();
+  const redirect = searchParams.get('redirect');
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -54,7 +58,7 @@ export function RegisterPage() {
         email: data.email,
         password: data.password,
       });
-      navigate('/confirm-email', { state: { email: data.email } });
+      navigate('/confirm-email', { state: { email: data.email, redirect } });
     } catch (err) {
       setError(getErrorMessage(err));
     } finally {

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -49,8 +49,11 @@ export const authService = {
     return response.data;
   },
 
-  async confirmEmail(data: ConfirmEmailData): Promise<AuthResponse> {
-    const response = await api.post<AuthResponse>('/auth/confirm', data);
+  // Cognito's confirmSignUp mints no tokens — POST /auth/confirm returns only a
+  // message. The user signs in afterward (the old AuthResponse typing led the
+  // confirm page to read undefined tokens and log itself out).
+  async confirmEmail(data: ConfirmEmailData): Promise<{ message: string }> {
+    const response = await api.post<{ message: string }>('/auth/confirm', data);
     return response.data;
   },
 

--- a/frontend/tests/e2e/register-flow.spec.ts
+++ b/frontend/tests/e2e/register-flow.spec.ts
@@ -11,7 +11,7 @@ import { test, expect } from '@playwright/test';
  * re-runs against a sticky local server.
  */
 test.describe('Register flow', () => {
-  test('register → confirm with correct code → land on onboarding/dashboard', async ({ page }) => {
+  test('register → confirm → sign in → land on onboarding', async ({ page }) => {
     const consoleErrors: string[] = [];
     page.on('pageerror', (err) => consoleErrors.push(String(err)));
     page.on('console', (msg) => {
@@ -40,7 +40,17 @@ test.describe('Register flow', () => {
     await page.getByLabel(/confirmation code/i).fill('123456');
     await page.getByRole('button', { name: /confirm email/i }).click();
 
-    // New users without a household are kicked into the onboarding wizard.
+    // Cognito's confirmSignUp mints NO tokens, so confirmation routes to the
+    // sign-in page — email prefilled, with a "confirmed" notice — rather than
+    // writing a half-authenticated session and bouncing off a guarded route.
+    await expect(page).toHaveURL(/\/login/);
+    await expect(page.getByText(/email confirmed/i)).toBeVisible();
+    await expect(page.getByLabel(/email address/i)).toHaveValue(email);
+
+    // Sign in to finish: a household-less new user is then routed into the
+    // onboarding wizard (App.tsx redirects when hasHousehold is false).
+    await page.getByLabel(/password/i).fill('Password123');
+    await page.getByRole('button', { name: /sign in/i }).click();
     await expect(page).toHaveURL(/\/onboarding/);
     expect(consoleErrors).toEqual([]);
   });

--- a/frontend/tests/unit/features/ConfirmEmailPage.test.tsx
+++ b/frontend/tests/unit/features/ConfirmEmailPage.test.tsx
@@ -2,19 +2,35 @@ import { describe, expect, it } from 'vitest';
 import { http, HttpResponse } from 'msw';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useLocation, useSearchParams } from 'react-router-dom';
 import { ConfirmEmailPage } from '@/features/auth/ConfirmEmailPage';
 import { server } from '../../msw/server';
 
 const API = 'http://localhost:4000';
 
-function renderPage(state?: { email?: string }) {
+/** Stand-in for the real LoginPage that surfaces the redirect query + the
+ *  justConfirmed/email handoff state, so tests can assert the confirm→login
+ *  routing carries them. */
+function LoginLanding() {
+  const [params] = useSearchParams();
+  const state = useLocation().state as { justConfirmed?: boolean; email?: string } | null;
+  return (
+    <div>
+      Login Page
+      <span>redirect:{params.get('redirect') ?? 'none'}</span>
+      {state?.justConfirmed && <span>confirmed:{state.email}</span>}
+    </div>
+  );
+}
+
+function renderPage(state?: { email?: string; redirect?: string }) {
   return render(
     <MemoryRouter initialEntries={[{ pathname: '/confirm-email', state: state ?? null }]}>
       <Routes>
         <Route path="/confirm-email" element={<ConfirmEmailPage />} />
         <Route path="/onboarding" element={<div>Onboarding Page</div>} />
         <Route path="/register" element={<div>Register Page</div>} />
+        <Route path="/login" element={<LoginLanding />} />
       </Routes>
     </MemoryRouter>
   );
@@ -39,6 +55,27 @@ describe('ConfirmEmailPage', () => {
     await user.click(screen.getByRole('button', { name: /resend code/i }));
     expect(await screen.findByText('Code resent')).toBeInTheDocument();
     expect(received).toEqual({ email: 'a@b.com' });
+  });
+
+  it('confirms then routes to login (no token reading), preserving the invite redirect', async () => {
+    let body: unknown;
+    server.use(
+      http.post(`${API}/auth/confirm`, async ({ request }) => {
+        body = await request.json();
+        // confirmSignUp returns only a message — NO tokens.
+        return HttpResponse.json({ message: 'Email confirmed' });
+      })
+    );
+    renderPage({ email: 'a@b.com', redirect: '/join/code-1' });
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText(/confirmation code/i), '123456');
+    await user.click(screen.getByRole('button', { name: /confirm email/i }));
+
+    // Lands on /login (not /onboarding), carrying the redirect + email handoff.
+    expect(await screen.findByText('Login Page')).toBeInTheDocument();
+    expect(screen.getByText('redirect:/join/code-1')).toBeInTheDocument();
+    expect(screen.getByText('confirmed:a@b.com')).toBeInTheDocument();
+    expect(body).toEqual({ email: 'a@b.com', code: '123456' });
   });
 
   it('shows an error alert if resend fails', async () => {


### PR DESCRIPTION
## Bug (audit #5 + #8)

**#5** — `ConfirmEmailPage` read `response.idToken/accessToken/refreshToken/user` off `POST /auth/confirm`, but Cognito's `confirmSignUp` issues **no tokens** — the handler returns only `{ message }`. So `setTokens(undefined,…)` + `setUser(undefined)` wrote a broken half-session and `navigate('/onboarding')` bounced off the ProtectedRoute back to `/login` — a confusing dead-end right after signup.

**#8** — the signup funnel dropped `?redirect=`: registering from a shared invite (`/register?redirect=/join/CODE`) lost the invite, so after confirming you landed on the dashboard instead of accepting the invite.

## Fix

- Confirm now just confirms, then routes to `/login` with the email **prefilled** and an "email confirmed — sign in" notice. `authService.confirmEmail` retyped to `{ message }` so the nonexistent tokens can't be read again.
- The redirect threads `register → confirm → /login?redirect=…` (LoginPage already forwards `?redirect=` post-login), so accepting an invite resumes after sign-in. Open-redirect guarded (same-origin app paths only).

**Not included — #16** (rehydration admits an idToken-without-refreshToken session): that's the *normal* restored-session state (refresh tokens live in sessionStorage by design, idToken in localStorage), so rejecting it up front would log out every restored tab — strictly worse. No safe change without persisting refresh tokens to localStorage, which is a deliberate security tradeoff. Left as-is.

## Test

Confirming routes to `/login` (not `/onboarding`) carrying the redirect + email, and POSTs only `{ email, code }`. Frontend: lint, **340 tests**, build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)