### PR TITLE
fix(chat): bill partial usage, atomic tool-pair persistence, abort abandoned streams

### DIFF
--- a/backend/src/services/chat/index.ts
+++ b/backend/src/services/chat/index.ts
@@ -26,6 +26,7 @@ import {
 } from './tools.js';
 import {
   appendMessage,
+  appendMessagePair,
   getBudget,
   getConversation,
   incrementBudget,
@@ -248,165 +249,178 @@ async function* turnEvents(
   // propose_reminder_task calls (e.g. "set up watering + fertilizing").
   const proposals: ProposedReminderTask[] = [];
 
-  for (let iter = 0; iter < MAX_TOOL_CALLS_PER_TURN + 1; iter++) {
-    const modelArgs = {
-      system: SYSTEM_PROMPT,
-      messages: messagesForModel,
-      tools: TOOL_REGISTRY,
-      maxOutputTokens: MAX_OUTPUT_TOKENS_PER_CALL,
-    };
+  try {
+    for (let iter = 0; iter < MAX_TOOL_CALLS_PER_TURN + 1; iter++) {
+      const modelArgs = {
+        system: SYSTEM_PROMPT,
+        messages: messagesForModel,
+        tools: TOOL_REGISTRY,
+        maxOutputTokens: MAX_OUTPUT_TOKENS_PER_CALL,
+      };
 
-    let response: BedrockChatResponse;
-    if (opts.streaming) {
-      // Manual iteration: `for await` would discard the generator's return
-      // value (the assembled response). Forward each text delta as it lands.
-      const stream = invokeChatModelStream(modelArgs);
-      let sawText = false;
-      for (;;) {
-        const next = await stream.next();
-        if (next.done) {
-          response = next.value;
-          break;
-        }
-        sawText = true;
-        yield { type: 'delta', text: next.value.text };
-      }
-      // A tool-use turn often opens with text ("Let me check your
-      // plants…"). Separate it from the next iteration's text so the
-      // streamed transcript stays readable. Transport-only.
-      if (sawText && response.stopReason === 'tool_use') {
-        yield { type: 'delta', text: '\n\n' };
-      }
-    } else {
-      response = await invokeChatModel(modelArgs);
-    }
-
-    totalInputTokens += response.inputTokens;
-    totalOutputTokens += response.outputTokens;
-    totalCost += response.costUsd;
-
-    // Persist this assistant turn (which may include tool_use blocks).
-    const assistantRecord: ChatMessageRecord = {
-      conversationId,
-      timestamp: new Date().toISOString(),
-      role: 'assistant',
-      content: response.content,
-      inputTokens: response.inputTokens,
-      outputTokens: response.outputTokens,
-      costUsd: response.costUsd,
-    };
-    await appendMessage(householdId, assistantRecord);
-
-    if (response.stopReason !== 'tool_use') {
-      finalAssistantBlocks = response.content;
-      break;
-    }
-
-    // Run every tool_use block in this turn, gather results, append a
-    // single user-role tool_result turn.
-    const toolUses = response.content.filter((b): b is ToolUseBlock => b.type === 'tool_use');
-    const resultsContent: ContentBlock[] = [];
-    for (const use of toolUses) {
-      toolCallCount += 1;
-      if (toolCallCount > MAX_TOOL_CALLS_PER_TURN) {
-        resultsContent.push({
-          type: 'tool_result',
-          tool_use_id: use.id,
-          content: 'Tool call cap exceeded for this turn. Answer with what you have so far.',
-          is_error: true,
-        });
-        continue;
-      }
-      const tool = findTool(use.name);
-      if (!tool) {
-        resultsContent.push({
-          type: 'tool_result',
-          tool_use_id: use.id,
-          content: `Unknown tool: ${use.name}`,
-          is_error: true,
-        });
-        continue;
-      }
-      yield { type: 'tool_start', name: use.name };
-      try {
-        // Deliberate `as never` dispatch cast — Claude's JSON-schema validation
-        // is the source of truth for each tool's input shape (see tools.ts).
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-        const out = await tool.execute(use.input as never, {
-          userId,
-          householdId,
-          toolCallNumber: toolCallCount,
-          // Lets propose_reminder_task enforce its own per-turn cap.
-          proposalsThisTurn: proposals.length,
-        });
-        // For propose_reminder_task: the executor returns
-        // { status: 'proposed', proposal: {...} } when the proposal passed
-        // validation. Pull the proposal out of the loop and into the API
-        // response so the UI can render a confirm card. Note we use the
-        // validated server-side proposal (with plantName/assigneeName
-        // looked up and a server-assigned proposalId), not the raw tool
-        // input, so a hallucinated plantId/assignee is rejected here.
-        if (use.name === 'propose_reminder_task') {
-          const result = out as ProposeReminderResult;
-          if (result.status === 'proposed' && result.proposal) {
-            proposals.push(result.proposal);
-            yield { type: 'proposal', proposal: result.proposal };
+      let response: BedrockChatResponse;
+      if (opts.streaming) {
+        // Manual iteration: `for await` would discard the generator's return
+        // value (the assembled response). Forward each text delta as it lands.
+        const stream = invokeChatModelStream(modelArgs);
+        let sawText = false;
+        for (;;) {
+          const next = await stream.next();
+          if (next.done) {
+            response = next.value;
+            break;
           }
+          sawText = true;
+          yield { type: 'delta', text: next.value.text };
         }
-        resultsContent.push({
-          type: 'tool_result',
-          tool_use_id: use.id,
-          content: JSON.stringify(out),
-        });
-      } catch (err) {
-        logger.warn({ err, toolName: use.name }, 'chat_tool_error');
-        resultsContent.push({
-          type: 'tool_result',
-          tool_use_id: use.id,
-          content: `Tool ${use.name} failed: ${(err as Error).message}`,
-          is_error: true,
-        });
+        // A tool-use turn often opens with text ("Let me check your
+        // plants…"). Separate it from the next iteration's text so the
+        // streamed transcript stays readable. Transport-only.
+        if (sawText && response.stopReason === 'tool_use') {
+          yield { type: 'delta', text: '\n\n' };
+        }
+      } else {
+        response = await invokeChatModel(modelArgs);
       }
-    }
-    audit('chat.tools_called', {
-      actorId: userId,
-      householdId,
-      metadata: {
-        tools: toolUses.map((u) => u.name),
+
+      totalInputTokens += response.inputTokens;
+      totalOutputTokens += response.outputTokens;
+      totalCost += response.costUsd;
+
+      // Build this assistant turn (which may include tool_use blocks). A
+      // tool_use turn is persisted TOGETHER with its tool_result turn below
+      // (appendMessagePair) so the two can never be half-written; a final turn
+      // has no partner and is persisted on its own.
+      const assistantRecord: ChatMessageRecord = {
         conversationId,
-      },
-    });
+        timestamp: new Date().toISOString(),
+        role: 'assistant',
+        content: response.content,
+        inputTokens: response.inputTokens,
+        outputTokens: response.outputTokens,
+        costUsd: response.costUsd,
+      };
 
-    // Persist the tool_result turn alongside the assistant tool_use turn.
-    // The next user turn rebuilds history from DDB; replaying an assistant
-    // tool_use with no matching tool_result is a Bedrock ValidationException,
-    // which would hard-fail every conversation right after a tool turn.
-    // Content blocks are stored as-is (DocumentClient marshals the nested
-    // maps/lists), so getConversation round-trips them verbatim.
-    const toolResultRecord: ChatMessageRecord = {
-      conversationId,
-      timestamp: new Date().toISOString(),
-      role: 'user',
-      content: resultsContent,
-    };
-    await appendMessage(householdId, toolResultRecord);
+      if (response.stopReason !== 'tool_use') {
+        await appendMessage(householdId, assistantRecord);
+        finalAssistantBlocks = response.content;
+        break;
+      }
 
-    // Append the assistant turn + tool_result turn to the next iteration's
-    // message list. Don't re-fetch DDB; we already have authoritative state
-    // in memory.
-    messagesForModel = [
-      ...messagesForModel,
-      { role: 'assistant', content: response.content },
-      { role: 'user', content: resultsContent },
-    ];
+      // Run every tool_use block in this turn, gather results, append a
+      // single user-role tool_result turn.
+      const toolUses = response.content.filter((b): b is ToolUseBlock => b.type === 'tool_use');
+      const resultsContent: ContentBlock[] = [];
+      for (const use of toolUses) {
+        toolCallCount += 1;
+        if (toolCallCount > MAX_TOOL_CALLS_PER_TURN) {
+          resultsContent.push({
+            type: 'tool_result',
+            tool_use_id: use.id,
+            content: 'Tool call cap exceeded for this turn. Answer with what you have so far.',
+            is_error: true,
+          });
+          continue;
+        }
+        const tool = findTool(use.name);
+        if (!tool) {
+          resultsContent.push({
+            type: 'tool_result',
+            tool_use_id: use.id,
+            content: `Unknown tool: ${use.name}`,
+            is_error: true,
+          });
+          continue;
+        }
+        yield { type: 'tool_start', name: use.name };
+        try {
+          // Deliberate `as never` dispatch cast — Claude's JSON-schema validation
+          // is the source of truth for each tool's input shape (see tools.ts).
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+          const out = await tool.execute(use.input as never, {
+            userId,
+            householdId,
+            toolCallNumber: toolCallCount,
+            // Lets propose_reminder_task enforce its own per-turn cap.
+            proposalsThisTurn: proposals.length,
+          });
+          // For propose_reminder_task: the executor returns
+          // { status: 'proposed', proposal: {...} } when the proposal passed
+          // validation. Pull the proposal out of the loop and into the API
+          // response so the UI can render a confirm card. Note we use the
+          // validated server-side proposal (with plantName/assigneeName
+          // looked up and a server-assigned proposalId), not the raw tool
+          // input, so a hallucinated plantId/assignee is rejected here.
+          if (use.name === 'propose_reminder_task') {
+            const result = out as ProposeReminderResult;
+            if (result.status === 'proposed' && result.proposal) {
+              proposals.push(result.proposal);
+              yield { type: 'proposal', proposal: result.proposal };
+            }
+          }
+          resultsContent.push({
+            type: 'tool_result',
+            tool_use_id: use.id,
+            content: JSON.stringify(out),
+          });
+        } catch (err) {
+          logger.warn({ err, toolName: use.name }, 'chat_tool_error');
+          resultsContent.push({
+            type: 'tool_result',
+            tool_use_id: use.id,
+            content: `Tool ${use.name} failed: ${(err as Error).message}`,
+            is_error: true,
+          });
+        }
+      }
+      audit('chat.tools_called', {
+        actorId: userId,
+        householdId,
+        metadata: {
+          tools: toolUses.map((u) => u.name),
+          conversationId,
+        },
+      });
+
+      // Persist the assistant tool_use turn and its tool_result turn ATOMICALLY.
+      // The next user turn rebuilds history from DDB; replaying an assistant
+      // tool_use with no matching tool_result is a Bedrock ValidationException,
+      // which would hard-fail every conversation right after a tool turn. Writing
+      // both in one transaction means a partial failure leaves neither (the turn
+      // is simply retried) instead of a permanently-broken orphan. Content blocks
+      // are stored as-is (DocumentClient marshals the nested maps/lists), so
+      // getConversation round-trips them verbatim.
+      const toolResultRecord: ChatMessageRecord = {
+        conversationId,
+        timestamp: new Date().toISOString(),
+        role: 'user',
+        content: resultsContent,
+      };
+      await appendMessagePair(householdId, assistantRecord, toolResultRecord);
+
+      // Append the assistant turn + tool_result turn to the next iteration's
+      // message list. Don't re-fetch DDB; we already have authoritative state
+      // in memory.
+      messagesForModel = [
+        ...messagesForModel,
+        { role: 'assistant', content: response.content },
+        { role: 'user', content: resultsContent },
+      ];
+    }
+  } finally {
+    // Commit token usage even if a mid-turn Bedrock call threw: partial usage
+    // (e.g. a 2nd tool-loop call that fails after the 1st already cost tokens)
+    // must still be billed, or the failed turn is effectively free and the
+    // monthly budget never converges. Skip a zero write — the over-budget gate
+    // can throw before any Bedrock call, and a turn can fail on its first call.
+    if (totalInputTokens > 0 || totalOutputTokens > 0) {
+      await incrementBudget(householdId, {
+        inputTokens: totalInputTokens,
+        outputTokens: totalOutputTokens,
+        costUsd: totalCost,
+      });
+    }
   }
-
-  // Update budget atomically once per turn.
-  await incrementBudget(householdId, {
-    inputTokens: totalInputTokens,
-    outputTokens: totalOutputTokens,
-    costUsd: totalCost,
-  });
 
   audit('chat.message_sent', {
     actorId: userId,

--- a/backend/src/services/chat/persistence.ts
+++ b/backend/src/services/chat/persistence.ts
@@ -12,7 +12,13 @@
  * unbounded).
  */
 import { v4 as uuid } from 'uuid';
-import { GetCommand, PutCommand, QueryCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
+import {
+  GetCommand,
+  PutCommand,
+  QueryCommand,
+  TransactWriteCommand,
+  UpdateCommand,
+} from '@aws-sdk/lib-dynamodb';
 import { dynamodb, TABLE_NAME } from '../../utils/dynamodb.js';
 import type { BudgetConfig, BudgetState, ChatMessageRecord } from './types.js';
 
@@ -64,25 +70,55 @@ async function nextConversationSeq(householdId: string, conversationId: string):
   return (res.Attributes?.seq as number | undefined) ?? 0;
 }
 
+/** DynamoDB item for a chat message at sequence `seq`. */
+function messageItem(householdId: string, message: ChatMessageRecord, seq: number) {
+  // 12 digits orders correctly past any realistic per-conversation message
+  // count. The `#SEQ` counter row's SK never matches the `#MSG#` prefix, so
+  // getConversation's begins_with query excludes it.
+  const sk = `CHAT#${message.conversationId}#MSG#${message.timestamp}#${String(seq).padStart(12, '0')}`;
+  return {
+    PK: `HOUSEHOLD#${householdId}`,
+    SK: sk,
+    entityType: 'ChatMessage',
+    ...message,
+    ttl: Math.floor(Date.now() / 1000) + CONVERSATION_TTL_SECONDS,
+  };
+}
+
 export async function appendMessage(
   householdId: string,
   message: ChatMessageRecord
 ): Promise<void> {
   const seq = await nextConversationSeq(householdId, message.conversationId);
-  // 12 digits orders correctly past any realistic per-conversation message
-  // count. The `#SEQ` counter row's SK never matches the `#MSG#` prefix, so
-  // getConversation's begins_with query excludes it.
-  const sk = `CHAT#${message.conversationId}#MSG#${message.timestamp}#${String(seq).padStart(12, '0')}`;
   await dynamodb.send(
-    new PutCommand({
-      TableName: TABLE_NAME,
-      Item: {
-        PK: `HOUSEHOLD#${householdId}`,
-        SK: sk,
-        entityType: 'ChatMessage',
-        ...message,
-        ttl: Math.floor(Date.now() / 1000) + CONVERSATION_TTL_SECONDS,
-      },
+    new PutCommand({ TableName: TABLE_NAME, Item: messageItem(householdId, message, seq) })
+  );
+}
+
+/**
+ * Append two messages ATOMICALLY (one TransactWrite).
+ *
+ * Used for an assistant tool_use turn + its answering tool_result turn: the
+ * two must land together or not at all. If they were written as two separate
+ * Puts and the second failed (process death, throttling), the conversation
+ * would hold an assistant tool_use with no matching tool_result — which
+ * Bedrock rejects with a ValidationException on EVERY subsequent replay,
+ * permanently breaking the conversation. The transaction makes that orphan
+ * impossible: a failure leaves neither row, and the user simply resends.
+ */
+export async function appendMessagePair(
+  householdId: string,
+  first: ChatMessageRecord,
+  second: ChatMessageRecord
+): Promise<void> {
+  const seq1 = await nextConversationSeq(householdId, first.conversationId);
+  const seq2 = await nextConversationSeq(householdId, second.conversationId);
+  await dynamodb.send(
+    new TransactWriteCommand({
+      TransactItems: [
+        { Put: { TableName: TABLE_NAME, Item: messageItem(householdId, first, seq1) } },
+        { Put: { TableName: TABLE_NAME, Item: messageItem(householdId, second, seq2) } },
+      ],
     })
   );
 }

--- a/backend/tests/unit/services/chatPersistence.test.ts
+++ b/backend/tests/unit/services/chatPersistence.test.ts
@@ -25,6 +25,9 @@ vi.mock('@aws-sdk/lib-dynamodb', () => ({
   UpdateCommand: vi.fn(function (input) {
     return { input, kind: 'Update' };
   }),
+  TransactWriteCommand: vi.fn(function (input) {
+    return { input, kind: 'TransactWrite' };
+  }),
 }));
 
 vi.mock('../../../src/utils/dynamodb.js', () => ({
@@ -35,7 +38,11 @@ vi.mock('../../../src/utils/dynamodb.js', () => ({
 }));
 
 import { dynamodb } from '../../../src/utils/dynamodb.js';
-import { appendMessage, getConversation } from '../../../src/services/chat/persistence.js';
+import {
+  appendMessage,
+  appendMessagePair,
+  getConversation,
+} from '../../../src/services/chat/persistence.js';
 import type { ChatMessageRecord } from '../../../src/services/chat/types.js';
 
 type CapturedCmd = { kind: string; input: { Item: Record<string, unknown> & { SK: string } } };
@@ -68,6 +75,41 @@ beforeEach(() => {
 });
 
 describe('chat message persistence', () => {
+  it('appendMessagePair writes both turns in ONE TransactWrite with ordered seqs', async () => {
+    const ts = '2026-06-11T12:00:00.000Z';
+    await appendMessagePair(
+      'hh-1',
+      {
+        conversationId: 'c1',
+        timestamp: ts,
+        role: 'assistant',
+        content: [{ type: 'tool_use', id: 'tu-1', name: 'list_household_plants', input: {} }],
+      },
+      {
+        conversationId: 'c1',
+        timestamp: ts,
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 'tu-1', content: '[]' }],
+      }
+    );
+
+    const tx = vi
+      .mocked(dynamodb.send)
+      .mock.calls.map(
+        (c) => c[0] as unknown as { kind: string; input: { TransactItems: unknown[] } }
+      )
+      .find((c) => c.kind === 'TransactWrite');
+    expect(tx).toBeDefined();
+    const items = (tx!.input.TransactItems as Array<{ Put: { Item: Record<string, string> } }>).map(
+      (t) => t.Put.Item
+    );
+    // Both writes ride the single transaction → no half-written orphan possible.
+    expect(items).toHaveLength(2);
+    expect(items.map((i) => i.role)).toEqual(['assistant', 'user']);
+    // The seq tie-breaker keeps the assistant tool_use ahead of its result.
+    expect(items[0].SK < items[1].SK).toBe(true);
+  });
+
   it('writes same-millisecond messages under distinct SKs that preserve write order', async () => {
     // beforeEach feeds the conversation-seq UpdateCommand a monotonic value.
     const ts = '2026-06-11T12:00:00.000Z';

--- a/backend/tests/unit/services/chatStreaming.test.ts
+++ b/backend/tests/unit/services/chatStreaming.test.ts
@@ -15,6 +15,7 @@ vi.mock('../../../src/services/chat/persistence.js', async () => {
     ...actual,
     newConversationId: vi.fn(() => 'conv-stream-1'),
     appendMessage: vi.fn(async () => undefined),
+    appendMessagePair: vi.fn(async () => undefined),
     getConversation: vi.fn(async () => []),
     getBudget: vi.fn(async () => ({
       householdId: 'hh-1',
@@ -38,7 +39,11 @@ import {
   type BedrockChatResponse,
   type BedrockStreamDelta,
 } from '../../../src/services/chat/bedrock.js';
-import { appendMessage, incrementBudget } from '../../../src/services/chat/persistence.js';
+import {
+  appendMessage,
+  appendMessagePair,
+  incrementBudget,
+} from '../../../src/services/chat/persistence.js';
 import * as plantService from '../../../src/services/plantService.js';
 
 beforeEach(() => {
@@ -198,10 +203,16 @@ describe('streamChatTurn', () => {
       expect(done.result.assistantText).toBe('Confirm the card to create it.');
     }
 
-    // user, assistant tool_use, user tool_result, assistant final — exactly
-    // the sync path's persistence, with budget rolled up once.
+    // Exactly the sync path's persistence: user text + final assistant via
+    // appendMessage, and the assistant tool_use + tool_result pair landed
+    // atomically via appendMessagePair, with budget rolled up once.
     const roles = vi.mocked(appendMessage).mock.calls.map((c) => c[1].role);
-    expect(roles).toEqual(['user', 'assistant', 'user', 'assistant']);
+    expect(roles).toEqual(['user', 'assistant']);
+    const pairRoles = vi
+      .mocked(appendMessagePair)
+      .mock.calls[0].slice(1)
+      .map((r) => r.role);
+    expect(pairRoles).toEqual(['assistant', 'user']);
     const [budgetHousehold, budgetDelta] = vi.mocked(incrementBudget).mock.calls[0];
     expect(budgetHousehold).toBe('hh-1');
     expect(budgetDelta.inputTokens).toBe(330);

--- a/backend/tests/unit/services/chatTurn.test.ts
+++ b/backend/tests/unit/services/chatTurn.test.ts
@@ -14,6 +14,7 @@ vi.mock('../../../src/services/chat/persistence.js', async () => {
     ...actual,
     newConversationId: vi.fn(() => 'conv-1'),
     appendMessage: vi.fn(async () => undefined),
+    appendMessagePair: vi.fn(async () => undefined),
     getConversation: vi.fn(async () => []),
     getBudget: vi.fn(async () => ({
       householdId: 'hh-1',
@@ -34,6 +35,7 @@ import { runChatTurn, trimHistory, BUDGET_CONFIG } from '../../../src/services/c
 import { invokeChatModel, type BedrockMessage } from '../../../src/services/chat/bedrock.js';
 import {
   appendMessage,
+  appendMessagePair,
   getBudget,
   getConversation,
   incrementBudget,
@@ -320,28 +322,65 @@ describe('runChatTurn', () => {
 
     await runChatTurn({ userId: 'u1', householdId: 'hh-1', message: 'list my plants' });
 
-    // user text, assistant tool_use, user tool_result, assistant final.
-    expect(vi.mocked(appendMessage)).toHaveBeenCalledTimes(4);
-    const records = vi.mocked(appendMessage).mock.calls.map((c) => c[1]);
-    expect(records.map((r) => r.role)).toEqual(['user', 'assistant', 'user', 'assistant']);
+    // The user text and the final assistant answer persist singly; the
+    // assistant tool_use turn and its tool_result turn land ATOMICALLY via
+    // appendMessagePair, so a half-write can't orphan a tool_use.
+    expect(vi.mocked(appendMessage)).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(appendMessage).mock.calls.map((c) => c[1].role)).toEqual([
+      'user',
+      'assistant',
+    ]);
 
-    const toolResultRecord = records[2];
+    expect(vi.mocked(appendMessagePair)).toHaveBeenCalledTimes(1);
+    const [, assistantToolUse, toolResultRecord] = vi.mocked(appendMessagePair).mock.calls[0];
+    expect(assistantToolUse.role).toBe('assistant');
+    expect(assistantToolUse.content[0]).toMatchObject({ type: 'tool_use', id: 'tu-1' });
+    expect(toolResultRecord.role).toBe('user');
     expect(toolResultRecord.conversationId).toBe('conv-1');
     expect(toolResultRecord.content).toHaveLength(1);
-    expect(toolResultRecord.content[0]).toMatchObject({
-      type: 'tool_result',
-      tool_use_id: 'tu-1',
-    });
-
-    // Timestamps must be non-decreasing so SK sort order replays correctly.
-    for (let i = 1; i < records.length; i++) {
-      expect(records[i].timestamp >= records[i - 1].timestamp).toBe(true);
-    }
+    expect(toolResultRecord.content[0]).toMatchObject({ type: 'tool_result', tool_use_id: 'tu-1' });
+    // The pair preserves write order (assistant before its tool_result).
+    expect(toolResultRecord.timestamp >= assistantToolUse.timestamp).toBe(true);
 
     // What we persisted is exactly what the model saw on the follow-up call.
     const secondCallMessages = vi.mocked(invokeChatModel).mock.calls[1][0].messages;
     expect(secondCallMessages.at(-1)?.content).toEqual(toolResultRecord.content);
     expectValidToolPairing(secondCallMessages);
+  });
+
+  it('commits partial token usage when a mid-turn Bedrock call fails', async () => {
+    vi.mocked(plantService.getPlants).mockResolvedValueOnce([]);
+    vi.mocked(invokeChatModel)
+      .mockResolvedValueOnce({
+        content: [{ type: 'tool_use', id: 'tu-1', name: 'list_household_plants', input: {} }],
+        stopReason: 'tool_use',
+        inputTokens: 100,
+        outputTokens: 10,
+        costUsd: 0.0003,
+      })
+      // The follow-up call (after the tool ran + cost tokens) throws.
+      .mockRejectedValueOnce(new Error('bedrock throttled'));
+
+    await expect(
+      runChatTurn({ userId: 'u1', householdId: 'hh-1', message: 'list my plants' })
+    ).rejects.toThrow('bedrock throttled');
+
+    // The first call's tokens are billed even though the turn threw — otherwise
+    // a failed turn is free and the monthly budget never converges.
+    expect(vi.mocked(incrementBudget)).toHaveBeenCalledWith('hh-1', {
+      inputTokens: 100,
+      outputTokens: 10,
+      costUsd: 0.0003,
+    });
+  });
+
+  it('does not write the budget when the turn fails before any Bedrock call', async () => {
+    vi.mocked(invokeChatModel).mockRejectedValueOnce(new Error('bedrock down'));
+    await expect(runChatTurn({ userId: 'u1', householdId: 'hh-1', message: 'hi' })).rejects.toThrow(
+      'bedrock down'
+    );
+    // No tokens consumed → no zero-write.
+    expect(vi.mocked(incrementBudget)).not.toHaveBeenCalled();
   });
 
   it('exposes propose_reminder_task with the confirm-card contract in the system prompt, and collects validated proposals', async () => {
@@ -414,9 +453,11 @@ describe('runChatTurn', () => {
     expect(typeof result.proposals[0].proposalId).toBe('string');
 
     // The persisted tool_result block carries the proposed payload, so a
-    // conversation reload can re-render the card from history.
-    const records = vi.mocked(appendMessage).mock.calls.map((c) => c[1]);
-    const toolResultBlock = records[2].content[0];
+    // conversation reload can re-render the card from history. It lands via the
+    // atomic appendMessagePair (assistant tool_use + tool_result), not a lone
+    // appendMessage.
+    const toolResultRecord = vi.mocked(appendMessagePair).mock.calls[0][2];
+    const toolResultBlock = toolResultRecord.content[0];
     expect(toolResultBlock.type).toBe('tool_result');
     if (toolResultBlock.type === 'tool_result') {
       const parsed = JSON.parse(toolResultBlock.content) as {

--- a/frontend/src/features/chat/ChatPage.tsx
+++ b/frontend/src/features/chat/ChatPage.tsx
@@ -36,6 +36,10 @@ export function ChatPage() {
   const [isSending, setIsSending] = useState(false);
   const [streamingText, setStreamingText] = useState('');
   const streamTextRef = useRef('');
+  // Aborts the in-flight stream when the user navigates away mid-turn, so the
+  // abandoned request stops and we don't fall back to a second (sync) turn.
+  const abortRef = useRef<AbortController | null>(null);
+  useEffect(() => () => abortRef.current?.abort(), []);
   const scrollRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const householdId = useActiveHouseholdId();
@@ -102,23 +106,35 @@ export function ChatPage() {
     setError(null);
     streamTextRef.current = '';
     setStreamingText('');
+    const controller = new AbortController();
+    abortRef.current = controller;
     try {
       if (streamUrl) {
         try {
-          const result = await chatService.streamMessage(message, conversationId, (event) => {
-            if (event.type === 'delta') {
-              streamTextRef.current += event.text;
-              setStreamingText(streamTextRef.current);
-            }
-          });
+          const result = await chatService.streamMessage(
+            message,
+            conversationId,
+            (event) => {
+              if (event.type === 'delta') {
+                streamTextRef.current += event.text;
+                setStreamingText(streamTextRef.current);
+              }
+            },
+            controller.signal
+          );
           // Prefer the streamed transcript (it may include tool-turn
           // preamble text); the result is authoritative for proposals/ids.
           appendAssistant(result, streamTextRef.current.trim() || result.assistantText);
           budgetQuery.refetch();
           return;
         } catch {
-          // Any stream failure (network, auth, malformed SSE, error event):
-          // discard partial output and retry once via the sync endpoint.
+          // A DELIBERATE abort (the user navigated away) must NOT fall back to
+          // the sync endpoint: the stream may already be completing server-side
+          // (messages persisted, budget charged), so a sync retry would run a
+          // whole second turn — double-charging and duplicating the message.
+          if (controller.signal.aborted) return;
+          // Any genuine stream failure (network, auth, malformed SSE, error
+          // event): discard partial output and retry once via the sync endpoint.
           streamTextRef.current = '';
           setStreamingText('');
         }
@@ -127,11 +143,15 @@ export function ChatPage() {
       appendAssistant(data, data.assistantText);
       budgetQuery.refetch();
     } catch (err) {
+      if (controller.signal.aborted) return;
       setError(getErrorMessage(err));
     } finally {
-      setIsSending(false);
-      streamTextRef.current = '';
-      setStreamingText('');
+      if (abortRef.current === controller) {
+        abortRef.current = null;
+        setIsSending(false);
+        streamTextRef.current = '';
+        setStreamingText('');
+      }
     }
   }
 

--- a/frontend/src/services/chatService.ts
+++ b/frontend/src/services/chatService.ts
@@ -120,7 +120,8 @@ export const chatService = {
   async streamMessage(
     message: string,
     conversationId: string | undefined,
-    onEvent?: (event: ChatStreamEvent) => void
+    onEvent?: (event: ChatStreamEvent) => void,
+    signal?: AbortSignal
   ): Promise<SendMessageResponse> {
     const url = getChatStreamUrl();
     if (!url) throw new Error('Chat streaming is not configured');
@@ -132,10 +133,15 @@ export const chatService = {
       ...buildAuthHeaders(useAuthStore.getState()),
     };
 
+    // `signal` aborts the in-flight POST when the caller unmounts, so an
+    // abandoned turn stops reading instead of running to completion. The reader
+    // loop below rejects with an AbortError, which the caller treats as a
+    // cancellation (no sync fallback) rather than a stream failure.
     const response = await fetch(url, {
       method: 'POST',
       headers,
       body: JSON.stringify({ message, conversationId }),
+      signal,
     });
     if (!response.ok || !response.body) {
       throw new Error(`Chat stream failed (${response.status})`);


### PR DESCRIPTION
Three chat-turn integrity fixes from the audit (#9, #10, #11), plus a documented deferral of #3/#4.

### #11 — partial usage went unbilled on a mid-turn failure
`incrementBudget` ran only **after** the tool loop. A mid-turn Bedrock failure (the follow-up call throws after the first already cost tokens) charged **nothing** — a failed turn was free and the monthly budget never converged. Moved into a `try/finally` that commits accumulated usage on any exit (skipping a zero-write when nothing was consumed).

### #9 — a half-written tool turn broke the conversation forever
The assistant `tool_use` turn and its `tool_result` turn were two separate `Put`s. If the second failed (process death, throttling), the conversation kept an assistant `tool_use` with **no matching `tool_result`** — which Bedrock rejects with a `ValidationException` on **every** later replay, permanently bricking the thread. New `appendMessagePair` writes both in one **TransactWrite**: a partial failure leaves neither (the turn is simply retried).

### #10 — abandoned streams kept running / triggered a double turn
`streamMessage` took no `AbortSignal` and `ChatPage` never cancelled, so navigating away mid-turn kept the fetch reading. Added an `AbortController` aborted on unmount. Critically, a **deliberate abort now skips the sync fallback** — the stream may already be completing server-side, so a fallback would run a whole second turn (double-charge + duplicate message). This closes **#3's common (unmount) path**.

### Deferred — documented, not patched
- **#3's rare network-drop variant** (stream completes server-side but the socket drops before the client sees `done`, then the sync fallback re-runs it) and **#4** (the over-budget gate's read→check→increment isn't atomic, so concurrent turns can overshoot). Both need a per-turn **idempotency/reservation key** threaded through both endpoints. The overshoot is bounded and self-correcting (the next turn 429s), and bolting an idempotency ledger onto the billing path deserves its own focused change rather than a rushed patch here.

### Tests
partial-usage-billed-on-failure + no-zero-write; `appendMessagePair` writes one ordered `TransactWrite`; tool-loop persistence asserts the atomic pair on both sync + stream paths. Backend **995**, frontend **339**, both lint + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)