### PR TITLE
feat(chat): turn idempotency (#3) + atomic budget reservation (#4)

### DIFF
--- a/backend/src/handlers/chat/handler.ts
+++ b/backend/src/handlers/chat/handler.ts
@@ -25,6 +25,9 @@ import { getBudget } from '../../services/chat/persistence.js';
 const sendMessageSchema = z.object({
   message: z.string().trim().min(1).max(4000),
   conversationId: z.string().uuid().optional(),
+  // Idempotency key (#3): stable across a stream attempt and its sync fallback
+  // so the same user message can't be charged/persisted twice.
+  turnId: z.string().uuid().optional(),
 });
 type SendMessageInput = z.infer<typeof sendMessageSchema>;
 
@@ -40,6 +43,7 @@ export const sendMessage = createHandler(
       householdId: user.householdId,
       conversationId: validatedBody.conversationId,
       message: validatedBody.message,
+      turnId: validatedBody.turnId,
     });
 
     return successResponse(result);

--- a/backend/src/handlers/chat/streamHandler.ts
+++ b/backend/src/handlers/chat/streamHandler.ts
@@ -39,6 +39,9 @@ import { runChatTurn, streamChatTurn } from '../../services/chat/index.js';
 const sendMessageSchema = z.object({
   message: z.string().trim().min(1).max(4000),
   conversationId: z.string().uuid().optional(),
+  // Idempotency key (#3) — shared with the sync endpoint so a stream that
+  // completes server-side isn't re-run when the client falls back.
+  turnId: z.string().uuid().optional(),
 });
 
 /**
@@ -203,7 +206,11 @@ async function resolveUser(
   return { userId: claims.sub, householdId };
 }
 
-function parseBody(event: StreamRequestEvent): { message: string; conversationId?: string } {
+function parseBody(event: StreamRequestEvent): {
+  message: string;
+  conversationId?: string;
+  turnId?: string;
+} {
   const raw = event.isBase64Encoded
     ? Buffer.from(event.body ?? '', 'base64').toString('utf8')
     : (event.body ?? '');
@@ -245,7 +252,7 @@ export async function streamRequestToSse(
 ): Promise<void> {
   const httpResponseStream = (globalThis as StreamifyCapableGlobal).awslambda?.HttpResponseStream;
   let user: { userId: string; householdId: string };
-  let body: { message: string; conversationId?: string };
+  let body: { message: string; conversationId?: string; turnId?: string };
   try {
     user = await resolveUser(event);
     body = parseBody(event);
@@ -278,6 +285,7 @@ export async function streamRequestToSse(
       householdId: user.householdId,
       conversationId: body.conversationId,
       message: body.message,
+      turnId: body.turnId,
     });
     for (;;) {
       const next = await gen.next();
@@ -313,8 +321,8 @@ async function bufferedHandler(
 ): Promise<{ statusCode: number; headers: Record<string, string>; body: string }> {
   try {
     const { userId, householdId } = await resolveUser(event);
-    const { message, conversationId } = parseBody(event);
-    const result = await runChatTurn({ userId, householdId, conversationId, message });
+    const { message, conversationId, turnId } = parseBody(event);
+    const result = await runChatTurn({ userId, householdId, conversationId, message, turnId });
     return {
       statusCode: 200,
       headers: { 'Content-Type': 'application/json' },

--- a/backend/src/local-server.ts
+++ b/backend/src/local-server.ts
@@ -2878,6 +2878,8 @@ app.post('/billing/webhook', (req, res) => {
 const sendMessageSchema = z.object({
   message: z.string().trim().min(1).max(4000),
   conversationId: z.string().uuid().optional(),
+  // Idempotency key (#3). The mock has no Bedrock/budget so it just accepts it.
+  turnId: z.string().uuid().optional(),
 });
 
 const CHAT_BUDGET = {

--- a/backend/src/services/chat/index.ts
+++ b/backend/src/services/chat/index.ts
@@ -27,14 +27,17 @@ import {
 import {
   appendMessage,
   appendMessagePair,
-  getBudget,
+  claimTurn,
+  finalizeTurn,
   getConversation,
   incrementBudget,
-  isOverBudget,
   newConversationId,
+  releaseTurn,
+  reserveBudget,
 } from './persistence.js';
 import type {
   BudgetConfig,
+  BudgetState,
   ChatMessageRecord,
   ContentBlock,
   TextBlock,
@@ -44,6 +47,15 @@ import type {
 const MAX_TOOL_CALLS_PER_TURN = 5;
 const MAX_OUTPUT_TOKENS_PER_CALL = 1024;
 const MAX_HISTORY_MESSAGES = 24;
+
+// Tokens reserved up front by the atomic budget gate (reserveBudget), then
+// reconciled to actual usage when the turn finishes. A modest representative
+// turn — enough that two concurrent turns can't both slip past the cap, not so
+// large it 429s users who still have real budget. NOT the absolute worst case
+// (6 Bedrock calls): a rare big turn may still overshoot slightly, bounded and
+// self-correcting on the next turn.
+export const RESERVE_INPUT_TOKENS = 8000;
+export const RESERVE_OUTPUT_TOKENS = 2048;
 
 // `||` (not `??`) — the Terraform variable defaults to "" to signal "use code
 // default", and `??` only treats null/undefined as missing. With `??`, an
@@ -94,6 +106,14 @@ export interface RunChatTurnInput {
   conversationId?: string;
   /** User-supplied text for this turn. */
   message: string;
+  /**
+   * Client-generated idempotency key, stable across a stream attempt AND its
+   * sync fallback for the SAME user message. Lets the backend replay a
+   * completed turn's result instead of running (and charging) it twice when a
+   * stream finishes server-side but the client falls back. Optional — turns
+   * without one just aren't deduped.
+   */
+  turnId?: string;
 }
 
 /**
@@ -213,16 +233,57 @@ async function* turnEvents(
   input: RunChatTurnInput,
   opts: { streaming: boolean }
 ): AsyncGenerator<ChatStreamEvent, RunChatTurnResult> {
-  const { userId, householdId, message } = input;
+  const { userId, householdId, message, turnId } = input;
   const conversationId = input.conversationId ?? newConversationId();
 
-  // Budget gate FIRST — cheaper to bail before any Bedrock call.
-  const budgetBefore = await getBudget(householdId);
-  if (isOverBudget(budgetBefore, BUDGET_CONFIG)) {
-    throw createHttpError(
-      429,
-      "You've used this month's chat allowance. The budget resets on the 1st of next month."
+  // Idempotency (#3): replay an already-completed turn instead of running it
+  // again. Closes the stream→sync fallback double-charge — a stream that
+  // finishes server-side but whose client falls back to the sync endpoint with
+  // the SAME turnId gets the stored result, not a second Bedrock turn.
+  if (turnId) {
+    const claim = await claimTurn(householdId, turnId);
+    if (claim.status === 'done' && claim.result) {
+      const stored = claim.result as unknown as RunChatTurnResult;
+      yield { type: 'start', conversationId: stored.conversationId };
+      yield { type: 'done', result: stored };
+      return stored;
+    }
+    if (claim.status === 'in_progress') {
+      // A prior attempt with this turnId is still running — don't run a second.
+      throw createHttpError(409, 'This message is already being processed — hang tight.');
+    }
+    // 'claimed' → we own this turn; run it (and finalize/release below).
+  }
+
+  // Atomic budget gate (#4): reserve a representative turn up front. The
+  // conditional reservation serializes concurrent turns so two can't both slip
+  // past the cap (the old read-then-check-then-increment left that window
+  // open); it's reconciled to ACTUAL usage in the finally below.
+  let budgetBefore: BudgetState;
+  try {
+    const reserved = await reserveBudget(
+      householdId,
+      { inputTokens: RESERVE_INPUT_TOKENS, outputTokens: RESERVE_OUTPUT_TOKENS },
+      BUDGET_CONFIG
     );
+    // Committed-before = post-reservation totals minus our own reservation.
+    budgetBefore = {
+      householdId,
+      yearMonth: reserved.yearMonth,
+      inputTokens: reserved.inputTokens - RESERVE_INPUT_TOKENS,
+      outputTokens: reserved.outputTokens - RESERVE_OUTPUT_TOKENS,
+      costUsd: reserved.costUsd,
+    };
+  } catch (err) {
+    if ((err as { name?: string }).name === 'ChatBudgetExceededError') {
+      // Release the idempotency claim so a retry (e.g. next month) can re-run.
+      if (turnId) await releaseTurn(householdId, turnId);
+      throw createHttpError(
+        429,
+        "You've used this month's chat allowance. The budget resets on the 1st of next month."
+      );
+    }
+    throw err;
   }
 
   yield { type: 'start', conversationId };
@@ -249,6 +310,9 @@ async function* turnEvents(
   // propose_reminder_task calls (e.g. "set up watering + fertilizing").
   const proposals: ProposedReminderTask[] = [];
 
+  // Distinguishes a clean loop exit from a thrown one inside the finally, which
+  // owns both the budget reconcile and the turn-claim resolution.
+  let failed = true;
   try {
     for (let iter = 0; iter < MAX_TOOL_CALLS_PER_TURN + 1; iter++) {
       const modelArgs = {
@@ -407,18 +471,27 @@ async function* turnEvents(
         { role: 'user', content: resultsContent },
       ];
     }
+    failed = false;
   } finally {
-    // Commit token usage even if a mid-turn Bedrock call threw: partial usage
-    // (e.g. a 2nd tool-loop call that fails after the 1st already cost tokens)
-    // must still be billed, or the failed turn is effectively free and the
-    // monthly budget never converges. Skip a zero write — the over-budget gate
-    // can throw before any Bedrock call, and a turn can fail on its first call.
-    if (totalInputTokens > 0 || totalOutputTokens > 0) {
-      await incrementBudget(householdId, {
-        inputTokens: totalInputTokens,
-        outputTokens: totalOutputTokens,
-        costUsd: totalCost,
-      });
+    // Reconcile the up-front reservation to ACTUAL usage. We already reserved
+    // RESERVE_* at the gate, so adding (actual - reserve) lands the committed
+    // total on the true usage — even if a mid-turn Bedrock call threw (the
+    // deltas can be negative; DynamoDB's ADD handles that). This always runs,
+    // so a failed turn still bills what it spent and frees the rest.
+    await incrementBudget(householdId, {
+      inputTokens: totalInputTokens - RESERVE_INPUT_TOKENS,
+      outputTokens: totalOutputTokens - RESERVE_OUTPUT_TOKENS,
+      costUsd: totalCost,
+    });
+    // A claimed turn that FAILED must release its idempotency slot so a
+    // legitimate retry (the client's sync fallback) can run fresh. Success is
+    // finalized below, after the result is built.
+    if (turnId && failed) {
+      try {
+        await releaseTurn(householdId, turnId);
+      } catch (err) {
+        logger.warn({ err: (err as Error).message, turnId }, 'chat_turn_release_failed');
+      }
     }
   }
 
@@ -451,6 +524,17 @@ async function* turnEvents(
       ),
     },
   };
+
+  // Record the completed result so a same-turnId retry replays it instead of
+  // re-running. Best-effort: if this write fails the worst case is a retry
+  // re-runs the turn (the pre-idempotency behavior), so never fail the turn.
+  if (turnId) {
+    try {
+      await finalizeTurn(householdId, turnId, result as unknown as Record<string, unknown>);
+    } catch (err) {
+      logger.warn({ err: (err as Error).message, turnId }, 'chat_turn_finalize_failed');
+    }
+  }
 
   yield { type: 'done', result };
   return result;

--- a/backend/src/services/chat/persistence.ts
+++ b/backend/src/services/chat/persistence.ts
@@ -13,6 +13,7 @@
  */
 import { v4 as uuid } from 'uuid';
 import {
+  DeleteCommand,
   GetCommand,
   PutCommand,
   QueryCommand,
@@ -24,6 +25,21 @@ import type { BudgetConfig, BudgetState, ChatMessageRecord } from './types.js';
 
 const CONVERSATION_TTL_SECONDS = 30 * 24 * 60 * 60;
 const BUDGET_TTL_SECONDS = 95 * 24 * 60 * 60;
+// A turn idempotency record outlives any realistic stream→sync fallback retry
+// window, then DynamoDB TTL sweeps it.
+const TURN_TTL_SECONDS = 10 * 60;
+
+/**
+ * Thrown by reserveBudget when the household is at/over its monthly cap. Call
+ * sites map it to the 429 response (checked by `err.name`, like the other
+ * service errors, so test automocks stay compatible).
+ */
+export class ChatBudgetExceededError extends Error {
+  constructor() {
+    super("You've used this month's chat allowance.");
+    this.name = 'ChatBudgetExceededError';
+  }
+}
 
 export function newConversationId(): string {
   return uuid();
@@ -209,5 +225,141 @@ export function isOverBudget(state: BudgetState, config: BudgetConfig): boolean 
   return (
     state.inputTokens >= config.maxInputTokensPerMonth ||
     state.outputTokens >= config.maxOutputTokensPerMonth
+  );
+}
+
+/**
+ * ATOMICALLY reserve `reserve` tokens against the monthly cap — the budget
+ * gate. Unlike a read-then-check-then-increment (which lets two concurrent
+ * turns both pass when near the cap), this is a single conditional UPDATE:
+ * DynamoDB serializes it, so the second concurrent turn's condition fails and
+ * it's rejected instead of overshooting. Returns the post-reservation committed
+ * totals (UPDATED_NEW) so the caller can derive remaining; the reservation is
+ * reconciled to ACTUAL usage by incrementBudget once the turn finishes.
+ *
+ * The reserve is a modest representative-turn estimate (not worst case), so the
+ * gate stays atomic for the common case without 429-ing users who still have
+ * budget. A turn that hard-crashes (Lambda kill) before reconciling leaks its
+ * reservation until the month resets — bounded and rare; this is a soft
+ * cost-control limit, not a hard billing stop.
+ *
+ * Throws ChatBudgetExceededError when the reservation can't fit under the cap.
+ */
+export async function reserveBudget(
+  householdId: string,
+  reserve: { inputTokens: number; outputTokens: number },
+  config: BudgetConfig
+): Promise<BudgetState> {
+  const ym = yearMonth();
+  try {
+    const res = await dynamodb.send(
+      new UpdateCommand({
+        TableName: TABLE_NAME,
+        Key: { PK: `HOUSEHOLD#${householdId}`, SK: `CHATBUDGET#${ym}` },
+        UpdateExpression:
+          'ADD inputTokens :rin, outputTokens :rout SET #t = if_not_exists(#t, :ttl), entityType = if_not_exists(entityType, :etype)',
+        // Allow the reservation only if BOTH counters still leave room for it
+        // (committed <= cap - reserve). Absent counters start at 0 → allowed.
+        ConditionExpression:
+          '(attribute_not_exists(inputTokens) OR inputTokens <= :inThreshold) AND (attribute_not_exists(outputTokens) OR outputTokens <= :outThreshold)',
+        ExpressionAttributeNames: { '#t': 'ttl' },
+        ExpressionAttributeValues: {
+          ':rin': reserve.inputTokens,
+          ':rout': reserve.outputTokens,
+          ':inThreshold': config.maxInputTokensPerMonth - reserve.inputTokens,
+          ':outThreshold': config.maxOutputTokensPerMonth - reserve.outputTokens,
+          ':ttl': Math.floor(Date.now() / 1000) + BUDGET_TTL_SECONDS,
+          ':etype': 'ChatBudget',
+        },
+        ReturnValues: 'UPDATED_NEW',
+      })
+    );
+    return {
+      householdId,
+      yearMonth: ym,
+      inputTokens: res.Attributes?.inputTokens as number,
+      outputTokens: res.Attributes?.outputTokens as number,
+      costUsd: (res.Attributes?.costUsd as number) ?? 0,
+    };
+  } catch (err) {
+    if ((err as { name?: string }).name === 'ConditionalCheckFailedException') {
+      throw new ChatBudgetExceededError();
+    }
+    throw err;
+  }
+}
+
+/**
+ * Result of claiming a turn's idempotency slot.
+ *   - 'claimed'     → we won; run the turn.
+ *   - 'done'        → a prior attempt finished; `result` is its stored output.
+ *   - 'in_progress' → a prior attempt is still running (rare race).
+ */
+export interface TurnClaim {
+  status: 'claimed' | 'done' | 'in_progress';
+  result?: Record<string, unknown>;
+}
+
+/**
+ * Claim a per-turn idempotency slot keyed by a client-supplied turnId. The
+ * conditional Put makes the first caller the owner; a later caller with the
+ * SAME turnId (e.g. a stream that completed server-side but whose client fell
+ * back to the sync endpoint) gets the stored result back instead of running —
+ * and charging — a duplicate turn.
+ */
+export async function claimTurn(householdId: string, turnId: string): Promise<TurnClaim> {
+  const key = { PK: `HOUSEHOLD#${householdId}`, SK: `CHATTURN#${turnId}` };
+  try {
+    await dynamodb.send(
+      new PutCommand({
+        TableName: TABLE_NAME,
+        Item: {
+          ...key,
+          entityType: 'ChatTurn',
+          status: 'in_progress',
+          ttl: Math.floor(Date.now() / 1000) + TURN_TTL_SECONDS,
+        },
+        ConditionExpression: 'attribute_not_exists(PK)',
+      })
+    );
+    return { status: 'claimed' };
+  } catch (err) {
+    if ((err as { name?: string }).name !== 'ConditionalCheckFailedException') throw err;
+    const existing = await dynamodb.send(new GetCommand({ TableName: TABLE_NAME, Key: key }));
+    if (existing.Item?.status === 'done') {
+      return { status: 'done', result: existing.Item.result as Record<string, unknown> };
+    }
+    return { status: 'in_progress' };
+  }
+}
+
+/** Record a completed turn's result so a same-turnId retry replays it. */
+export async function finalizeTurn(
+  householdId: string,
+  turnId: string,
+  result: Record<string, unknown>
+): Promise<void> {
+  await dynamodb.send(
+    new PutCommand({
+      TableName: TABLE_NAME,
+      Item: {
+        PK: `HOUSEHOLD#${householdId}`,
+        SK: `CHATTURN#${turnId}`,
+        entityType: 'ChatTurn',
+        status: 'done',
+        result,
+        ttl: Math.floor(Date.now() / 1000) + TURN_TTL_SECONDS,
+      },
+    })
+  );
+}
+
+/** Release a claimed-but-failed turn so a legitimate retry can run it fresh. */
+export async function releaseTurn(householdId: string, turnId: string): Promise<void> {
+  await dynamodb.send(
+    new DeleteCommand({
+      TableName: TABLE_NAME,
+      Key: { PK: `HOUSEHOLD#${householdId}`, SK: `CHATTURN#${turnId}` },
+    })
   );
 }

--- a/backend/tests/unit/services/chatPersistence.test.ts
+++ b/backend/tests/unit/services/chatPersistence.test.ts
@@ -41,7 +41,11 @@ import { dynamodb } from '../../../src/utils/dynamodb.js';
 import {
   appendMessage,
   appendMessagePair,
+  claimTurn,
+  finalizeTurn,
   getConversation,
+  reserveBudget,
+  ChatBudgetExceededError,
 } from '../../../src/services/chat/persistence.js';
 import type { ChatMessageRecord } from '../../../src/services/chat/types.js';
 
@@ -108,6 +112,68 @@ describe('chat message persistence', () => {
     expect(items.map((i) => i.role)).toEqual(['assistant', 'user']);
     // The seq tie-breaker keeps the assistant tool_use ahead of its result.
     expect(items[0].SK < items[1].SK).toBe(true);
+  });
+
+  it('reserveBudget gates via a conditional ADD at (cap - reserve), mapping a failed condition to ChatBudgetExceededError', async () => {
+    const config = { maxInputTokensPerMonth: 250000, maxOutputTokensPerMonth: 50000 };
+    // Success: returns the post-reservation committed totals.
+    vi.mocked(dynamodb.send).mockResolvedValueOnce({
+      Attributes: { inputTokens: 8000, outputTokens: 2048 },
+    } as never);
+    const state = await reserveBudget('hh-1', { inputTokens: 8000, outputTokens: 2048 }, config);
+    expect(state.inputTokens).toBe(8000);
+
+    const cmd = vi.mocked(dynamodb.send).mock.calls[0][0] as unknown as {
+      kind: string;
+      input: { ConditionExpression: string; ExpressionAttributeValues: Record<string, number> };
+    };
+    expect(cmd.kind).toBe('Update');
+    // The condition leaves room for the reservation: committed <= cap - reserve.
+    expect(cmd.input.ExpressionAttributeValues[':inThreshold']).toBe(250000 - 8000);
+    expect(cmd.input.ExpressionAttributeValues[':outThreshold']).toBe(50000 - 2048);
+    expect(cmd.input.ConditionExpression).toContain('inputTokens <= :inThreshold');
+
+    // Over cap → the conditional write fails → ChatBudgetExceededError.
+    vi.mocked(dynamodb.send).mockRejectedValueOnce(
+      Object.assign(new Error('cond'), { name: 'ConditionalCheckFailedException' })
+    );
+    await expect(
+      reserveBudget('hh-1', { inputTokens: 8000, outputTokens: 2048 }, config)
+    ).rejects.toBeInstanceOf(ChatBudgetExceededError);
+  });
+
+  it('claimTurn wins with a conditional Put, then replays a prior done result on a lost claim', async () => {
+    // Win: the attribute_not_exists Put succeeds.
+    vi.mocked(dynamodb.send).mockResolvedValueOnce({} as never);
+    expect(await claimTurn('hh-1', 't1')).toEqual({ status: 'claimed' });
+    const put = vi.mocked(dynamodb.send).mock.calls[0][0] as unknown as {
+      kind: string;
+      input: { ConditionExpression: string };
+    };
+    expect(put.kind).toBe('Put');
+    expect(put.input.ConditionExpression).toBe('attribute_not_exists(PK)');
+
+    // Lost claim → read the existing 'done' row → return its stored result.
+    vi.mocked(dynamodb.send).mockRejectedValueOnce(
+      Object.assign(new Error('cond'), { name: 'ConditionalCheckFailedException' })
+    );
+    vi.mocked(dynamodb.send).mockResolvedValueOnce({
+      Item: { status: 'done', result: { assistantText: 'cached' } },
+    } as never);
+    const claim = await claimTurn('hh-1', 't1');
+    expect(claim.status).toBe('done');
+    expect(claim.result).toEqual({ assistantText: 'cached' });
+  });
+
+  it('finalizeTurn records the completed result keyed by turnId', async () => {
+    vi.mocked(dynamodb.send).mockResolvedValueOnce({} as never);
+    await finalizeTurn('hh-1', 't9', { assistantText: 'done' });
+    const put = vi.mocked(dynamodb.send).mock.calls[0][0] as unknown as {
+      input: { Item: { SK: string; status: string; result: Record<string, unknown> } };
+    };
+    expect(put.input.Item.SK).toBe('CHATTURN#t9');
+    expect(put.input.Item.status).toBe('done');
+    expect(put.input.Item.result).toEqual({ assistantText: 'done' });
   });
 
   it('writes same-millisecond messages under distinct SKs that preserve write order', async () => {

--- a/backend/tests/unit/services/chatStreaming.test.ts
+++ b/backend/tests/unit/services/chatStreaming.test.ts
@@ -17,14 +17,19 @@ vi.mock('../../../src/services/chat/persistence.js', async () => {
     appendMessage: vi.fn(async () => undefined),
     appendMessagePair: vi.fn(async () => undefined),
     getConversation: vi.fn(async () => []),
-    getBudget: vi.fn(async () => ({
-      householdId: 'hh-1',
-      yearMonth: '2026-06',
-      inputTokens: 0,
-      outputTokens: 0,
-      costUsd: 0,
-    })),
+    reserveBudget: vi.fn(
+      async (_hh: string, reserve: { inputTokens: number; outputTokens: number }) => ({
+        householdId: 'hh-1',
+        yearMonth: '2026-06',
+        inputTokens: reserve.inputTokens,
+        outputTokens: reserve.outputTokens,
+        costUsd: 0,
+      })
+    ),
     incrementBudget: vi.fn(async () => undefined),
+    claimTurn: vi.fn(async () => ({ status: 'claimed' as const })),
+    finalizeTurn: vi.fn(async () => undefined),
+    releaseTurn: vi.fn(async () => undefined),
   };
 });
 vi.mock('../../../src/services/plantService.js');
@@ -32,7 +37,12 @@ vi.mock('../../../src/services/taskService.js');
 vi.mock('../../../src/services/climate.js');
 vi.mock('../../../src/services/householdService.js');
 
-import { streamChatTurn, type ChatStreamEvent } from '../../../src/services/chat/index.js';
+import {
+  streamChatTurn,
+  type ChatStreamEvent,
+  RESERVE_INPUT_TOKENS,
+  RESERVE_OUTPUT_TOKENS,
+} from '../../../src/services/chat/index.js';
 import {
   invokeChatModel,
   invokeChatModelStream,
@@ -112,9 +122,10 @@ describe('streamChatTurn', () => {
       content: [{ type: 'text', text: 'You have no plants yet.' }],
     });
     expect(vi.mocked(incrementBudget)).toHaveBeenCalledTimes(1);
+    // Reconcile = actual - reserved (same atomic-reservation accounting as sync).
     expect(vi.mocked(incrementBudget)).toHaveBeenCalledWith('hh-1', {
-      inputTokens: 100,
-      outputTokens: 20,
+      inputTokens: 100 - RESERVE_INPUT_TOKENS,
+      outputTokens: 20 - RESERVE_OUTPUT_TOKENS,
       costUsd: 0.0006,
     });
     // The streaming path never touches the sync Bedrock operation.
@@ -215,20 +226,18 @@ describe('streamChatTurn', () => {
     expect(pairRoles).toEqual(['assistant', 'user']);
     const [budgetHousehold, budgetDelta] = vi.mocked(incrementBudget).mock.calls[0];
     expect(budgetHousehold).toBe('hh-1');
-    expect(budgetDelta.inputTokens).toBe(330);
-    expect(budgetDelta.outputTokens).toBe(70);
+    // Reconcile = actual - reserved across both stream calls.
+    expect(budgetDelta.inputTokens).toBe(330 - RESERVE_INPUT_TOKENS);
+    expect(budgetDelta.outputTokens).toBe(70 - RESERVE_OUTPUT_TOKENS);
     expect(budgetDelta.costUsd).toBeCloseTo(0.0021, 10);
   });
 
   it('still gates on the budget before any Bedrock call', async () => {
     const persistence = await import('../../../src/services/chat/persistence.js');
-    vi.mocked(persistence.getBudget).mockResolvedValueOnce({
-      householdId: 'hh-1',
-      yearMonth: '2026-06',
-      inputTokens: Number.MAX_SAFE_INTEGER,
-      outputTokens: 0,
-      costUsd: 99,
-    });
+    // The atomic gate rejects the reservation when over cap.
+    vi.mocked(persistence.reserveBudget).mockRejectedValueOnce(
+      new persistence.ChatBudgetExceededError()
+    );
 
     await expect(
       collect({ userId: 'u1', householdId: 'hh-1', message: 'hello' })

--- a/backend/tests/unit/services/chatTurn.test.ts
+++ b/backend/tests/unit/services/chatTurn.test.ts
@@ -16,14 +16,21 @@ vi.mock('../../../src/services/chat/persistence.js', async () => {
     appendMessage: vi.fn(async () => undefined),
     appendMessagePair: vi.fn(async () => undefined),
     getConversation: vi.fn(async () => []),
-    getBudget: vi.fn(async () => ({
-      householdId: 'hh-1',
-      yearMonth: '2026-05',
-      inputTokens: 0,
-      outputTokens: 0,
-      costUsd: 0,
-    })),
+    // The atomic gate: returns the POST-reservation committed totals. Default to
+    // a fresh budget (committed 0 → post-reserve == the reservation).
+    reserveBudget: vi.fn(
+      async (_hh: string, reserve: { inputTokens: number; outputTokens: number }) => ({
+        householdId: 'hh-1',
+        yearMonth: '2026-05',
+        inputTokens: reserve.inputTokens,
+        outputTokens: reserve.outputTokens,
+        costUsd: 0,
+      })
+    ),
     incrementBudget: vi.fn(async () => undefined),
+    claimTurn: vi.fn(async () => ({ status: 'claimed' as const })),
+    finalizeTurn: vi.fn(async () => undefined),
+    releaseTurn: vi.fn(async () => undefined),
   };
 });
 vi.mock('../../../src/services/plantService.js');
@@ -31,14 +38,24 @@ vi.mock('../../../src/services/taskService.js');
 vi.mock('../../../src/services/climate.js');
 vi.mock('../../../src/services/householdService.js');
 
-import { runChatTurn, trimHistory, BUDGET_CONFIG } from '../../../src/services/chat/index.js';
+import {
+  runChatTurn,
+  trimHistory,
+  BUDGET_CONFIG,
+  RESERVE_INPUT_TOKENS,
+  RESERVE_OUTPUT_TOKENS,
+} from '../../../src/services/chat/index.js';
 import { invokeChatModel, type BedrockMessage } from '../../../src/services/chat/bedrock.js';
 import {
   appendMessage,
   appendMessagePair,
-  getBudget,
+  claimTurn,
+  finalizeTurn,
   getConversation,
   incrementBudget,
+  releaseTurn,
+  reserveBudget,
+  ChatBudgetExceededError,
 } from '../../../src/services/chat/persistence.js';
 import type {
   ChatMessageRecord,
@@ -108,10 +125,11 @@ describe('runChatTurn', () => {
     const calls = vi.mocked(appendMessage).mock.calls;
     expect(calls[0][1].role).toBe('user');
     expect(calls[1][1].role).toBe('assistant');
-    // Budget incremented once with the full turn's usage.
+    // Budget reconciled once: the up-front reservation is replaced by actual
+    // usage, so the committed delta is (actual - reserved).
     expect(vi.mocked(incrementBudget)).toHaveBeenCalledWith('hh-1', {
-      inputTokens: 100,
-      outputTokens: 20,
+      inputTokens: 100 - RESERVE_INPUT_TOKENS,
+      outputTokens: 20 - RESERVE_OUTPUT_TOKENS,
       costUsd: 0.0006,
     });
   });
@@ -166,27 +184,23 @@ describe('runChatTurn', () => {
     expect(vi.mocked(plantService.getPlants)).toHaveBeenCalledWith('hh-1');
     // Bedrock called twice (tool_use turn + final turn).
     expect(vi.mocked(invokeChatModel)).toHaveBeenCalledTimes(2);
-    // Combined budget update.
+    // Combined budget reconcile across both Bedrock calls (actual - reserved).
     expect(vi.mocked(incrementBudget)).toHaveBeenCalledWith('hh-1', {
-      inputTokens: 450,
-      outputTokens: 70,
+      inputTokens: 450 - RESERVE_INPUT_TOKENS,
+      outputTokens: 70 - RESERVE_OUTPUT_TOKENS,
       costUsd: 0.0025,
     });
   });
 
-  it('refuses to invoke Bedrock when the household is over budget', async () => {
-    vi.mocked(getBudget).mockResolvedValueOnce({
-      householdId: 'hh-1',
-      yearMonth: '2026-05',
-      inputTokens: BUDGET_CONFIG.maxInputTokensPerMonth,
-      outputTokens: 0,
-      costUsd: 1,
-    });
+  it('refuses to invoke Bedrock when the budget reservation is rejected (over cap)', async () => {
+    // The atomic gate (reserveBudget) throws when the reservation can't fit.
+    vi.mocked(reserveBudget).mockRejectedValueOnce(new ChatBudgetExceededError());
 
     await expect(
       runChatTurn({ userId: 'u1', householdId: 'hh-1', message: 'hello' })
     ).rejects.toMatchObject({ statusCode: 429 });
     expect(vi.mocked(invokeChatModel)).not.toHaveBeenCalled();
+    // The reservation never landed, so nothing to reconcile.
     expect(vi.mocked(incrementBudget)).not.toHaveBeenCalled();
   });
 
@@ -365,22 +379,89 @@ describe('runChatTurn', () => {
       runChatTurn({ userId: 'u1', householdId: 'hh-1', message: 'list my plants' })
     ).rejects.toThrow('bedrock throttled');
 
-    // The first call's tokens are billed even though the turn threw — otherwise
-    // a failed turn is free and the monthly budget never converges.
+    // The first call's tokens are billed even though the turn threw (reconcile
+    // = actual - reserved) — otherwise a failed turn is free and the budget
+    // never converges. The unused part of the reservation is released.
     expect(vi.mocked(incrementBudget)).toHaveBeenCalledWith('hh-1', {
-      inputTokens: 100,
-      outputTokens: 10,
+      inputTokens: 100 - RESERVE_INPUT_TOKENS,
+      outputTokens: 10 - RESERVE_OUTPUT_TOKENS,
       costUsd: 0.0003,
     });
   });
 
-  it('does not write the budget when the turn fails before any Bedrock call', async () => {
+  it('releases the whole reservation when the turn fails before consuming tokens', async () => {
     vi.mocked(invokeChatModel).mockRejectedValueOnce(new Error('bedrock down'));
     await expect(runChatTurn({ userId: 'u1', householdId: 'hh-1', message: 'hi' })).rejects.toThrow(
       'bedrock down'
     );
-    // No tokens consumed → no zero-write.
+    // Reservation landed at the gate, then the first call threw → reconcile
+    // gives back the full reservation (0 - reserved), netting zero committed.
+    expect(vi.mocked(incrementBudget)).toHaveBeenCalledWith('hh-1', {
+      inputTokens: -RESERVE_INPUT_TOKENS,
+      outputTokens: -RESERVE_OUTPUT_TOKENS,
+      costUsd: 0,
+    });
+  });
+
+  // --- Turn idempotency (#3) ---
+
+  it('replays a completed turn (idempotency hit) without running or charging again', async () => {
+    const stored = {
+      conversationId: 'conv-prior',
+      assistantText: 'Already answered.',
+      proposals: [],
+      budgetRemaining: { inputTokens: 123, outputTokens: 45 },
+    };
+    vi.mocked(claimTurn).mockResolvedValueOnce({ status: 'done', result: stored });
+
+    const result = await runChatTurn({
+      userId: 'u1',
+      householdId: 'hh-1',
+      message: 'hi',
+      turnId: 'turn-1',
+    });
+
+    expect(result).toEqual(stored);
+    // Nothing ran: no Bedrock, no reservation, no persistence, no budget write.
+    expect(vi.mocked(invokeChatModel)).not.toHaveBeenCalled();
+    expect(vi.mocked(reserveBudget)).not.toHaveBeenCalled();
+    expect(vi.mocked(appendMessage)).not.toHaveBeenCalled();
     expect(vi.mocked(incrementBudget)).not.toHaveBeenCalled();
+  });
+
+  it('rejects with 409 when a prior attempt for the same turnId is still running', async () => {
+    vi.mocked(claimTurn).mockResolvedValueOnce({ status: 'in_progress' });
+    await expect(
+      runChatTurn({ userId: 'u1', householdId: 'hh-1', message: 'hi', turnId: 'turn-2' })
+    ).rejects.toMatchObject({ statusCode: 409 });
+    expect(vi.mocked(invokeChatModel)).not.toHaveBeenCalled();
+    expect(vi.mocked(reserveBudget)).not.toHaveBeenCalled();
+  });
+
+  it('finalizes the turn record on success (so a retry replays it)', async () => {
+    vi.mocked(invokeChatModel).mockResolvedValueOnce({
+      content: [{ type: 'text', text: 'ok' }],
+      stopReason: 'end_turn',
+      inputTokens: 10,
+      outputTokens: 5,
+      costUsd: 0.0001,
+    });
+    await runChatTurn({ userId: 'u1', householdId: 'hh-1', message: 'hi', turnId: 'turn-3' });
+    expect(vi.mocked(finalizeTurn)).toHaveBeenCalledWith(
+      'hh-1',
+      'turn-3',
+      expect.objectContaining({ assistantText: 'ok' })
+    );
+    expect(vi.mocked(releaseTurn)).not.toHaveBeenCalled();
+  });
+
+  it('releases the turn claim when the turn fails (so the fallback can retry)', async () => {
+    vi.mocked(invokeChatModel).mockRejectedValueOnce(new Error('boom'));
+    await expect(
+      runChatTurn({ userId: 'u1', householdId: 'hh-1', message: 'hi', turnId: 'turn-4' })
+    ).rejects.toThrow('boom');
+    expect(vi.mocked(releaseTurn)).toHaveBeenCalledWith('hh-1', 'turn-4');
+    expect(vi.mocked(finalizeTurn)).not.toHaveBeenCalled();
   });
 
   it('exposes propose_reminder_task with the confirm-card contract in the system prompt, and collects validated proposals', async () => {

--- a/frontend/src/features/chat/ChatPage.tsx
+++ b/frontend/src/features/chat/ChatPage.tsx
@@ -108,6 +108,11 @@ export function ChatPage() {
     setStreamingText('');
     const controller = new AbortController();
     abortRef.current = controller;
+    // One idempotency key for this send, shared by the stream attempt AND its
+    // sync fallback. If the stream completes server-side but we fall back, the
+    // backend recognizes the turnId and replays the stored result instead of
+    // running a second (double-charging, duplicate-message) turn.
+    const turnId = crypto.randomUUID();
     try {
       if (streamUrl) {
         try {
@@ -120,7 +125,8 @@ export function ChatPage() {
                 setStreamingText(streamTextRef.current);
               }
             },
-            controller.signal
+            controller.signal,
+            turnId
           );
           // Prefer the streamed transcript (it may include tool-turn
           // preamble text); the result is authoritative for proposals/ids.
@@ -134,12 +140,14 @@ export function ChatPage() {
           // whole second turn — double-charging and duplicating the message.
           if (controller.signal.aborted) return;
           // Any genuine stream failure (network, auth, malformed SSE, error
-          // event): discard partial output and retry once via the sync endpoint.
+          // event): discard partial output and retry once via the sync endpoint
+          // — reusing turnId so a stream that DID finish server-side replays
+          // rather than re-runs.
           streamTextRef.current = '';
           setStreamingText('');
         }
       }
-      const data = await chatService.sendMessage(message, conversationId);
+      const data = await chatService.sendMessage(message, conversationId, turnId);
       appendAssistant(data, data.assistantText);
       budgetQuery.refetch();
     } catch (err) {

--- a/frontend/src/services/chatService.ts
+++ b/frontend/src/services/chatService.ts
@@ -102,10 +102,15 @@ export function parseProposalBlock(block: ChatContentBlock): ProposedReminderTas
 }
 
 export const chatService = {
-  async sendMessage(message: string, conversationId?: string): Promise<SendMessageResponse> {
+  async sendMessage(
+    message: string,
+    conversationId?: string,
+    turnId?: string
+  ): Promise<SendMessageResponse> {
     const response = await api.post<SendMessageResponse>('/chat/messages', {
       message,
       conversationId,
+      turnId,
     });
     return response.data;
   },
@@ -121,7 +126,8 @@ export const chatService = {
     message: string,
     conversationId: string | undefined,
     onEvent?: (event: ChatStreamEvent) => void,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    turnId?: string
   ): Promise<SendMessageResponse> {
     const url = getChatStreamUrl();
     if (!url) throw new Error('Chat streaming is not configured');
@@ -140,7 +146,7 @@ export const chatService = {
     const response = await fetch(url, {
       method: 'POST',
       headers,
-      body: JSON.stringify({ message, conversationId }),
+      body: JSON.stringify({ message, conversationId, turnId }),
       signal,
     });
     if (!response.ok || !response.body) {


### PR DESCRIPTION
Closes the two chat findings deferred from the v0.10.0 audit batch. Both needed a per-turn ledger, so they ship together.

## Spec

### #3 — stream→sync fallback double-charge
**Problem.** When the SSE stream completes server-side but the client's connection drops before it sees `done`, the client falls back to the sync endpoint and runs a **whole second turn**: double Bedrock cost, double budget charge, duplicate user message in the conversation.

**Design.** A client-generated **`turnId`** (`crypto.randomUUID()`), generated once per send and reused by the stream attempt *and* its sync fallback:
- `claimTurn` does a conditional `Put` (`attribute_not_exists`) of a `CHATTURN#<turnId>` row (`status: in_progress`, 10-min TTL).
- **Won** → run the turn; on success `finalizeTurn(result)` (`status: done`), on failure `releaseTurn` (delete) so a genuinely-failed stream's fallback runs fresh.
- **Lost + `done`** → return the **stored result** (no Bedrock, no charge, no duplicate). ← the fix.
- **Lost + `in_progress`** → `409` (a prior attempt is still running; don't double-run).

### #4 — non-atomic budget gate
**Problem.** The gate read `getBudget`, checked `isOverBudget`, then `incrementBudget`d much later. Two concurrent turns both pass the read before either writes → overshoot.

**Design.** `reserveBudget` — a single **conditional `UPDATE`** that reserves a representative turn up front (`ADD` gated on `committed <= cap - reserve`). DynamoDB serializes conditional writes, so the second concurrent turn's condition fails and it's rejected (`429`) instead of overshooting. The reservation is **reconciled to actual usage** in the `finally` (`incrementBudget(actual - reserved)`; deltas may be negative — `ADD` handles it), so a failed turn still bills what it spent and frees the rest.

**Tradeoff (documented in code).** A hard Lambda kill *between* reserve and reconcile leaks the reservation until the month resets. Reserves are modest (`8000` in / `2048` out vs `250k`/`50k` caps) and hard-kills are rare — acceptable for a soft cost-control cap, not a hard billing stop. Not absolute-worst-case, so a rare 6-tool-call turn can still overshoot slightly (bounded, self-correcting).

## Surface
- New persistence: `reserveBudget`, `claimTurn` / `finalizeTurn` / `releaseTurn`, `ChatBudgetExceededError`.
- `turnId` threaded through `runChatTurn`/`streamChatTurn`, both handlers, the local dev server, and the frontend (`chatService` + `ChatPage` — one key per send, reused by the fallback).

## Tests
Idempotency replay (no re-run/charge), in-progress `409`, finalize-on-success / release-on-failure; reconcile = `actual - reserved` on success / partial-failure / release paths; `reserveBudget` conditional shape (`cap - reserve` thresholds) + over-cap → `ChatBudgetExceededError`; `claimTurn` win/replay; `finalizeTurn` shape. **Backend 1005, frontend 342, both lint + build green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)