### PR TITLE
ci: vendor standards + harden workflows

### DIFF
--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -21,8 +21,10 @@ env:
   # Bucket holding per-version Lambda zips that auto-rollback restores from.
   ARTIFACT_BUCKET: family-greenhouse-tfstate-014248889144
 
+# Least-privilege default: read-only token. Jobs that assume an AWS role via
+# OIDC (aws-actions/configure-aws-credentials) grant `id-token: write` at the
+# job level below; every other job runs with the read-only default.
 permissions:
-  id-token: write
   contents: read
 
 jobs:
@@ -61,12 +63,12 @@ jobs:
     needs: validate
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ needs.validate.outputs.version }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -96,13 +98,13 @@ jobs:
         run: npm run build
 
       - name: Upload frontend artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: frontend-dist-${{ needs.validate.outputs.version }}
           path: frontend/dist
 
       - name: Upload backend artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: backend-dist-${{ needs.validate.outputs.version }}
           path: backend/dist
@@ -111,6 +113,10 @@ jobs:
     name: Terraform Apply
     runs-on: ubuntu-latest
     needs: [validate, build]
+    # OIDC: assumes AWS_PRODUCTION_ROLE_ARN via configure-aws-credentials.
+    permissions:
+      id-token: write
+      contents: read
     # `terraform apply -auto-approve` runs FIRST and can replace Cognito / DDB
     # / CloudFront / IAM. Gate it behind the same `production` environment as
     # deploy-backend so the prod infra apply requires a reviewer approval too —
@@ -124,18 +130,18 @@ jobs:
       cloudfront_id: ${{ steps.outputs.outputs.cloudfront_id }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ needs.validate.outputs.version }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ secrets.AWS_PRODUCTION_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
         with:
           terraform_version: 1.5.7
           terraform_wrapper: false
@@ -159,19 +165,23 @@ jobs:
     name: Deploy Frontend
     runs-on: ubuntu-latest
     needs: [validate, terraform]
+    # OIDC: assumes AWS_PRODUCTION_ROLE_ARN via configure-aws-credentials.
+    permissions:
+      id-token: write
+      contents: read
     # Same `production` approval gate as the terraform + deploy-backend jobs:
     # an S3 sync + CloudFront invalidation to the live site is a prod mutation
     # and must not run on an untagged/unreviewed path.
     environment: production
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ secrets.AWS_PRODUCTION_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Download frontend artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: frontend-dist-${{ needs.validate.outputs.version }}
           path: dist
@@ -197,24 +207,28 @@ jobs:
     name: Deploy Backend
     runs-on: ubuntu-latest
     needs: [validate, terraform]
+    # OIDC: assumes AWS_PRODUCTION_ROLE_ARN via configure-aws-credentials.
+    permissions:
+      id-token: write
+      contents: read
     # The `production` environment requires manual approval per its rule
     # configuration in GitHub. cd jobs gated on this won't run until a
     # required reviewer approves the deployment.
     environment: production
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ needs.validate.outputs.version }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ secrets.AWS_PRODUCTION_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Download backend artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: backend-dist-${{ needs.validate.outputs.version }}
           path: dist
@@ -241,7 +255,7 @@ jobs:
           cat prev-versions.txt
 
       - name: Upload prev-versions artifact (for rollback)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: prev-versions-${{ needs.validate.outputs.version }}
           path: prev-versions.txt
@@ -300,14 +314,18 @@ jobs:
     name: Post-deploy smoke (Playwright e2e against prod)
     runs-on: ubuntu-latest
     needs: [deploy-frontend, deploy-backend]
+    # OIDC: assumes AWS_PRODUCTION_ROLE_ARN for Cognito test-user create+delete.
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ needs.validate.outputs.version }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -320,7 +338,7 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Configure AWS credentials (Cognito admin for test-user create+delete)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ secrets.AWS_PRODUCTION_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
@@ -339,7 +357,7 @@ jobs:
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: playwright-smoke-report-${{ needs.validate.outputs.version }}
           path: frontend/playwright-report
@@ -350,19 +368,23 @@ jobs:
     runs-on: ubuntu-latest
     needs: [validate, deploy-backend, smoke-tests]
     if: failure() && needs.deploy-backend.result == 'success'
+    # OIDC: assumes AWS_PRODUCTION_ROLE_ARN via configure-aws-credentials.
+    permissions:
+      id-token: write
+      contents: read
     # SCOPE: this auto-rollback reverts Lambda *code* ONLY. The `terraform
     # apply` that ran earlier in this deploy (Cognito/DDB/CloudFront/IAM/etc.)
     # is NOT auto-rolled-back — if a bad infra change is what broke smoke,
     # revert the tfvars/module change and run a corrective deploy by hand.
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ secrets.AWS_PRODUCTION_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Download previous versions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: prev-versions-${{ needs.validate.outputs.version }}
 

--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -23,8 +23,10 @@ env:
   AWS_REGION: us-east-1
   ENVIRONMENT: staging
 
+# Least-privilege default: read-only token. Jobs that assume an AWS role via
+# OIDC (aws-actions/configure-aws-credentials) grant `id-token: write` at the
+# job level below; every other job runs with the read-only default.
 permissions:
-  id-token: write
   contents: read
 
 jobs:
@@ -33,10 +35,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -58,13 +60,13 @@ jobs:
         run: npm run build
 
       - name: Upload frontend artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: frontend-dist
           path: frontend/dist
 
       - name: Upload backend artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: backend-dist
           path: backend/dist
@@ -73,6 +75,10 @@ jobs:
     name: Terraform Apply
     runs-on: ubuntu-latest
     needs: build
+    # OIDC: assumes AWS_DEPLOY_ROLE_ARN via configure-aws-credentials.
+    permissions:
+      id-token: write
+      contents: read
     defaults:
       run:
         working-directory: infrastructure
@@ -81,16 +87,16 @@ jobs:
       cloudfront_id: ${{ steps.outputs.outputs.cloudfront_id }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
         with:
           terraform_version: 1.5.7
           terraform_wrapper: false
@@ -115,15 +121,19 @@ jobs:
     name: Deploy Frontend
     runs-on: ubuntu-latest
     needs: terraform
+    # OIDC: assumes AWS_DEPLOY_ROLE_ARN via configure-aws-credentials.
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Download frontend artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: frontend-dist
           path: dist
@@ -149,18 +159,22 @@ jobs:
     name: Deploy Backend
     runs-on: ubuntu-latest
     needs: terraform
+    # OIDC: assumes AWS_DEPLOY_ROLE_ARN via configure-aws-credentials.
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Download backend artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: backend-dist
           path: dist
@@ -199,10 +213,10 @@ jobs:
     needs: [deploy-frontend, deploy-backend]
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -222,7 +236,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: playwright-report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   NODE_VERSION: '20'
 
@@ -19,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           # commitlint needs both the base and head commits in its range;
           # the default shallow clone (fetch-depth 1) leaves the base SHA
@@ -27,7 +30,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -53,10 +56,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -77,10 +80,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -93,7 +96,7 @@ jobs:
         run: npm run test:coverage
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           files: frontend/coverage/lcov.info
           flags: frontend
@@ -104,10 +107,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -120,7 +123,7 @@ jobs:
         run: npm run test:coverage
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           files: backend/coverage/lcov.info
           flags: backend
@@ -131,14 +134,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           # Full history so gitleaks scans every commit, not just the tip —
           # a secret committed then removed still needs to be caught.
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -179,7 +182,7 @@ jobs:
       image: semgrep/semgrep
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Semgrep scan
         run: |
@@ -202,10 +205,10 @@ jobs:
         working-directory: infrastructure
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
         with:
           terraform_version: 1.5.7
 
@@ -224,10 +227,10 @@ jobs:
     needs: [lint, typecheck, test-frontend, test-backend]
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -244,13 +247,13 @@ jobs:
         run: npm run build
 
       - name: Upload frontend artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: frontend-dist
           path: frontend/dist
 
       - name: Upload backend artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: backend-dist
           path: backend/dist
@@ -268,10 +271,10 @@ jobs:
         profile: [desktop, mobile]
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -289,7 +292,7 @@ jobs:
 
       - name: Upload Lighthouse reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: lighthouse-${{ matrix.profile }}
           path: frontend/.lighthouseci/${{ matrix.profile }}
@@ -301,10 +304,10 @@ jobs:
     needs: [build]
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -326,10 +329,10 @@ jobs:
     needs: [build]
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -346,7 +349,7 @@ jobs:
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: playwright-report
           path: frontend/playwright-report

--- a/.prettierignore
+++ b/.prettierignore
@@ -17,3 +17,9 @@ frontend/vite.config.d.ts
 # (*x* → _x_) would silently desync the committed embeddings and trip the
 # corpus drift guard. Treat them as data, not formatted source.
 backend/src/data/plant-care-corpus
+
+# Vendored portfolio-standards — upstream content synced verbatim from
+# ChelseaKR/portfolio-standards by Renovate (see renovate.json + the pinned
+# docs/standards/.standards-version). Not authored here; reformatting it would
+# diverge from upstream and churn the version-sync diff. Treat as vendored.
+docs/standards

--- a/docs/standards/.standards-version
+++ b/docs/standards/.standards-version
@@ -1,0 +1,3 @@
+# Pinned portfolio-standards version. Bumped by Renovate (see renovate.json).
+# Source of truth: https://github.com/ChelseaKR/portfolio-standards
+standards_version=v1.0.1

--- a/docs/standards/ACCESSIBILITY-STANDARD.md
+++ b/docs/standards/ACCESSIBILITY-STANDARD.md
@@ -1,0 +1,253 @@
+# Accessibility Standard
+
+The canonical accessibility floor for everything in this portfolio that renders HTML to a human — the three frontends (`personal-site`, `davis-bike-hazard-map`, `trans-docs-navigator`) **and** any HTML a Python repo emits (eval-harness report pages, RAG answer pages, GTFS scorecards, generated `index.html`). Repos override the *values* (a civic transit tool serves a Spanish-dominant California public; a local-only CLI may render no HTML at all) but not the *structure* or the *gates*.
+
+**Floor:** WCAG 2.2 Level AA. Not 2.0, not 2.1 — 2.2, because it is backward-compatible (2.2 AA ⊇ 2.1 AA ⊇ 2.0 AA) and is the standard EN 301 549 v4.1.1 will harmonize to under the EU EAA. Where a repo already exceeds this (`personal-site` ships some AAA), the higher bar is enforced, not relaxed. *Rejected: targeting 2.1 AA "because that's what ADA Title II mandates today" — the 6 new 2.2 SC are cheap to meet on greenfield and expensive to retrofit; we pay now.*
+
+**Enforcement is binary.** Automated tooling mechanically catches ~30–57% of WCAG violations. That ~30–57% is **AUTO-GATED** (merge-blocking CI). The remainder requires human judgment and is **REVIEW-GATED** (a checklist item + a committed, dated artifact). There is no "aspirational" third category. A control that is neither auto-gated nor backed by a committed review artifact does not exist.
+
+This document is the single source of accessibility rigor. Repos record only project-specific values and findings (route lists, ignore-list justifications, the dated screen-reader walkthrough, the ACR). Reference, don't repeat.
+
+---
+
+## 0. Scope, applicability, and N/A declaration
+
+| Repo class | Examples | This standard applies to |
+|---|---|---|
+| **Frontend (TS/Vite/React)** | `personal-site`, `davis-bike-hazard-map`, `trans-docs-navigator` | Everything below, full force. |
+| **Python repo emitting user-facing HTML** | eval-harness report pages (`civic-ai-eval-harness`, `govchat-eval`), RAG answer pages (`civic-rag-starter-kit`, `fare-assistant`), `gtfs-scorecard` HTML output | §1 AUTO-GATEs run against the *generated* HTML (built in CI, then scanned). §2 REVIEW-GATEs apply to each primary task the page supports. |
+| **Civic / public-facing content** | `gtfs-scorecard`, `fare-assistant`, `trans-docs-navigator`, `civic-rag-starter-kit`, `davis-bike-hazard-map` | All of the above **plus** §3 plain-language gate. |
+| **No-HTML repo** | local-only libraries/CLIs (`ledger`, `nearmiss` core, `swelter`, `tods-validate`, `women-artist-discovery`, `self-osint-monitor`) | Declares **N/A with reason** (below). The standard does not silently skip. |
+
+**N/A is a declaration, not a default.** A repo that renders no HTML to a human records, in its `ROADMAP.md` Metrics table:
+
+```
+| Accessibility (ACCESSIBILITY-STANDARD) | N/A — emits no human-facing HTML (CLI/library only). Re-enter scope if a report page, web UI, or HTML export is added. | n/a | n/a | — |
+```
+
+A repo that emits HTML but claims a specific gate is N/A (e.g. "no drag interactions, 2.5.7 N/A") records the SC and the reason. Silent omission is a defect.
+
+> **`nearmiss` / `swelter` / `ledger`:** these are local-first but several render summary/report HTML. If the HTML is opened in a browser by a human, it is in scope — re-read the table above before declaring N/A.
+
+---
+
+## 1. AUTO-GATES (merge-blocking CI)
+
+Every gate below either blocks the merge or it is not a gate. `make verify` runs the same checks locally that CI runs remotely — byte-for-byte where the repo already achieves that (most Python repos do; frontends should). No `continue-on-error`, no `|| true`. **The advisory `pa11y`/`axe` pattern (`continue-on-error: true`) currently in `civic-ai-eval-harness`, `govchat-eval`, `civic-rag-starter-kit`, `fare-assistant` is hereby retired** — those flags are deleted, the checks block.
+
+| Metric | Target | Measured by | Gate |
+|---|---|---|---|
+| axe-core violations (WCAG 2.2 AA) | **0** of impact `critical`, `serious`, `moderate` | `@axe-core/playwright` (frontends) / `@axe-core/cli` against built HTML (Python report pages); `--tags wcag2a,wcag2aa,wcag22aa` | merge-blocking |
+| Lighthouse CI accessibility score | **≥ 0.90**; `gtfs-scorecard` **≥ 0.95** (it self-declares ≥95 in `CLAUDE.md` but runs **no** a11y CI — it MUST wire LHCI) | `@lhci/cli autorun`, assertion budget | merge-blocking |
+| pa11y-ci errors | **0** errors; `--standard WCAG2AA`, `--level-cap-when-needs-review=AA`; warnings logged, not blocking | `pa11y-ci` over the route list | merge-blocking |
+| Lint-time a11y (React) | **0** `jsx-a11y` errors | `eslint-plugin-jsx-a11y` `recommended` + key rules to `error` | merge-blocking (pre-commit + CI) |
+| Color contrast | text ≥ **4.5:1** (large ≥ 3:1); non-text/UI ≥ **3:1** (SC 1.4.11) | axe `color-contrast` rule + design-token contrast unit test | merge-blocking |
+| Target size (SC 2.5.8, **new in 2.2**) | all pointer targets **≥ 24×24 CSS px** (inline/equivalent/essential excepted) | axe `target-size` rule (verify enabled) + stylelint custom rule | merge-blocking |
+| Keyboard path | every primary task completable Tab/Shift-Tab/Enter/Space/Arrow/Escape; visible focus; **focus never fully obscured** (SC 2.4.11, **new in 2.2**) | Playwright keyboard-only spec per primary task | merge-blocking |
+| Reduced motion | no essential motion without `@media (prefers-reduced-motion: reduce)` honored | Playwright spec asserts animations suppressed under emulated reduced-motion | merge-blocking |
+| 200% zoom / 320px reflow (SC 1.4.10) | no horizontal scroll, no content loss at 320 CSS px width / 400% text zoom | Playwright viewport spec (320×256) asserts `scrollWidth ≤ clientWidth` on `body` | merge-blocking |
+
+### 1.1 Tool selection (decisions, not a survey)
+
+- **axe-core** is the canonical rule engine — zero-false-positive policy, covers WCAG 2.2 AA, scoped via `--tags wcag22aa`. It powers Lighthouse and pa11y, so the three tools agree on the rule set. *Rejected: HTML_CodeSniffer as the pa11y runner — axe runner has materially better 2.2 coverage and no double-reporting against Lighthouse.*
+- **Playwright** drives the dynamic gates (keyboard, reduced-motion, reflow) the static scanners can't see, and is already the cross-browser smoke driver in `QUALITY-AND-METRICS-STANDARD` §3 — no new dependency.
+- **Lighthouse CI** gives the page-level score budget and a trend artifact. Its score is weighted and a pass does **not** prove AA conformance — it is a floor, never the proof. axe + pa11y + Playwright + the §2 review gates are the proof.
+- **eslint-plugin-jsx-a11y** shifts the cheap violations (missing `alt`, unlabeled inputs, bad ARIA) to authoring time so they never reach CI.
+
+### 1.2 Frontend CI snippet (`personal-site` / `davis-bike-hazard-map` / `trans-docs-navigator`)
+
+`jsx-a11y` as a required, erroring rule set — not warnings:
+
+```jsonc
+// eslint.config.js (flat) — a11y block
+import jsxA11y from "eslint-plugin-jsx-a11y";
+export default [
+  jsxA11y.flatConfigs.recommended,
+  { rules: {
+      "jsx-a11y/no-autofocus": "error",
+      "jsx-a11y/anchor-is-valid": "error",
+      "jsx-a11y/control-has-associated-label": "error",
+      "jsx-a11y/no-static-element-interactions": "error",
+  }},
+];
+```
+
+axe via Playwright, failing on `moderate`+ (note: `axe` default critical/serious only — we widen it):
+
+```ts
+// a11y.spec.ts
+import { test, expect } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+
+for (const route of ["/", "/about", "/projects"]) {       // repo records its route list
+  test(`axe AA: ${route}`, async ({ page }) => {
+    await page.goto(route);
+    const r = await new AxeBuilder({ page })
+      .withTags(["wcag2a", "wcag2aa", "wcag22aa"])
+      .analyze();
+    const blocking = r.violations.filter(v =>
+      ["critical", "serious", "moderate"].includes(v.impact ?? ""));
+    expect(blocking, JSON.stringify(blocking, null, 2)).toEqual([]);
+  });
+}
+```
+
+```js
+// lighthouserc.cjs
+module.exports = {
+  ci: {
+    collect: { staticDistDir: "./dist", url: ["/", "/about", "/projects"] },
+    assert: { assertions: { "categories:accessibility": ["error", { minScore: 0.9 }] } }, // gtfs-scorecard: 0.95
+    upload: { target: "filesystem", outputDir: "./.lighthouseci" },
+  },
+};
+```
+
+```yaml
+# .github/workflows/ci.yml — a11y job (actions SHA-pinned per SECURITY-AND-SUPPLY-CHAIN-STANDARD)
+  a11y:
+    runs-on: ubuntu-latest
+    permissions: { contents: read }   # default-read per CI-CD-STANDARD
+    steps:
+      - uses: actions/checkout@<40-char-sha>          # v4.2.2
+      - uses: actions/setup-node@<40-char-sha>        # v4.1.0
+      - run: npm ci && npm run build
+      - run: npx playwright install --with-deps chromium
+      - run: npx playwright test a11y.spec.ts kbd.spec.ts reflow.spec.ts reduced-motion.spec.ts
+      - run: npx @lhci/cli autorun
+      - run: npx pa11y-ci --config .pa11yci.json
+      - uses: actions/upload-artifact@<40-char-sha>   # v4.4.3  (axe + lhci + pa11y JSON)
+        if: always()
+        with: { name: a11y-reports, path: "{.lighthouseci,pa11y,axe}/**" }
+```
+
+```jsonc
+// .pa11yci.json
+{ "defaults": { "standard": "WCAG2AA", "runners": ["axe"], "level": "error",
+                "chromeLaunchConfig": { "args": ["--no-sandbox"] } },
+  "urls": ["http://localhost:4173/", "http://localhost:4173/about"] }
+```
+
+### 1.3 Python repos that emit HTML
+
+The HTML is a build artifact, so the a11y check is part of the build: render it, then scan it. Wire into `make verify` so local == CI.
+
+```makefile
+# Makefile — runs in `make verify` for any repo emitting HTML
+a11y: build-html            ## scan generated HTML for WCAG 2.2 AA violations
+	npx --yes @axe-core/cli --tags wcag2a,wcag2aa,wcag22aa --exit \
+	  $(shell find dist/reports -name '*.html')
+	npx --yes pa11y-ci --config .pa11yci.json
+```
+
+This closes the gap where **eval harnesses ship user-facing HTML reports but never gate on their own output's accessibility**. The report page an analyst reads is in scope exactly like a frontend route. `civic-rag-starter-kit` / `fare-assistant` RAG answer pages: the rendered answer + citations are scanned (heading order, link names, contrast of citation chips — all axe-catchable).
+
+### 1.4 Curated ignore list (the only escape hatch)
+
+A real violation that cannot be fixed (third-party embed, upstream library bug) is suppressed **only** via a committed, justified ignore entry — never via `continue-on-error`. Each entry carries the rule id, the URL, a one-line reason, and a tracking issue. An empty `ignore: []` is the expected state.
+
+```jsonc
+// .pa11yci.json → "ignore"
+"ignore": [
+  // "WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail" — leaflet attribution chip, contrast fixed upstream in leaflet@2, tracked #214 (davis-bike-hazard-map)
+]
+```
+
+---
+
+## 2. REVIEW-GATES (human judgment + committed artifact)
+
+Each is paired with a checklist item in the repo's `docs/RESPONSIBLE-TECH-AUDITS.md` (Accessibility audit, framework §E) and a **dated, committed artifact**, regenerated/refreshed per release. A review gate with no committed artifact is not a gate.
+
+| Review gate | Artifact (committed, dated) | Cadence |
+|---|---|---|
+| **Screen-reader walkthrough** of every primary task | `docs/a11y/screen-reader-walkthrough-YYYY-MM-DD.md` — pass/fail per task, AT/browser pairing, announced name/role/value/state notes | per release |
+| **Keyboard-only walkthrough** (beyond the automated path) | same file or `keyboard-walkthrough-YYYY-MM-DD.md` — verifies 2.4.11, 2.4.3, 2.1.1, focus traps, skip links | per release |
+| **ARIA APG pattern audit** for each custom interactive widget | `docs/a11y/apg-<widget>.md` — APG pattern referenced, roles/states/keys verified, deviations justified | on add/change of the widget |
+| **Accessibility Conformance Report (ACR/VPAT 2.4)** vs WCAG 2.2 AA + EN 301 549 | `docs/a11y/ACR.md` (VPAT 2.4 Rev or equiv.) | per major release |
+| **Cognitive / plain-language review** of forms & auth flows | entry in release accessibility checklist — verifies 3.3.7, 3.3.8, 3.2.6 | per release (where forms/auth exist) |
+| **Accessibility statement** published | `docs/a11y/STATEMENT.md` (linked from the site footer) — conformance level, known gaps, contact, date | per release |
+| **Third-party / embedded content audit** | note in ACR | annually + on new embed |
+
+### 2.1 Screen-reader matrix (the pairing is not optional)
+
+A screen-reader pass means these AT/browser pairings, because AT behavior diverges and "works in one" proves nothing:
+
+| Pairing | Platform | Required for |
+|---|---|---|
+| **NVDA + Firefox or Chrome** | Windows | every in-scope repo |
+| **VoiceOver + Safari** | macOS | every in-scope repo |
+| **VoiceOver + Safari** | iOS | any repo with a mobile-web/PWA surface or touch targets (`davis-bike-hazard-map` map UI, `personal-site`) |
+
+JAWS + Chrome/Edge is the enterprise baseline; add it for any repo with a named government/enterprise client. NVDA and VoiceOver are free, so cost is never the reason a row is skipped.
+
+**Resolve the pending rows now:** `habitable`, `nearmiss`, and `queer-the-stacks` carry pending NVDA/VoiceOver walkthrough rows in their audit docs. Each must ship a completed, dated walkthrough artifact (or a clean N/A-with-reason per §0) before its next release tag. A "pending" row is a failing review gate, not a placeholder.
+
+### 2.2 The 6 WCAG 2.2 AA success criteria — explicit handling
+
+These are new in 2.2 and most are partly review-gated because tooling under-covers them. Every in-scope repo states pass / N/A-with-reason for each:
+
+| SC | Requirement | Primary gate |
+|---|---|---|
+| **2.4.11 Focus Not Obscured (Min)** | focused component not fully hidden by author content (sticky headers/cookie bars) | AUTO (Playwright focus-visibility spec) |
+| **2.5.7 Dragging Movements** | every drag has a single-pointer alternative (acute for `davis-bike-hazard-map` pan/zoom, marker drag) | REVIEW (committed note) + AUTO where a click alt exists to assert |
+| **2.5.8 Target Size (Min)** | pointer targets ≥ 24×24 CSS px | AUTO (axe `target-size` + stylelint) |
+| **3.2.6 Consistent Help** | help mechanisms in same relative order across pages | REVIEW (multi-page navigation note) |
+| **3.3.7 Redundant Entry** | previously entered info auto-populated/selectable | REVIEW (forms/auth checklist) |
+| **3.3.8 Accessible Authentication (Min)** | no cognitive-function-test gate without an alternative | REVIEW (auth flows; N/A where no auth) |
+
+> SC **4.1.1 Parsing** is obsolete in 2.2 — do **not** gate on it. The three AAA additions (2.4.12, 2.4.13, 3.3.9) are not required at AA; `personal-site` may opt in where already met.
+
+---
+
+## 3. Plain-language gate (civic content)
+
+Civic repos serve a public that did not choose to be users and cannot route around bad copy: `gtfs-scorecard`, `fare-assistant`, `trans-docs-navigator`, `civic-rag-starter-kit`, `davis-bike-hazard-map`. WCAG 2.2 AA has no plain-language SC at AA (3.1.5 is AAA), but ADA Title II + the civic mission make readable, non-jargon content a hard requirement here.
+
+| Metric | Target | Measured by | Gate |
+|---|---|---|---|
+| Reading level of public-facing prose & RAG answer scaffolding (labels, errors, help, disclaimers) | **≤ Grade 8** (US) for static UI copy | `textstat` Flesch-Kincaid check in CI over extracted strings | merge-blocking (auto) |
+| RAG-generated answer readability | reported, not hard-gated (model output varies) | `textstat` logged per eval run; regression > 1 grade flagged | review-gated |
+| Plain-language editorial review | clear, jargon-defined, action-oriented | committed reviewer sign-off in release checklist | review-gated |
+
+```python
+# tests/test_plain_language.py  (civic repos)
+import textstat
+from app.i18n import extract_ui_strings   # en + es catalogs (see INTERNATIONALIZATION-STANDARD)
+
+def test_ui_copy_reading_level():
+    failures = {k: g for k, v in extract_ui_strings("en").items()
+                if (g := textstat.flesch_kincaid_grade(v)) > 8.0}
+    assert not failures, f"UI strings above grade 8: {failures}"
+```
+
+For bilingual civic repos, the plain-language gate runs against the EN catalog; the ES catalog is reviewed by a human (no reliable automated ES grade-level metric — declared review-gated, not skipped). i18n catalog mechanics live in `INTERNATIONALIZATION-STANDARD`; this standard requires only that **both** locales clear an a11y screen-reader pass and that the language attribute (`lang`/`xml:lang`, SC 3.1.1/3.1.2) is correct per rendered locale (AUTO — axe `html-has-lang`, `valid-lang`).
+
+---
+
+## 4. Legal context (why these targets, not softer ones)
+
+Not a compliance treatise — the floor and the deadlines that set it.
+
+- **ADA Title II (2024 final rule, deadlines extended Apr 2026):** state/local-government web content must meet **WCAG 2.1 AA** — **Apr 26 2027** (pop. ≥ 50,000) / **Apr 26 2028** (< 50,000 + special districts). Our civic repos (`gtfs-scorecard`, `fare-assistant`, `davis-bike-hazard-map`, transit data for CA jurisdictions) are exactly the content this rule covers when adopted by or for a public entity. Any repo with a named public-entity client records its applicable deadline in `ROADMAP.md`. We target 2.2 AA (a superset) so a 2.1 AA deadline is met automatically.
+- **EN 301 549:** v3.2.1 (current) incorporates WCAG 2.1 AA (Clause 9); **v4.1.1 (expected 2026) incorporates 2.2 AA** and becomes the binding EU EAA technical standard once in the Official Journal. The ACR (§2) cites v3.2.1 today and switches to v4.1.1 on harmonization.
+- **Section 508:** WCAG 2.0 AA formal floor today; a 2.2 refresh is pending at the Access Board. The ACR/VPAT 2.4 artifact is what federal procurement requires — we ship it regardless.
+- **WCAG 3.0:** Working Draft (Mar 2026), not enforceable, no W3C Recommendation expected before ~2029. **Monitor only — build no compliance program around it.** Continue enforcing 2.2 AA.
+
+---
+
+## 5. What goes in each repo (reference, don't repeat)
+
+Cross-cutting rigor lives here. Each in-scope repo records only:
+
+1. **`ROADMAP.md` Metrics rows** for axe (`0`), Lighthouse a11y (`≥ 0.9` / `0.95`), pa11y (`0`), keyboard path, and the §3 reading-level gate where civic — each marked merge-blocking or review-gated, owner named.
+2. **Its route/URL list** consumed by the Playwright, LHCI, and pa11y configs.
+3. **Its justified ignore list** (§1.4), expected empty.
+4. **The §2 committed artifacts** under `docs/a11y/` — walkthroughs, APG audits, ACR, statement, all dated.
+5. **N/A declarations with reasons** for any gate that does not apply (§0).
+
+A no-HTML repo records one line: the N/A declaration. Nothing more.
+
+---
+
+Last verified: 2026-06-21 · Recheck cadence: on any WCAG 2.x revision, EN 301 549 publication (v4.1.1 watch), ADA Title II deadline change, or axe-core / pa11y / Lighthouse major release — and at minimum annually. Confirm current standard and tool versions at build time.

--- a/docs/standards/AI-EVALUATION-STANDARD.md
+++ b/docs/standards/AI-EVALUATION-STANDARD.md
@@ -1,0 +1,214 @@
+# AI Evaluation Standard
+
+The AI-specific companion to `RESPONSIBLE-TECH-FRAMEWORK.md`. The framework asks *what could go wrong, how do we test, what do we commit to, how is it enforced*; this document supplies the **named tools, numeric thresholds, and CI gates** for AI/RAG/eval systems so that every AI repo enforces the same bar instead of reinventing it. Cross-cutting rigor lives here once; repos record only project-specific values and findings in `docs/ROADMAP.md` (Metrics table) and `docs/RESPONSIBLE-TECH-AUDITS.md`.
+
+This standard codifies practice that **already exists in the best repos** (`govchat-eval`, `civic-ai-eval-harness`'s judge-calibration kappa gate; `fare-assistant` / `civic-rag-starter-kit`'s code-enforced citation guards; `women-artist-discovery`'s AST-level no-inference test) and makes it the portfolio norm. The work is propagation, not invention.
+
+**Regulatory frame (de-facto enforceable as of 2026-06-21):** NIST AI RMF 1.0 + the Generative AI Profile (NIST AI 600-1) supply the risk taxonomy; ISO/IEC 42001:2023 supplies the management-system artifacts (risk register, Statement of Applicability, impact assessment); the EU AI Act is in **full force since 2026-08-02** for high-risk systems (Annex III deadline 2027-12-02), with GPAI obligations live since 2025-08. None of this portfolio's systems are believed high-risk or GPAI today — but each AI repo must **declare** that classification rather than assume it (see §6).
+
+---
+
+## 0. Scope — which repos this binds, and the mandatory N/A declaration
+
+**In scope (AI/RAG/eval repos):** `civic-ai-eval-harness`, `civic-rag-starter-kit`, `govchat-eval`, `trans-docs-navigator`, `women-artist-discovery`, `queer-the-stacks` (and its undocumented fork `queer-specfic-reader` — reconcile per `CODE-QUALITY-STANDARD`; until reconciled, both inherit this standard). `fare-assistant` and `jobradar` are in scope for any feature that retrieves + generates or ranks people.
+
+**Out of scope:** repos with no model inference in a user-facing or decision-making path (`davis-bike-hazard-map`, `personal-site`, `gtfs-scorecard`, `tods-validate`, `habitable`, `ledger`, `nearmiss`, `swelter`, `olive-bark-logger`, `self-osint-monitor`).
+
+A repo is **never silently out of scope.** Every repo's `docs/ROADMAP.md` carries one line:
+
+```
+AI-Evaluation-Standard: APPLIES  (tiers: RAG, red-team, model-card)
+# or
+AI-Evaluation-Standard: N/A — no model inference in any user-facing or decision path. Reviewed 2026-06-21.
+```
+
+A new `uses:` of an LLM SDK (`anthropic`, `openai`, etc.) flips the declaration to APPLIES and is itself a REVIEW-GATE: the PR introducing the first model call cannot merge without the §1–§3 gates wired or an explicit, dated waiver in the Metrics table.
+
+**Provider note:** the portfolio standardizes on Anthropic Claude for generation and LLM-as-judge unless a repo's ROADMAP records a "rejected because" note. Evaluators (RAGAS/DeepEval) are provider-agnostic and run against whatever model the repo pins.
+
+---
+
+## 1. Metric suite — the three-layer eval (AUTO-GATE)
+
+RAG evaluation is **three layers: retrieval, generation, calibration.** A repo that retrieves-then-generates must gate all three. Tooling: **RAGAS or DeepEval** for offline scoring (reference-free, runs in `pytest`, gates every prompt/retrieval change). *Rejected:* TruLens/Arize Phoenix as the gate — excellent for production tracing, but their value is online observability, not a fast CI gate; adopt them under `OBSERVABILITY-STANDARD` for the online layer, not here. LangSmith rejected as a gate — ties CI to a hosted service and the LangChain ecosystem.
+
+The benchmark is a committed, version-controlled set of **100–500 labeled queries** (`tests/eval/benchmark/*.jsonl`) with disaggregation labels (language, segment). It is a build artifact, regenerated and re-committed like any audit.
+
+| Metric | Target | Measured by | Gate | Owner |
+|--------|--------|-------------|------|-------|
+| Faithfulness / groundedness | ≥ 0.80 | RAGAS/DeepEval over benchmark | AUTO-GATE | — |
+| Context Recall @ k=20 | ≥ 0.80 | RAGAS Context Recall | AUTO-GATE | — |
+| Context Precision | ≥ 0.70 (narrow-domain) | RAGAS Context Precision | AUTO-GATE | — |
+| Answer relevancy | ≥ 0.75 | RAGAS Answer Relevancy | AUTO-GATE | — |
+| Citation accuracy (claim-level) | ≥ 0.90 atomic-fact precision | FActScore against retrieved context | AUTO-GATE | — |
+| Hallucination / confabulation rate | ≤ 5% on held-out benchmark | reference-free detector + FActScore | AUTO-GATE | — |
+| Refusal correctness | ≥ 0.95 on should-refuse set; ≤ 2% over-refusal on should-answer set | labeled refusal benchmark | AUTO-GATE | — |
+| Truthfulness (model-version change) | no drop > 3 pp from model-card baseline | TruthfulQA (817 q) | AUTO-GATE on model bump | — |
+| Per-segment pass rate (disaggregated) | no segment > 5 pp below the macro mean | benchmark grouped by `segment`/`lang` label | AUTO-GATE | — |
+| EN/ES pass-rate parity | |EN − ES| ≤ 5 pp | bilingual benchmark slice | AUTO-GATE (bilingual repos) | — |
+
+**Trigger:** these gates run on **every PR touching prompts, retrieval, chunking, reranking, prompt assembly, or the pinned model version.** A path filter on `.github/workflows/eval.yml` plus a label is acceptable, but the eval job is a **required status check** — it cannot be `continue-on-error` or `|| true` (the same `|| true` defeat that neutered `pip-audit` in `ledger`/`nearmiss` is forbidden here by rule).
+
+**No ungrounded code path.** Where the repo already code-enforces grounding (`fare-assistant`, civic RAG repos), the citation guard is a unit test, not just an eval metric: a generated claim with no supporting retrieved span is a test failure, asserted with injected fixtures. This is the portfolio norm, lifted from those repos.
+
+DeepEval-in-pytest is the reference wiring (runs under the existing `pytest` + `make verify` stack):
+
+```python
+# tests/eval/test_rag_gates.py
+import json, pathlib, pytest
+from deepeval import assert_test
+from deepeval.metrics import FaithfulnessMetric, ContextualRecallMetric, ContextualPrecisionMetric
+from deepeval.test_case import LLMTestCase
+
+CASES = [json.loads(l) for l in (pathlib.Path(__file__).parent / "benchmark/civic.jsonl").read_text().splitlines()]
+
+@pytest.mark.parametrize("row", CASES, ids=lambda r: r["id"])
+def test_rag(row):
+    tc = LLMTestCase(
+        input=row["query"], actual_output=row["answer"],
+        retrieval_context=row["contexts"], expected_output=row["reference"],
+    )
+    assert_test(tc, [
+        FaithfulnessMetric(threshold=0.80),
+        ContextualRecallMetric(threshold=0.80),    # k=20 retrieval
+        ContextualPrecisionMetric(threshold=0.70),
+    ])
+```
+
+```makefile
+# Makefile — same target CI runs (no local/remote drift)
+eval:
+	uv run pytest tests/eval -q --eval-report=docs/audits/eval-run.json
+verify: lint type test security eval   # eval is part of the blocking chain
+```
+
+---
+
+## 2. Red-team / jailbreak suite (AUTO-GATE on critical; REVIEW-GATE for the structured exercise)
+
+Tooling: **Garak** (NVIDIA, 120+ probes — baseline scanner, nightly + PR) and **Promptfoo** (CI-native YAML, GitHub Actions, findings mapped to OWASP-LLM / NIST AI RMF / EU AI Act — the gate). *Rejected as the CI gate:* PyRIT — superb multi-turn (Crescendo, TAP) orchestration but no CI integration or dashboard; it is the tool for the **quarterly structured red-team** (REVIEW-GATE below), not the per-PR gate.
+
+The required checklist is **OWASP Top 10 for LLM Applications v2.0 (LLM01–LLM10)**. Every LLM feature is reviewed against all ten before ship; Promptfoo emits the mapping.
+
+| Control | Target | Measured by | Gate |
+|---------|--------|-------------|------|
+| OWASP LLM01–LLM10 red-team scan | 0 critical-severity findings open | Promptfoo `redteam` (OWASP plugin) | AUTO-GATE on prompt/model PR |
+| Garak baseline probe suite | 0 critical regressions vs. baseline | `garak` nightly + on model bump | AUTO-GATE (nightly required check) |
+| Prompt-injection (direct + indirect, RAG context) | resists curated injection corpus | Promptfoo + repo injection fixtures | AUTO-GATE |
+| System-prompt / context leakage | no system prompt or other-tenant context emitted | Promptfoo `harmful:privacy` + leak probes | AUTO-GATE |
+| Structured multi-turn red-team | findings triaged, severities assigned, remediation tracked | PyRIT (Crescendo+TAP) → committed report | REVIEW-GATE, ≥ quarterly + each major model/prompt release |
+
+```yaml
+# promptfooconfig.yaml — redteam gate, OWASP-mapped
+redteam:
+  plugins: [owasp:llm]            # LLM01..LLM10
+  strategies: [jailbreak, prompt-injection, base64]
+  numTests: 25
+targets:
+  - id: https://localhost:8000/answer   # the RAG endpoint under test
+defaultTest:
+  assert:
+    - type: promptfoo:redteam
+      severity: critical
+      threshold: 0          # zero open critical findings → merge-blocking
+```
+
+The structured exercise produces `docs/audits/red-team-<date>.md` (findings, severity, OWASP category, remediation, sign-off) — committed, regenerated per release, exactly the "audit-as-artifact" discipline the portfolio already practices.
+
+---
+
+## 3. Judge calibration (AUTO-GATE) + the eval-driven-development loop
+
+LLM-as-judge metrics are only trustworthy if the judge tracks human labels. **Lift `govchat-eval`/`civic-ai-eval-harness`'s calibration gate to the portfolio standard:** weekly human review of 50–100 sampled traces, scored against the automated judge, with agreement and Cohen's kappa as a merge-blocking gate.
+
+| Metric | Target | Measured by | Gate |
+|--------|--------|-------------|------|
+| Judge ↔ human raw agreement | ≥ 0.80 | calibration set (50–100 labeled traces) | AUTO-GATE |
+| Cohen's kappa | ≥ 0.60 | same | AUTO-GATE |
+| Calibration freshness | set re-labeled within 30 days | timestamp on `tests/eval/calibration/*.jsonl` | AUTO-GATE (stale set fails) |
+| Judge drift (month-over-month) | tracked, no silent degradation | kappa trend committed to eval report | REVIEW-GATE |
+
+The full eval-driven-development loop (REVIEW-GATE for the online + drift layers, since they need judgment and committed artifacts):
+
+1. **Offline** — the §1 benchmark gates every prompt/model change in CI. (AUTO)
+2. **Online** — sample 5–20% of production traffic, score with LLM-as-judge (target judge latency < 5 s), log results. (REVIEW — wire via `OBSERVABILITY-STANDARD` OTel traces; not all repos are deployed, so this is N/A-with-reason for local-only repos.)
+3. **Calibration** — the weekly human pass above; document kappa, track drift monthly. (AUTO for the gate, REVIEW for the drift narrative.)
+
+---
+
+## 4. Model cards & data cards as committed artifacts (AUTO-GATE on completeness; REVIEW-GATE on honesty)
+
+Transparency artifacts are **committed files regenerated on release**, never slideware — consistent with `RESPONSIBLE-TECH-FRAMEWORK.md` §D and the portfolio's existing data/model cards. Format: Hugging Face **model card** spec (YAML front-matter + narrative) and **Datasheets for Datasets** (Gebru et al., 7 sections). Even for repos that *use* rather than *train* a model, a model card documents the pinned model, intended/out-of-scope use, eval results, and limitations.
+
+| Artifact | Required content | Measured by | Gate |
+|----------|------------------|-------------|------|
+| `docs/cards/model-card.md` | YAML: `language, license, base_model, pipeline_tag, library_name`, ≥ 1 `model-index` eval result; narrative: intended use, **out-of-scope use**, eval results with **per-group fairness breakdown**, limitations, CO₂/compute if trained | JSON-Schema lint of YAML front-matter | AUTO-GATE |
+| `docs/cards/data-card-*.md` | All 7 datasheet sections: Motivation, Composition, Collection, Preprocessing, Uses, Distribution, Maintenance — non-empty | section-presence lint (pre-run hook before any fine-tune) | AUTO-GATE |
+| Environmental footprint | GPU-hours + CO₂e (CodeCarbon / ML CO₂ Impact) | committed to model card, training repos only | AUTO-GATE on train; **N/A-with-reason** for API-only repos |
+| Card honesty / framing | limitations and out-of-scope are truthful, not box-ticking | accountable-owner review | REVIEW-GATE per release |
+
+```yaml
+# .github/workflows/cards.yml — front-matter completeness lint
+- run: |
+    uv run python -c "
+    import sys,yaml,pathlib
+    fm=yaml.safe_load(pathlib.Path('docs/cards/model-card.md').read_text().split('---')[1])
+    req={'language','license','base_model','pipeline_tag','library_name','model-index'}
+    missing=req-set(fm)
+    sys.exit(f'model-card missing: {missing}' if missing else 0)"
+```
+
+Datasheet completeness is a **pre-run hook**: a fine-tune or training run with a missing/empty-section datasheet **aborts**.
+
+---
+
+## 5. Regression gates — how the thresholds bind in CI
+
+The gate is **regression on a committed baseline**, not an absolute floor alone. Each repo commits `docs/audits/eval-baseline.json`; the CI eval job fails if any §1 metric drops below its threshold **or** regresses > the per-metric tolerance from baseline.
+
+| Change class | Gates triggered |
+|--------------|-----------------|
+| Prompt template / system prompt | §1 full suite, §2 Promptfoo OWASP, §3 calibration freshness |
+| Retrieval / chunking / reranker | §1 retrieval metrics (recall@20, precision), faithfulness, citation accuracy |
+| Pinned model version bump | §1 full suite, §2 Garak + Promptfoo, TruthfulQA drift ≤ 3 pp, model-card update required |
+| New benchmark queries | re-baseline (REVIEW-GATE: owner approves the new baseline JSON) |
+| New AI feature / first model call | all of the above + §6 risk classification (REVIEW-GATE) |
+
+**Reference, don't repeat:** the eval thresholds above are stated once here. A repo's `docs/ROADMAP.md` Metrics table records only its *measured* values and any justified deviation (e.g. a broad-domain repo raising the Context Precision target's domain qualifier), each carrying a one-line rationale. Silent deviation is a defect.
+
+---
+
+## 6. Governance artifacts — NIST AI RMF / ISO 42001 / EU AI Act (REVIEW-GATE)
+
+These require human judgment, so they are REVIEW-GATEs paired with a committed artifact and an accountable-owner sign-off. They extend `RESPONSIBLE-TECH-AUDITS.md`, not duplicate it.
+
+| Artifact | Frame | Trigger / cadence | Gate |
+|----------|-------|-------------------|------|
+| `docs/audits/ai-risk-register.md` | NIST AI RMF **MAP**: inventory each AI system, its risk tier, which of the 12 AI 600-1 GenAI risks apply (confabulation, bias/homogenization, data privacy, info integrity, etc.) | before any new AI feature ships; review ≥ quarterly | REVIEW-GATE |
+| `docs/audits/ai-impact-assessment-<feature>.md` | ISO 42001 **Clause 6.1.4** impact assessment: societal + individual consequences | per feature that processes personal data, makes consequential decisions, or faces external users | REVIEW-GATE |
+| `docs/audits/iso42001-soa.md` | ISO 42001 Statement of Applicability: applicable Annex A controls (of 42) + exclusion rationale | per production AI system; review annually + on architecture change | REVIEW-GATE |
+| EU AI Act classification line | Annex III high-risk? GPAI? compute near 10²⁵ FLOPs? | per AI feature; recorded in the risk register | REVIEW-GATE — **must be explicit** |
+
+**Classification is mandatory and explicit.** A typical entry: *"Not Annex III high-risk (no recruitment/credit/law-enforcement/education/critical-infra decisioning); not GPAI; API-only, training compute = 0. Reviewed 2026-06-21 by <owner>."* If a feature *does* land in Annex III, the conformity-assessment package (technical docs Art. 18, QMS Art. 17, Declaration of Conformity Art. 47) becomes a hard pre-ship REVIEW-GATE with the 2027-12-02 Annex III deadline. The civic repos (`civic-rag-starter-kit`, `govchat-eval`, `fare-assistant`) are the highest-attention candidates and must keep this line current.
+
+The portfolio's **no-inference / no-outing** guarantees are first-class risk-register entries: `women-artist-discovery`'s AST-level "no identity inference ever" static test and `ledger`'s no-outing sentinel job are the enforcement of the "Harmful Bias" and "Data Privacy" RMF risks — referenced here, owned in those repos.
+
+---
+
+## What gets committed into each AI repo
+
+Per `DOCUMENTATION-STANDARD.md`, each in-scope repo carries, regenerated by `make verify` / on release:
+
+- `tests/eval/benchmark/*.jsonl` — the 100–500-query labeled, disaggregated benchmark.
+- `tests/eval/calibration/*.jsonl` — the dated judge-calibration set.
+- `docs/audits/eval-run.json` + `eval-baseline.json` — the eval artifact and its baseline.
+- `docs/audits/red-team-<date>.md` — the structured red-team report.
+- `docs/cards/model-card.md` + `docs/cards/data-card-*.md`.
+- `docs/audits/ai-risk-register.md`, `iso42001-soa.md`, `ai-impact-assessment-*.md`.
+- One ROADMAP line declaring APPLIES (with tiers) or N/A-with-reason.
+
+Every item is either an AUTO-GATE (mechanically checked, merge-blocking) or a REVIEW-GATE (human sign-off + committed artifact). There is no third "aspirational" category.
+
+---
+
+Last verified: 2026-06-21 · Recheck cadence: per NIST AI RMF / AI 600-1, ISO/IEC 42001, EU AI Act phase-gate, and OWASP Top 10 for LLMs revision — and whenever RAGAS/DeepEval/Garak/Promptfoo ship a breaking metric/threshold change. Confirm framework versions and tool defaults at build time.

--- a/docs/standards/CI-CD-STANDARD.md
+++ b/docs/standards/CI-CD-STANDARD.md
@@ -1,0 +1,319 @@
+# CI/CD Standard
+
+This is the canonical definition of the **merge-blocking pipeline** and the **GitHub Actions security posture** every repo in this portfolio ships. It owns the *shape* of CI (stage order, gates, token model, branch protection, deploy/release safety); it does **not** own the *content* of individual gates — those live in their own standards and are referenced here, not repeated:
+
+| This doc references | For |
+|---|---|
+| `SECURITY-AND-SUPPLY-CHAIN-STANDARD.md` | SHA pinning, SBOM, cosign/SLSA, Scorecard thresholds, SAST/SCA/secret/container scanning |
+| `CODE-QUALITY-STANDARD.md` | ruff/mypy/pytest floors, coverage thresholds, `uv.lock`, src layout |
+| `QUALITY-AND-METRICS-STANDARD.md` | the quality-attribute taxonomy and the per-repo Metrics ledger shape |
+| `ACCESSIBILITY-STANDARD.md` | axe/Lighthouse/pa11y gates, target-size, ACR |
+| `AI-EVALUATION-STANDARD.md` | faithfulness/red-team/calibration gates on prompt/retrieval PRs |
+| `OBSERVABILITY-STANDARD.md` | structured-log schema, OTel, `/livez`/`/readyz` |
+| `INTERNATIONALIZATION-STANDARD.md` | catalog format, key-parity, pseudolocale |
+
+> **Enforcement is binary.** A control is **AUTO-GATE** (mechanically checkable, merge-blocking in CI) or **REVIEW-GATE** (human judgment, paired with a checklist item and a committed artifact). There is no "aspirational" third category. If a row below cannot be made one of these two, it is a defect in this document.
+
+The threat model is **active, not theoretical**: the March 2026 `trivy-action` force-push (secrets exfiltrated from 75 tags), the `tj-actions` compromise, and the February 2026 AI-automated cache-poisoning campaign against Microsoft/DataDog/CNCF repos are why every control below exists. ~13 of 19 repos in this portfolio still reference actions by mutable tag; this standard closes that.
+
+---
+
+## 1. The canonical merge-blocking pipeline
+
+Every repo ships **one CI workflow** (`.github/workflows/ci.yml`) whose jobs run these stages **in this order**. A merge to `main` requires **every** applicable stage green. `make verify` (Python) / `npm run verify` (TS) runs the same gates locally — see §9.
+
+```
+1. format        ruff format --check / prettier --check        → fail on any deviation
+2. lint          ruff check (+ zizmor on workflow PRs)          → fail on any finding
+3. type          mypy --strict / tsc --noEmit                   → zero errors
+4. test          pytest --cov (branch>=85%, libs>=90%) / vitest → fail under threshold
+5. security      semgrep + gitleaks + pip-audit/osv + trivy     → fail HIGH/CRITICAL (see SEC std)
+6. a11y          axe-core + pa11y-ci + Lighthouse (UI repos)    → see ACCESSIBILITY std
+7. perf          k6 / Lighthouse CI budgets                     → regression >10% fails
+8. responsible   eval/citation/consent/no-outing gates          → see RESPONSIBLE-TECH + AI-EVAL
+9. build         build artifact + container + SBOM + provenance → see SECURITY std
+```
+
+Stages 1–5 are mandatory for **every** repo (including `self-osint-monitor`, which must scaffold this as its M0 deliverable before any M1 code, and `gtfs-scorecard`, whose root has no CI today). Stages 6–8 apply by repo shape and are declared **applicable or N/A-with-reason** in the repo's `ROADMAP.md` Metrics ledger — silently skipping a stage is a defect.
+
+| Stage | Applies to | N/A-with-reason permitted when |
+|---|---|---|
+| 1–5 | all repos | never |
+| 6 a11y | any repo emitting HTML/UI (frontends, **eval harnesses whose reports are user-facing**) | no human-facing HTML output, declared in ledger |
+| 7 perf | hosted services, frontends, LLM routes | pure library/CLI with no latency contract |
+| 8 responsible | AI/RAG/eval, privacy-first, civic repos | repo's Responsible-Tech audit marks the gate N/A |
+
+---
+
+## 2. Least-privilege `GITHUB_TOKEN`
+
+**Default is write; this is wrong.** Org-level default is set to read-only (Settings → Actions → General → "Read repository contents and packages permissions"), and **every** workflow declares a top-level `permissions` block. Write is granted **per-job, never top-level**.
+
+| Metric | Target | Measured by | Gate |
+|---|---|---|---|
+| Top-level `permissions:` present | every workflow | zizmor + Scorecard Token-Permissions | AUTO-GATE |
+| Token-Permissions score | **10/10** | `ossf/scorecard-action` on default branch | AUTO-GATE (fail < 8) |
+| Write scopes | job-level only, minimal set | zizmor `excessive-permissions` rule | AUTO-GATE |
+
+Currently missing the block entirely: `gtfs-scorecard`, `jobradar`, `personal-site`, `tods-validate` ci.yml. Required pattern:
+
+```yaml
+# top of every workflow — deny by default
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    permissions:
+      contents: read          # explicit even when same as top-level
+    # ...
+  publish:
+    permissions:
+      contents: read
+      id-token: write          # OIDC, see §3
+      attestations: write      # SLSA provenance, see SECURITY std
+      packages: write          # only this job, only because it pushes
+```
+
+**No `secrets: inherit`** in reusable-workflow calls — pass each secret explicitly. **`persist-credentials: false`** on every `actions/checkout`. **No untrusted `github.*` context** interpolated into `run:` blocks — assign to an intermediate `env:` var first (zizmor `template-injection`, merge-blocking).
+
+---
+
+## 3. OIDC for cloud auth — no long-lived secrets
+
+Every workflow that touches AWS/GCP/Azure authenticates via **OIDC**; long-lived cloud keys in Actions secrets are prohibited. OIDC is already adopted where AWS is used (`jobradar`, `fare-assistant`, `personal-site`, `civic-ai-eval-harness` publishing) — this makes it mandatory and closes the trust scope.
+
+| Metric | Target | Measured by | Gate |
+|---|---|---|---|
+| Cloud creds via OIDC | 100% of cloud-touching jobs | grep for `aws-access-key`/static creds in workflows; zizmor | AUTO-GATE |
+| OIDC trust subject scope | `repo:org/repo:environment:<env>` (never `:*`, never org-wide) | review of cloud trust policy artifact | REVIEW-GATE |
+| New long-lived cloud secret added | alert | org audit-log rule on `org.update_actions_secret` | REVIEW-GATE |
+
+```yaml
+  deploy:
+    environment: production
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: aws-actions/configure-aws-credentials@<40-char-sha>  # v4.x — see SEC std for pinning
+        with:
+          role-to-assume: arn:aws:iam::ACCT:role/personal-site-deploy
+          aws-region: us-west-2
+          # NO aws-access-key-id / aws-secret-access-key anywhere
+```
+
+The IAM trust policy `sub` must pin to the **specific repo + environment claim**, e.g. `repo:ckellyreif/personal-site:environment:production`. A wildcard subject is a REVIEW-GATE failure.
+
+---
+
+## 4. SHA-pinned actions (reference SECURITY-AND-SUPPLY-CHAIN-STANDARD)
+
+The full pinning/SBOM/signing posture lives in `SECURITY-AND-SUPPLY-CHAIN-STANDARD.md`. CI restates only the **merge-blocking surface** that this pipeline enforces:
+
+| Metric | Target | Measured by | Gate |
+|---|---|---|---|
+| Every `uses:` pinned to 40-char SHA + `# vX.Y.Z` comment | 100% (incl. reusable workflows **and the deploy path**) | zizmor `unpinned-uses` + Scorecard Pinned-Dependencies | AUTO-GATE |
+| Pinned-Dependencies score | **≥ 9/10** | `ossf/scorecard-action` | AUTO-GATE |
+| SHA freshness | Renovate `helpers:pinGitHubActionDigestsToSemver`, `minimumReleaseAge: 72h` | committed `renovate.json` / `dependabot.yml` | AUTO-GATE (config present) |
+
+Today only `habitable`, `trans-docs-navigator`, `civic-ai-eval-harness`/`govchat-eval` pin. `nearmiss` (0/17), `gtfs-scorecard` (0/2) are fully tag-pinned; `trans-docs-navigator` leaks **one straggler tag in `deploy-aws-preview.yml`** — the deploy path is in scope, fix it. Migrate with `pin-github-action` or StepSecurity Action-Advisor:
+
+```bash
+# pins every uses: to its current SHA + version comment, repo-wide
+npx pin-github-action .github/workflows/*.yml
+# verify nothing references a tag/branch
+! grep -rEn 'uses:.*@(v?[0-9]|main|master|latest)\b' .github/workflows/
+```
+
+---
+
+## 5. Branch protection, required checks, no admin bypass
+
+Branch protection is enforced via **org-level GitHub Rulesets** (not per-repo settings, which admins can edit) and committed as a per-repo artifact so the posture is reviewable in-tree. This is essentially absent portfolio-wide today and must be added everywhere.
+
+| Metric | Target | Measured by | Gate |
+|---|---|---|---|
+| Branch-Protection score | **≥ 8/10** | `ossf/scorecard-action` | AUTO-GATE |
+| Required reviewers on `main`/`release/*` | ≥ 1 (≥ 2 for civic/PII repos: `fare-assistant`, `gtfs-scorecard`, civic-rag) | ruleset artifact `.github/rulesets/main.json` | REVIEW-GATE |
+| Required status checks | `format,lint,type,test,security` + `zizmor` + `codeql-actions` + applicable a11y/perf/responsible | ruleset `required_status_checks` | AUTO-GATE |
+| Dismiss stale reviews on push | on | ruleset | AUTO-GATE |
+| Admin bypass on `main` | **disabled** (`enforce_admins: true`) | direct-push test (owner push must fail) | AUTO-GATE |
+| Force-push to `main`/`release/*` | blocked | ruleset | AUTO-GATE |
+
+The committed ruleset doubles as evidence and feeds SLSA Source Track L2 (`attest-build-provenance` populates `sourceLevels` only when branch protection with required reviews is active — see SECURITY std).
+
+```jsonc
+// .github/rulesets/main.json (committed; mirrors the org ruleset)
+{
+  "name": "protect-main",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": { "ref_name": { "include": ["refs/heads/main", "refs/heads/release/*"] } },
+  "rules": [
+    { "type": "pull_request", "parameters": { "required_approving_review_count": 1,
+      "dismiss_stale_reviews_on_push": true, "require_code_owner_review": true } },
+    { "type": "required_status_checks", "parameters": { "required_status_checks": [
+      {"context": "format"}, {"context": "lint"}, {"context": "type"},
+      {"context": "test"}, {"context": "security"}, {"context": "zizmor"},
+      {"context": "codeql-actions"} ] } },
+    { "type": "non_fast_forward" },        // no force-push
+    { "type": "deletion" }
+  ],
+  "bypass_actors": []                       // empty = no admin bypass
+}
+```
+
+---
+
+## 6. CODEOWNERS on security-critical paths
+
+A committed `CODEOWNERS` routes `.github/workflows/`, rulesets, IaC, and security-critical files to a required reviewer; the ruleset sets `require_code_owner_review`. This is mechanically enforced — a PR touching a workflow cannot merge without that review. Absent portfolio-wide today.
+
+```
+# .github/CODEOWNERS
+*                               @ckellyreif
+/.github/workflows/             @ckellyreif      # workflow edits = poisoned-pipeline risk
+/.github/rulesets/              @ckellyreif
+/infra/  /terraform/            @ckellyreif
+/SECURITY.md  /.github/dependabot.yml  /renovate.json  @ckellyreif
+# repo-specific responsible-tech guards (no-outing, consent gate, citation):
+/tests/test_no_outing.py        @ckellyreif      # ledger
+/tests/test_no_identity_inference.py  @ckellyreif # women-artist-discovery
+```
+
+| Metric | Target | Gate |
+|---|---|---|
+| `CODEOWNERS` exists and covers `.github/workflows/` | yes | AUTO-GATE (file presence + path coverage check) |
+| Code-owner review required by ruleset | on | REVIEW-GATE (ruleset artifact) |
+
+---
+
+## 7. Workflow SAST (zizmor + CodeQL `language: actions`)
+
+The workflows themselves are scanned. **zizmor nowhere in the portfolio today** — required.
+
+| Metric | Target | Measured by | Gate |
+|---|---|---|---|
+| zizmor on any PR touching `.github/workflows/**` | zero High/Critical findings; SARIF to Code Scanning | required status check `zizmor` | AUTO-GATE |
+| CodeQL `language: actions` | nightly + on workflow PRs | required status check `codeql-actions` | AUTO-GATE |
+| Dangerous-Workflow score | **10/10** | Scorecard (no `pull_request_target` checkout of untrusted code; no script injection) | AUTO-GATE (fail < 10) |
+
+```yaml
+# .github/workflows/zizmor.yml
+name: zizmor
+on:
+  pull_request: { paths: ['.github/workflows/**', '.github/actions/**'] }
+permissions:
+  contents: read
+  security-events: write          # SARIF upload only
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<sha>          # v4.x; persist-credentials: false
+        with: { persist-credentials: false }
+      - uses: zizmorcore/zizmor-action@<sha>  # vX.Y.Z
+```
+
+`pull_request_target` / `workflow_run` are **prohibited** unless the workflow verifies actor membership and never checks out PR code; the only approved cross-privilege pattern is unprivileged `pull_request` uploads artifact → privileged `workflow_run` verifies then acts (zizmor + Scorecard enforce this).
+
+---
+
+## 8. Deploy & release safety: environments, concurrency, no-cache
+
+### 8a. GitHub Environments with required reviewers
+Production/staging deploys run only through a **named GitHub Environment** with ≥ 1 required reviewer and "Protected branches only" deployment restriction. Even a workflow running a compromised action cannot reach prod without human sign-off.
+
+| Metric | Target | Gate |
+|---|---|---|
+| Prod/staging deploy gated by named Environment + required reviewer + prevent-self-review | yes | REVIEW-GATE (committed `environments-audit-YYYY-QN.json`, quarterly) |
+
+### 8b. Concurrency groups
+Deploy/release workflows set a concurrency group to prevent racing deploys; called reusable workflows declare their **own** group independent of the caller. Inconsistently applied today (`gtfs-scorecard` has 10 workflows, eval harnesses 9, most repos 1–2).
+
+```yaml
+concurrency:
+  group: deploy-${{ github.ref }}            # deploy/release: serialize
+  cancel-in-progress: false                  # never cancel an in-flight deploy
+# CI/lint jobs may use cancel-in-progress: true
+```
+
+| Metric | Target | Measured by | Gate |
+|---|---|---|---|
+| `concurrency:` on every deploy/release job | present, `cancel-in-progress: false` | workflow-lint check / zizmor | AUTO-GATE |
+
+### 8c. Caching disabled in release/publish jobs
+Cache (`actions/cache`, `cache: true` on `setup-*`) is **prohibited** in any job that deploys to prod, publishes a package, generates SLSA provenance, or holds `id-token: write` — cache poisoning violates SLSA L3 isolation. Cache is allowed only in `pull_request`-triggered build/test jobs.
+
+| Metric | Target | Measured by | Gate |
+|---|---|---|---|
+| No caching in release/publish/provenance/`id-token` jobs | enforced | zizmor cache-poisoning rule + workflow-lint | AUTO-GATE |
+
+---
+
+## 9. Reusable workflows + `make verify` reproduces CI locally
+
+**Reusable org workflows.** Build/test/security-scan/deploy logic lives once in a shared `.github` repo (`ckellyreif/.github`) and product repos *call* it rather than copy-pasting. Callers must not override security-critical inputs (`permissions`, environment names). This kills the per-repo drift that lets a green build in one repo fail in another.
+
+```yaml
+jobs:
+  ci:
+    uses: ckellyreif/.github/.github/workflows/python-verify.yml@<sha>  # vX.Y.Z
+    permissions:
+      contents: read
+    # caller may pass project values (coverage floor) but NOT permissions/secrets blanket
+    with: { cov-fail-under: 90 }   # libraries; default 85
+```
+
+| Metric | Target | Gate |
+|---|---|---|
+| Build/deploy logic via central reusable workflow | yes (product repos) | REVIEW-GATE (quarterly reusable-workflow security review, committed) |
+| Caller does not override `permissions`/secrets | enforced | AUTO-GATE (zizmor on caller) |
+
+**`make verify` ≡ CI.** The single command runs the *same* gate set CI runs, eliminating local/remote drift. Several Python repos already ship a `make verify` that is byte-for-byte identical to CI — this makes that the portfolio rule. CI calls the same Makefile target it asks contributors to run; the two cannot diverge.
+
+```makefile
+# Makefile — CI invokes `make verify`; nothing in CI runs gates the Makefile doesn't
+verify: format-check lint type test security
+format-check: ; ruff format --check .
+lint:         ; ruff check .
+type:         ; mypy --strict src
+test:         ; pytest --cov=src --cov-branch --cov-fail-under=85
+security:     ; pip-audit && gitleaks detect --no-banner   # NO `|| true` — see SECURITY std
+```
+
+| Metric | Target | Measured by | Gate |
+|---|---|---|---|
+| `make verify` runs the exact CI gate set | identical command surface | CI job that *only* runs `make verify` for stages 1–5 | AUTO-GATE |
+| Config consolidated in single `pyproject.toml`, `uv sync --frozen` | no `ruff.toml`/`pytest.ini`/`requirements.txt` strays | CODE-QUALITY-STANDARD | AUTO-GATE |
+
+**Repo-specific layout fixes this standard surfaces** (resolved under CODE-QUALITY-STANDARD, gated here via "`make verify` at repo root must exist and pass"):
+- `jobradar`: no `pyproject.toml` — splits config across `requirements.txt` + `ruff.toml` + `pytest.ini`, no mypy. Consolidate; add type gate.
+- `gtfs-scorecard`: real project hidden at `pipeline/pyproject.toml`, no root `make verify`/`uv.lock`. Add root `Makefile` delegating to `pipeline/`, or hoist config.
+- `self-osint-monitor`: spec-only, no CI/Makefile/pyproject. Scaffold §1 + §2 + §9 as the **M0 deliverable** before M1 code (and sequence the consent gate per AI-EVAL/RESPONSIBLE-TECH).
+- `queer-the-stacks` / `queer-specfic-reader`: duplicate `queer_the_stacks` package. Reconcile to one repo before applying this standard twice (REVIEW-GATE: documented fork/rename decision).
+
+---
+
+## 10. Per-repo CI declaration (committed artifact)
+
+Each repo's `ROADMAP.md` Metrics ledger (shape defined in `QUALITY-AND-METRICS-STANDARD.md`) carries the CI-specific rows so enforcement is unambiguous and every optional stage is explicitly **applicable or N/A-with-reason**:
+
+| Metric | Target | Measured by | Gate | Owner |
+|---|---|---|---|---|
+| Token-Permissions | 10/10 | scorecard-action | AUTO-GATE | — |
+| Pinned-Dependencies | ≥ 9/10 | scorecard-action | AUTO-GATE | — |
+| Branch-Protection | ≥ 8/10 | scorecard-action | AUTO-GATE | — |
+| Dangerous-Workflow | 10/10 | scorecard-action | AUTO-GATE | — |
+| Cloud auth via OIDC | 100% | workflow grep + zizmor | AUTO-GATE | — |
+| zizmor on workflow PRs | 0 High/Crit | required check | AUTO-GATE | — |
+| `make verify` ≡ CI | identical | CI job | AUTO-GATE | — |
+| Deploy reviewer gate | env + ≥1 reviewer | environments-audit | REVIEW-GATE | — |
+| a11y / perf / responsible stages | applicable **or** N/A-with-reason | ledger row | per stage | — |
+
+A stage marked N/A **must** carry a one-line reason (e.g. "perf: pure library, no latency contract"; "i18n: single-user English-only CLI, entry point `_()` documented"). A blank or missing row is a merge-blocking defect.
+
+---
+
+Last verified: 2026-06-21 · Recheck cadence: per GitHub Actions security-feature release, OpenSSF Scorecard minor (currently v5.5), SLSA spec revision (currently v1.2), and OWASP Top-10 CI/CD update — review at least quarterly given the active supply-chain threat environment. Confirm current action SHAs, Scorecard check weights, and GitHub ruleset schema at build time.

--- a/docs/standards/CODE-QUALITY-STANDARD.md
+++ b/docs/standards/CODE-QUALITY-STANDARD.md
@@ -1,0 +1,299 @@
+# Code Quality Standard
+
+This is the canonical definition of **what a healthy source tree looks like** across the ~18 repos in this portfolio, and the mechanism by which each rule is **enforced** rather than recommended. Languages, versions, linters, type checkers, test floors, complexity ceilings, layout, dependency management, and review process live here once. Repos override the *values* permitted below (a hobby logger may target 85% coverage; a published library targets 90%) and record only project-specific findings — they never re-derive the structure.
+
+> **Enforcement is binary.** A control is **AUTO-GATE** (mechanically checkable, merge-blocking in CI and reproduced by `make verify`) or **REVIEW-GATE** (requires human judgment, paired with a checklist item and a committed artifact). There is no "aspirational" third category. Ambiguity is a defect: if a rule cannot be reduced to a number plus a tool, it does not belong here.
+
+> **Scope boundary.** This document owns *intrinsic code quality*: language/version, lint, format, types, tests, complexity, layout, deps, docstrings, review, ADRs. Cross-cutting rigor lives in sibling standards and is referenced, not repeated: supply-chain pinning and signing → `SECURITY-AND-SUPPLY-CHAIN-STANDARD`; workflow hardening/OIDC/branch protection → `CI-CD-STANDARD`; logging/OTel/SLOs → `OBSERVABILITY-STANDARD`; catalogs/key-parity → `INTERNATIONALIZATION-STANDARD`; axe/Lighthouse/SR walkthroughs → `ACCESSIBILITY-STANDARD`; RAG/red-team thresholds → `AI-EVALUATION-STANDARD`; DORA + Definition-of-Done → `QUALITY-AND-METRICS-STANDARD`; ISO 25010 attribute map → `QUALITY-AND-METRICS-STANDARD`; audit artifacts → `RESPONSIBLE-TECH-FRAMEWORK`.
+
+---
+
+## 0. Why this exists now
+
+The Python core of this portfolio is already mature — ruff + mypy + pytest + committed `uv.lock` in a single `pyproject.toml`, with `make verify` byte-for-byte identical to CI in several repos. The defect is **drift**: four distinct ruff major-version floors for the same linter, mypy split across 1.10/1.11, coverage floors ranging from unset to 94%, `jobradar` with no `pyproject.toml` at all, `gtfs-scorecard` hiding its project under `pipeline/`, and `self-osint-monitor` with no toolchain. A passing build in one repo can fail in another running the same logical stack. This standard pins the canonical floors so the stack is *one* stack.
+
+The work is propagation, not invention. Every rule below already exists in at least one repo; the rule names the version and makes it portfolio-wide.
+
+---
+
+## 1. Languages & runtime versions
+
+Pinned floors. A repo above the floor is conformant; a repo below it is a defect. New repos start at the floor.
+
+| Language | Min version | Pin mechanism | Gate |
+|----------|-------------|---------------|------|
+| Python | `requires-python = ">=3.12"` (3.13 preferred for new repos; 3.11 EOL-track only with a justified ADR) | `[project].requires-python` + committed `.python-version` (`uv python pin`) | AUTO-GATE |
+| TypeScript | 5.9+ (5.6+ required for `strictBuiltinIteratorReturn`) | `devDependencies.typescript` + `tsc --noEmit` | AUTO-GATE |
+| Node (frontends/Lambda) | 22 LTS | `package.json` `engines.node` + `.nvmrc` | AUTO-GATE |
+
+Rationale: Python 3.10 reaches EOL October 2026; pinning ≥3.12 buys structural-pattern-matching and `tomllib` everywhere and removes the 3.10/3.11 conditional-import branches that inflate complexity. **Rejected:** floating `requires-python = ">=3.9"` — keeps dead compat branches alive and blocks `match` adoption.
+
+---
+
+## 2. Python toolchain (canonical floors)
+
+The entire toolchain consolidates into a single root `pyproject.toml`. **No** `ruff.toml`, `pytest.ini`, `mypy.ini`, `setup.py`, `setup.cfg`, `tox.ini`, `.flake8`, or `requirements.txt` (lockfile excepted). This deletion is named for `jobradar` (splits config across `requirements.txt` + `ruff.toml` + `pytest.ini`, no mypy) and `gtfs-scorecard` (config under `pipeline/`, no top-level `uv.lock`).
+
+| Concern | Tool | Canonical pin / target | Measured by | Gate |
+|---------|------|------------------------|-------------|------|
+| Lint + format + import-sort + modernize + bandit | **ruff** | `>=0.15.0` (current 0.15.x); `select=[E,W,F,I,UP,B,SIM,S,C90,RUF]`, `ignore=[E501]` | `ruff check` (exit≠0 fails) + `ruff format --check` | AUTO-GATE |
+| Cyclomatic complexity | ruff C901 | `max-complexity = 10` | same `ruff check` run | AUTO-GATE |
+| Static typing | **mypy `--strict`** (pin `>=1.18`) — or **pyright `strict`** / **pyrefly `>=1.1`** for new repos wanting speed | **zero** errors | `mypy --strict` (or `pyright`/`pyrefly check`) exit≠0 fails | AUTO-GATE |
+| Test runner | **pytest** | `>=8.0` (`minversion = "8.0"`); `--strict-markers --strict-config --import-mode=importlib` | `pytest` exit code | AUTO-GATE |
+| Coverage (branch) | **pytest-cov** + coverage.py 7.x | **≥85% branch** (applications) / **≥90%** (published libraries); `branch = true` | `--cov-fail-under` exit≠0 fails | AUTO-GATE |
+| Dependency resolution | **uv** | `>=0.11.0`; `uv.lock` committed; CI runs `uv sync --frozen` | lockfile-drift check + frozen install | AUTO-GATE |
+| Build backend | **hatchling** | `build-backend = "hatchling.build"` | wheel build in CI | AUTO-GATE |
+| CVE scan (deps) | **pip-audit** | block on fixed HIGH+CRITICAL — **`\|\| true` is forbidden** | `pip-audit` exit code (see §9) | AUTO-GATE |
+| Dev-side fast feedback | **pre-commit** | ruff hooks pinned to `v0.15.x`; mypy/pyright as pre-push | local + `pre-commit.ci` | REVIEW-GATE |
+
+**Single-source ruff/mypy/pytest config** (paste into root `pyproject.toml`; this is the portfolio default — repos change values, not keys):
+
+```toml
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+requires-python = ">=3.12"
+
+[tool.ruff]
+line-length = 88
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM", "S", "C90", "RUF"]
+ignore = ["E501"]            # line length owned by the formatter
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["S101"]       # assert is expected in tests
+[tool.ruff.lint.mccabe]
+max-complexity = 10
+[tool.ruff.format]
+quote-style = "double"
+
+[tool.mypy]
+strict = true
+warn_return_any = true
+disallow_untyped_defs = true
+# pyright/pyrefly equivalent: typeCheckingMode = "strict"
+
+[tool.pytest.ini_options]
+minversion = "8.0"
+testpaths = ["tests"]
+addopts = "-ra --strict-markers --strict-config --import-mode=importlib"
+markers = [
+  "slow: > 2s",
+  "integration: requires an external service",
+  "smoke: critical path",
+]
+
+[tool.coverage.run]
+branch = true
+source = ["src"]
+[tool.coverage.report]
+fail_under = 85             # libraries: 90
+show_missing = true
+```
+
+**CI / `make verify` body** (the two MUST be identical — this is the portfolio's drift-killer; do not let them diverge):
+
+```make
+verify:
+	uv sync --frozen
+	ruff check .
+	ruff format --check .
+	mypy --strict src        # or: pyright  /  pyrefly check
+	pytest -n auto --cov=src --cov-branch --cov-report=xml --cov-fail-under=85
+	pip-audit                # no `|| true`; see SECURITY-AND-SUPPLY-CHAIN-STANDARD
+```
+
+**Drift remediation (mandatory, tracked per repo):** raise ruff to `>=0.15.x` (fixes `fare-assistant`, `habitable`, `ledger`, `swelter`, `queer-the-stacks`, `women-artist-discovery` at `>=0.6`; `tods-validate` `>=0.5`; `nearmiss` `>=0.4`); pin mypy `>=1.18` (resolves the 1.10/1.11 split); set `--cov-fail-under` everywhere it is unset (`fare-assistant`, `gtfs-scorecard`, `nearmiss`, `swelter`, `tods-validate`); migrate `jobradar` to a root `pyproject.toml` + add mypy; lift `gtfs-scorecard` config and `uv.lock` to repo root; add `pyright`/`pyrefly` benchmark before any mypy→pyright swap.
+
+---
+
+## 3. TypeScript / frontend toolchain
+
+Applies to `personal-site`, `davis-bike-hazard-map`, `trans-docs-navigator`, and any future TS surface (including Lambda handlers). One `eslint.config.mjs` (flat config; legacy `.eslintrc` is unsupported in ESLint v10). Prettier is a **separate** step, never an ESLint rule.
+
+| Concern | Tool | Canonical target | Measured by | Gate |
+|---------|------|------------------|-------------|------|
+| Type strictness | `tsc --noEmit` | `strict: true` **plus** `noUncheckedIndexedAccess`, `exactOptionalPropertyTypes`, `noImplicitReturns`, `noUnusedLocals`, `noUnusedParameters`, `noImplicitOverride`, `noFallthroughCasesInSwitch` | `tsc --noEmit` exit code | AUTO-GATE |
+| Lint | ESLint v10 flat + typescript-eslint v8 | `strictTypeChecked` + `stylisticTypeChecked` + `react-hooks/recommended` (incl. `exhaustive-deps`) + `jsx-a11y/recommended`; `--max-warnings 0`; `eslint-config-prettier` last | `eslint .` exit code | AUTO-GATE |
+| Format | Prettier 3 | `singleQuote:true, trailingComma:"all", printWidth:100, semi:true`; run via `prettier --check .` | separate CI step | AUTO-GATE |
+| Unit/component tests + coverage | Vitest v4 (`provider:"v8"`) | lines/branches/functions/statements **≥80%**, `coverage.perFile: true` | threshold exit code | AUTO-GATE |
+| E2E | Playwright | Chromium min; `retries:2`, `forbidOnly:!!process.env.CI` | suite exit code | AUTO-GATE |
+| Bundle budget | size-limit v12 | critical-path JS **≤170 KB gzip** | `andresz1/size-limit-action` PR gate | AUTO-GATE |
+| Chunk warning | Vite 8 | `build.chunkSizeWarningLimit: 500`; `target:"baseline-widely-available"` | build log + reviewer | REVIEW-GATE |
+| Bundle composition | rollup-plugin-visualizer | committed HTML artifact for any PR adding a dep >50 KB gzip; no duplicate React/date libs | reviewer | REVIEW-GATE |
+| SCA | `npm audit --audit-level=high` / OSV-Scanner | block on fixed HIGH+CRITICAL | exit code | AUTO-GATE |
+
+`noEmit: true`, `isolatedModules: true`, `moduleResolution: "bundler"`, `module: "ESNext"` are required (emit belongs to Vite/esbuild, not `tsc`).
+
+**Biome v2** is an acceptable single-binary replacement for ESLint+Prettier **only on a greenfield TS repo that does not need `react-hooks/exhaustive-deps` or type-aware rules** (`no-floating-promises`). All three current frontends use hooks → they keep the ESLint stack. A repo choosing Biome records the rule-gap audit as an ADR (REVIEW-GATE). **React Compiler** (`babel-plugin-react-compiler`) is opt-in per-file (`compilationMode:"annotation"`) and REVIEW-GATE: validate output in Vitest before enabling, then strip the now-redundant manual `useMemo`/`useCallback`.
+
+---
+
+## 4. Project layout
+
+| Rule | Requirement | Gate |
+|------|-------------|------|
+| Python package location | `src/<package>/` (PyPA src layout); `[tool.hatch.build.targets.wheel] packages = ["src/<package>"]`; never import from repo root without editable install | REVIEW-GATE (caught by `make verify` running against the installed wheel) |
+| Tests location | `tests/` at repo root, never inside `src/` | AUTO-GATE (ruff/pytest paths) |
+| Config location | exactly one root `pyproject.toml` (TS: one `package.json` + `eslint.config.mjs` + `vitest.config.ts`); no nested or duplicate config | AUTO-GATE (a repo-root config-presence check) |
+| Monorepo-style nesting | forbidden unless declared in an ADR | REVIEW-GATE |
+
+Named remediation: `gtfs-scorecard` must surface a root `pyproject.toml`/`Makefile`/`uv.lock` (its real project lives under `pipeline/`); `jobradar` must adopt `src/` + root config.
+
+---
+
+## 5. Dependency management
+
+| Rule | Requirement | Gate |
+|------|-------------|------|
+| Lockfile | `uv.lock` committed; CI installs with `uv sync --frozen` (fails if lock is stale) | AUTO-GATE |
+| Dev deps | declared in PEP 735 `[dependency-groups]` (not `[project.optional-dependencies]`) so linters/type-checkers never ship as extras | AUTO-GATE (lint of `pyproject.toml`) |
+| Hash pinning (deployed services) | `uv pip compile --generate-hashes` for the deployed requirement set | REVIEW-GATE |
+| Update bot | Dependabot **or** Renovate enabled (`minimumReleaseAge: 72h`); required for OpenSSF Scorecard `Dependency-Update-Tool` | REVIEW-GATE (artifact: committed config) |
+| Adding a dependency | new runtime dep requires a one-line rationale in the PR; new dep >50 KB gzip (TS) requires a visualizer artifact (§3) | REVIEW-GATE |
+
+GitHub Actions SHA-pinning, SBOM, Sigstore signing, and SLSA provenance are **not** specified here — see `SECURITY-AND-SUPPLY-CHAIN-STANDARD`. This document only requires that application/library dependencies are locked and scanned.
+
+---
+
+## 6. Docstrings, comments, and dead-code hygiene
+
+| Rule | Requirement | Gate |
+|------|-------------|------|
+| Module docstring | every Python module and every public TS module has a one-line purpose statement | AUTO-GATE (ruff `D`-subset where enabled; else REVIEW-GATE via checklist) |
+| Public API docstrings | every public function/class/CLI flag documents intent, args, raises/returns | REVIEW-GATE (paired with `DOCUMENTATION-STANDARD`) |
+| Comments explain *why* | comments justify non-obvious decisions, not restate code | REVIEW-GATE |
+| **No `TODO`/`FIXME`/`HACK` without a linked issue** | every such marker carries an issue URL, e.g. `# TODO(#142): ...`; bare markers fail CI | AUTO-GATE |
+| No `type: ignore` / `eslint-disable` / `# noqa` without a linked issue | each suppression carries a code *and* an issue reference; blanket ignores fail CI | AUTO-GATE |
+| Commented-out code | forbidden on `main`; delete it (git is the archive) | REVIEW-GATE |
+
+Bare-TODO gate (drop into CI; portfolio-standard regex):
+
+```bash
+# fails if any TODO/FIXME/HACK lacks a (#NNN) or full issue URL on the same line
+! grep -rEn '(TODO|FIXME|HACK)' --include='*.py' --include='*.ts' --include='*.tsx' src \
+  | grep -Ev '\(#[0-9]+\)|https?://[^ ]+/issues/[0-9]+'
+```
+
+---
+
+## 7. Code review rules
+
+| Rule | Requirement | Gate |
+|------|-------------|------|
+| PR required | no direct pushes to `main`; ≥1 approving review from someone other than the last pusher (≥2 for auth, PII, payment, safety-critical, prompt/retrieval paths) | AUTO-GATE (branch ruleset — see `CI-CD-STANDARD`) |
+| Stale reviews | dismissed on new commits | AUTO-GATE |
+| CODEOWNERS | committed; routes `.github/workflows/`, security-critical files, and `DEFINITION_OF_DONE.md` to a required reviewer | AUTO-GATE (existence) / REVIEW-GATE (routing correctness) |
+| Status checks | all CI jobs green, branch up to date (strict) | AUTO-GATE |
+| Linear history + signed commits | squash/rebase only; GPG/SSH signature verification on `main` | AUTO-GATE |
+| PR template DoD | every PR carries the `QUALITY-AND-METRICS-STANDARD` DoD checklist; merge blocked until checked | REVIEW-GATE |
+| Self-merge | prohibited on `main` (no admin bypass) | AUTO-GATE |
+
+Solo-maintainer note: most repos here have one human author. "≥1 review" is still enforced via branch protection; the maintainer satisfies it through an explicit self-review pass recorded in the PR plus all AUTO-GATEs green. The point of the gate is that *the checks ran and were acknowledged*, not headcount.
+
+---
+
+## 8. Architecture Decision Records (ADRs)
+
+| Rule | Requirement | Gate |
+|------|-------------|------|
+| Location | `docs/adr/NNNN-title.md`, MADR format (Context / Decision / Consequences / Status) | REVIEW-GATE |
+| When required | any choice that is expensive to reverse: language/runtime floor change, type-checker swap (mypy→pyright/pyrefly), Biome adoption, datastore, public API shape, security/PII boundary, **declaring a standard N/A** (§11) | REVIEW-GATE (checklist item; PR touching these without an ADR is rejected) |
+| Immutability | ADRs are append-only; supersede, never edit silently (set `Status: superseded by NNNN`) | REVIEW-GATE |
+
+---
+
+## 9. The merge-gate list (Python)
+
+A merge to `main` requires **every** AUTO-GATE green and **every** REVIEW-GATE attested. `make verify` reproduces all AUTO-GATEs locally and is byte-for-byte the CI body.
+
+```
+AUTO-GATE (CI, blocking):
+  1. uv sync --frozen                         # lock not stale
+  2. ruff check .                             # lint + imports + bandit(S) + complexity(C901≤10)
+  3. ruff format --check .                    # formatting
+  4. mypy --strict src                        # (or pyright / pyrefly check) — zero errors
+  5. pytest -n auto --cov=src --cov-branch --cov-fail-under=85   # 90 for libraries
+  6. pip-audit                                # fixed HIGH+CRITICAL block; NO `|| true`
+  7. no bare TODO/FIXME/HACK; no un-issued suppressions
+  8. single-root-config + src-layout presence check
+REVIEW-GATE (human, attested in PR):
+  9. src layout sane; public API docstrings; ADR present if §8 triggered;
+     DoD checklist complete; CODEOWNERS routing correct
+```
+
+## 9a. The merge-gate list (TypeScript)
+
+```
+AUTO-GATE (CI, blocking):
+  1. tsc --noEmit                             # strict + 7 beyond-strict flags
+  2. eslint . --max-warnings 0                # strictTypeChecked + react-hooks + jsx-a11y
+  3. prettier --check .
+  4. vitest run --coverage                    # lines/branches/functions/statements ≥80, perFile
+  5. playwright test                          # Chromium; forbidOnly in CI
+  6. size-limit                               # critical-path JS ≤170 KB gzip
+  7. npm audit --audit-level=high  (or OSV-Scanner)
+  8. no bare TODO; no un-issued eslint-disable
+REVIEW-GATE (human):
+  9. visualizer artifact for deps >50 KB; React Compiler output validated;
+     ADR if §8 triggered; DoD checklist complete
+```
+
+Accessibility (axe/Lighthouse/pa11y), observability, i18n key-parity, and AI-eval gates are **also** merge-blocking where applicable — they are specified in their own standards and surface here only as additional required status checks.
+
+---
+
+## 10. Mutation testing (quality of the tests themselves)
+
+Line/branch coverage proves code *ran*, not that assertions *catch regressions*. For repos whose correctness is load-bearing (the AI/eval harnesses, `ledger`'s no-outing guarantee, `fare-assistant` grounding guards, civic RAG citation guards), a mutation-testing pass quantifies test strength.
+
+| Metric | Target | Tool | Gate |
+|--------|--------|------|------|
+| Mutation score (core safety modules) | ≥70% killed | `mutmut` / `cosmic-ray` (Py), Stryker (TS) | REVIEW-GATE (nightly, not per-PR; surviving mutants triaged) |
+
+REVIEW-GATE because run time makes it a poor per-PR blocker; the artifact is a committed mutation report regenerated per release.
+
+---
+
+## 11. When this standard does NOT apply — declare N/A, never skip silently
+
+A repo that opts out of a rule records the decision; silence is a defect. The declaration lives in the repo's `README.md` "Standards conformance" block (or an ADR for §8 triggers) as `N/A — <reason>`.
+
+| Rule | Legitimately N/A when… | Required declaration |
+|------|------------------------|----------------------|
+| TS/frontend toolchain (§3) | repo has no TypeScript surface | `frontend-quality: N/A — pure-Python service` |
+| Coverage 90% library floor | repo is an application, not a published library | `coverage: app floor 85% — not a published library` |
+| PyPI Trusted Publisher / attestations | repo is never published to an index | `publish: N/A — internal/site only` |
+| Mutation testing (§10) | repo has no safety-critical module | `mutation: N/A — no load-bearing correctness guarantee` |
+| Playwright E2E | library/CLI with no UI | `e2e: N/A — no browser surface` |
+| Container CVE scan | repo ships no Dockerfile | `container-scan: N/A — no Dockerfile` |
+
+What is **never** N/A for shipping code: ruff, type-checking, pytest+coverage floor, complexity ≤10, `uv.lock` frozen, dependency CVE scan, no-bare-TODO, PR review, single-root-config. A repo cannot declare these out of scope.
+
+**`self-osint-monitor` is the explicit exception:** it is spec-only (no CI, no `pyproject.toml`, no tests). Its M0/M1 deliverable is to *author* this standard as scaffold — root `pyproject.toml` with the §2 block, `make verify` == CI, `src/` layout, `uv.lock` — **before** any feature code, sequenced after its consent gate. The near-duplicate pair `queer-the-stacks` / `queer-specfic-reader` (same `queer_the_stacks` package) must be reconciled (merge or formally fork-with-ADR) so standards work is not double-counted and the two do not drift.
+
+---
+
+## 12. Conformance ledger (per repo)
+
+Each repo's `README.md` carries this table so a reader sees compliance at a glance. Values, not structure, vary.
+
+| Control | This repo's value | Gate | Status |
+|---------|-------------------|------|--------|
+| ruff | `>=0.15.x`, full select set | AUTO | ✅ / ⛔ |
+| type checker | mypy --strict @1.18 | AUTO | |
+| branch coverage | ≥85% (lib: 90%) | AUTO | |
+| max-complexity | 10 | AUTO | |
+| `uv.lock` frozen | yes | AUTO | |
+| dep CVE scan | pip-audit, no `\|\| true` | AUTO | |
+| no bare TODO | enforced | AUTO | |
+| src layout | yes | REVIEW | |
+| ADRs | `docs/adr/` | REVIEW | |
+| N/A declarations | listed with reasons | REVIEW | |
+
+---
+
+Last verified: 2026-06-21 · Recheck cadence: quarterly, and on any release of ruff (minor), uv (minor), mypy/pyright/pyrefly (minor), TypeScript (minor), ESLint/typescript-eslint (major), Vitest (major), or a new PEP affecting `pyproject.toml` / packaging.

--- a/docs/standards/DOCUMENTATION-STANDARD.md
+++ b/docs/standards/DOCUMENTATION-STANDARD.md
@@ -1,0 +1,207 @@
+# Documentation Standard
+
+This standard defines the documentation every repo in this portfolio carries, what each document is responsible for, how an autonomous agent (Claude Code) reads and acts on them, and how a repo vendors and declares the cross-cutting `STANDARDS/` set. It exists so that no project re-invents structure and so that "production-ready" means the same thing across all ~18 repos.
+
+Doc index: 8 of the `STANDARDS/` set. Peers it routes to: `CODE-QUALITY-STANDARD`, `SECURITY-AND-SUPPLY-CHAIN-STANDARD`, `CI-CD-STANDARD`, `OBSERVABILITY-STANDARD`, `ACCESSIBILITY-STANDARD`, `INTERNATIONALIZATION-STANDARD`, `AI-EVALUATION-STANDARD`, `QUALITY-AND-METRICS-STANDARD`, `RESPONSIBLE-TECH-FRAMEWORK`.
+
+---
+
+## 1. The `STANDARDS/` set
+
+The portfolio standardizes rigor in one place and references it everywhere. Repos do **not** copy enforcement machinery into their own docs; they cite the standard and record only project-specific values and findings ("reference, don't repeat").
+
+| # | Standard | Owns | One-line rationale |
+|---|----------|------|--------------------|
+| 0 | `RESPONSIBLE-TECH-FRAMEWORK.md` | Ethics/privacy/bias/transparency audit *methodology*, the audit-as-artifact discipline | The portfolio's signature strength; the *how*, not the per-repo findings |
+| 1 | `CODE-QUALITY-STANDARD.md` | ruff/mypy/pytest floors, coverage thresholds, layout, `make verify`/CI parity | Same logical stack must pin to the same versions and rule sets across repos |
+| 2 | `SECURITY-AND-SUPPLY-CHAIN-STANDARD.md` | SAST/SCA/secret-scan/container-CVE, SHA-pinning, SBOM, signing, provenance | tj-actions/trivy-action 2026 compromises made mutable-tag refs an active threat |
+| 3 | `CI-CD-STANDARD.md` | Token permissions, OIDC, branch protection, CODEOWNERS, workflow SAST, concurrency | Default-write `GITHUB_TOKEN` and unscanned workflows are the systemic CI gap |
+| 4 | `OBSERVABILITY-STANDARD.md` | Structured logging, OTel, SLOs, health probes — tiered by deployment shape | ~15 repos log unstructured; no repo emits OTel spans or defines SLOs |
+| 5 | `ACCESSIBILITY-STANDARD.md` | WCAG 2.2 AA floor, axe/Lighthouse/pa11y gates, SR walkthroughs | Structural gates are strong; browser-engine checks must graduate to blocking |
+| 6 | `INTERNATIONALIZATION-STANDARD.md` | Portable catalogs (gettext `.po` / MF2-ICU), key-parity, pseudolocale | Civic repos target Spanish-dominant CA populations on hand-rolled dicts |
+| 7 | `AI-EVALUATION-STANDARD.md` | RAG faithfulness, red-team, hallucination, judge-calibration, model cards | World-class bespoke eval discipline exists; codify it as the named norm |
+| 8 | `DOCUMENTATION-STANDARD.md` (this) | Doc responsibilities, authoring rules, agent consumption, vendoring, declaration | So "production-ready" means one thing everywhere |
+| 9 | `QUALITY-AND-METRICS-STANDARD.md` | DORA tracking, Definition of Done, the merge-gate manifest | The roll-up that the gates in 1–7 report into |
+
+**Rejected alternative:** a single monolithic `STANDARDS.md`. Rejected because the doc index is the unit of vendoring and N/A declaration; one file per concern lets a repo mark exactly which concerns are out of scope.
+
+### 1.1 How a repo vendors `STANDARDS/`
+
+`STANDARDS/` is a single source of truth, not duplicated prose per repo. Vendoring mechanism, in priority order:
+
+1. **Git submodule** at `STANDARDS/` pointing at the canonical standards repo, pinned to a tag (`standards@vMAJOR.MINOR`). This is the default.
+2. **`git subtree`** for repos where contributors cannot initialize submodules (frontends handed to non-git collaborators).
+
+Whichever is used, the pin is recorded and is itself subject to the supply-chain currency rules.
+
+| Metric | Target | Measured by | Gate |
+|--------|--------|-------------|------|
+| `STANDARDS/` present and pinned | Submodule/subtree pinned to a released tag, not a floating branch | `git submodule status` shows a tag-resolved SHA; CI step asserts non-`heads/` ref | AUTO-GATE |
+| Vendored version is current | Within one minor of the latest `standards` tag | CI compares pinned tag to `gh release view --repo <standards>`; warns at 1 minor, fails at 2 | AUTO-GATE |
+| No forked/edited standard text in-repo | `STANDARDS/*.md` byte-identical to the pinned tag | CI `git diff --exit-code` against the submodule blob | AUTO-GATE |
+
+```yaml
+# .github/workflows/standards-pin.yml  (snippet)
+- name: Assert STANDARDS/ is tag-pinned and unmodified
+  run: |
+    git submodule status STANDARDS | grep -Eq '^\s' \
+      || { echo "STANDARDS/ submodule not initialized"; exit 1; }
+    git -C STANDARDS describe --exact-match --tags HEAD \
+      || { echo "STANDARDS/ not pinned to a released tag"; exit 1; }
+    git diff --quiet HEAD -- STANDARDS \
+      || { echo "STANDARDS/ has local edits — edit upstream, not here"; exit 1; }
+```
+
+**N/A:** none. Every repo vendors `STANDARDS/`. `self-osint-monitor` (spec-only) vendors it at M0 as part of the scaffold, before any M1 code.
+
+---
+
+## 2. Documents and their single responsibilities
+
+| Document | Owns | Does **not** own |
+|----------|------|------------------|
+| `README.md` | First contact: what/why/for-whom, status, quickstart, the Claude Code build entrypoint, **and the Standards Conformance table (§5)** | Detailed specs, metrics tables, audit findings |
+| `docs/ROADMAP.md` | The buildable spec: problem, product, research, design, architecture, quality targets, the phased build plan, GTM, legal, ops | Generic enforcement machinery (lives in `STANDARDS/`) |
+| `docs/RESPONSIBLE-TECH-AUDITS.md` | Project-specific ethics, bias, privacy, transparency, accessibility, security findings, checklists, and committed reports (DPIA, ACR/VPAT, threat model, data/model cards, residual-risk register) | The audit *methodology* (lives in `STANDARDS/RESPONSIBLE-TECH-FRAMEWORK.md`) |
+| `docs/adr/NNNN-*.md` | The **ADR log**: every architecturally-significant or guardrail-affecting decision, immutably, in order | Day-to-day task notes; reversible trivia |
+| `CHANGELOG.md` | Human-facing record of what changed per release, Keep a Changelog format, SemVer | Commit-by-commit history (that is `git log`) |
+| `CITATION.cff` | How to cite the work; author, ORCID, DOI when archived | Licensing (that is `LICENSE`) |
+| `SECURITY.md` | Supported versions, private disclosure channel, response SLA | Scan configuration (that lives in CI + standard 2) |
+| `CONTRIBUTING.md` | How to build, test, run `make verify`, and the DCO/sign-off + review rules | Code of conduct prose if a separate `CODE_OF_CONDUCT.md` exists |
+| `STANDARDS/*` | Cross-cutting rigor stated once | Anything project-specific |
+
+---
+
+## 3. The ADR log
+
+Decisions that change architecture, a hard guardrail, a dependency with a license/supply-chain impact, or a quality/audit threshold are recorded as ADRs. This replaces the prior practice of appending ADR prose to the roadmap's architecture section, which did not scale and was not diffable.
+
+| Metric | Target | Measured by | Gate |
+|--------|--------|-------------|------|
+| ADR log exists | `docs/adr/` with `0000-record-architecture-decisions.md` and a MADR-format template | File presence check in CI | AUTO-GATE |
+| ADRs are sequential and immutable | Filenames `NNNN-kebab-title.md`, monotonic, superseded (never edited) by a later ADR's `Status: Superseded by NNNN` | CI lints numbering gaps/dupes and forbids content changes to an `Accepted` ADR (diff on existing IDs blocks) | AUTO-GATE |
+| Guardrail changes carry an ADR | Any PR touching a no-outing/grounding/consent/identity-inference guard, `permissions:` blocks, or a coverage/eval threshold links an ADR | CODEOWNERS routes those paths to a required reviewer who confirms the ADR link | REVIEW-GATE (checklist item + committed ADR artifact) |
+
+Required ADR front matter: `Status` (`Proposed`/`Accepted`/`Superseded by NNNN`/`Deprecated`), `Date`, `Deciders`, `Context`, `Decision`, `Consequences`. Status is one of the listed values — there is no informal state.
+
+```
+docs/adr/
+  0000-record-architecture-decisions.md   # the meta-ADR; explains the log
+  0001-pin-actions-to-full-sha.md
+  0002-gettext-po-over-python-dicts.md     # e.g. an i18n repo
+```
+
+**N/A:** none for any repo past `Spec` status. A `Spec`-status repo (`self-osint-monitor`) carries the log skeleton and ADR-0001 = "scaffold standards before M1 code".
+
+---
+
+## 4. CHANGELOG / CITATION / SECURITY / CONTRIBUTING expectations
+
+These four files have one canonical shape portfolio-wide so a reader (or agent) never guesses.
+
+| File | Required content | Measured by | Gate |
+|------|------------------|-------------|------|
+| `CHANGELOG.md` | Keep-a-Changelog headings; `Unreleased` section; SemVer; every release tag has a dated entry | `git tag` ⇄ changelog parity check; `Unreleased` non-empty on a tagging PR | AUTO-GATE |
+| `CITATION.cff` | Valid CFF 1.2.0; `title`, `authors` (with ORCID where held), `version`, `date-released`, `license`; DOI once Zenodo-archived | `cffconvert --validate` in CI | AUTO-GATE |
+| `SECURITY.md` | Supported-versions table, a private disclosure channel (GitHub private vuln reporting enabled), and a stated triage SLA (≤ 72 h ack) | File presence + repo setting `private-vulnerability-reporting=enabled` via `gh api` | AUTO-GATE (presence); REVIEW-GATE (SLA accuracy) |
+| `CONTRIBUTING.md` | `make verify` as the single local gate, the PR review/sign-off rule, and a pointer to the README conformance table | Presence + a link-check that `make verify` and `STANDARDS/` are referenced | AUTO-GATE |
+
+```cff
+# CITATION.cff (minimal valid)
+cff-version: 1.2.0
+title: <repo>
+message: "If you use this work, please cite it."
+authors:
+  - family-names: Kelly-Reif
+    given-names: Chelsea
+    orcid: "https://orcid.org/0000-0000-0000-0000"
+version: 0.1.0
+date-released: 2026-06-21
+license: MIT
+```
+
+**N/A-with-reason allowances:**
+- `CITATION.cff` may be marked N/A only for repos with no scholarly/civic-reuse intent (a purely personal local-only tool). The README states: `CITATION.cff — N/A: personal local-only utility, no external reuse expected.`
+- No repo may mark `SECURITY.md` or `CHANGELOG.md` N/A. `CONTRIBUTING.md` may be N/A only for single-author `Spec`-status repos, and must flip to required at `Scaffolded`.
+
+---
+
+## 5. Every README declares which standards apply
+
+Silent skipping is the defect this section eliminates. Each README carries a **Standards Conformance** table listing all ten standards (§1) with one of three states: `Applies` (and conformant), `Applies — gap tracked in #NN` (non-conformant, with an open issue), or `N/A — <one-line reason>`. There is no fourth state and no blank cell.
+
+| Metric | Target | Measured by | Gate |
+|--------|--------|-------------|------|
+| Conformance table complete | All ten standards present, each with a non-empty state | A `verify-conformance` CI script parses the README table; missing/blank row fails | AUTO-GATE |
+| Every `N/A` has a reason | No bare `N/A` | Same script: `N/A` rows must match `N/A — .+` | AUTO-GATE |
+| Every gap links an issue | `Applies — gap tracked in #NN` resolves to an open issue | `gh issue view NN` exists and is open | AUTO-GATE |
+| `N/A` reasons are honest | Human confirms (e.g., i18n N/A genuinely is English-only single-user) | Release checklist line | REVIEW-GATE |
+
+Example README block (a privacy-first local library, e.g. `ledger`):
+
+```markdown
+## Standards Conformance
+| Standard | State |
+|----------|-------|
+| Responsible-Tech Framework | Applies (no-outing guarantee, sentinel-identity CI job) |
+| Code Quality | Applies |
+| Security & Supply-Chain | Applies — gap tracked in #142 (pip-audit ran with `|| true`; gate restored) |
+| CI/CD | Applies |
+| Observability | Applies — library tier: `--log-format json` opt-in; OTel out-of-scope (no server) |
+| Accessibility | N/A — headless library, no HTML/UI surface |
+| Internationalization | Applies — EN/ES key-parity gate; migrating dicts → gettext `.po` (#138) |
+| AI Evaluation | N/A — no model/prompt/retrieval surface |
+| Documentation | Applies |
+| Quality & Metrics | Applies |
+```
+
+Common, **pre-approved** `N/A` patterns (still must be written out):
+- Accessibility / i18n **N/A** for a headless library or CLI with no user-facing HTML and English-only operator output — but i18n N/A repos must still record the one-line entry point: "wrap user strings in `_()` to add a catalog."
+- AI-Evaluation **N/A** for any repo with no prompt/retrieval/model-version surface.
+- Observability OTel marked out-of-scope for the library/CLI tier (per standard 4's tiering) — this is a tier selection, not a skip.
+
+---
+
+## 6. Authoring rules
+
+1. **Decisions, not options.** A roadmap states the chosen stack, data source, and metric with a one-line rationale. Alternatives appear only as a short "rejected because" note. Ambiguity is a defect.
+2. **Every claim about quality is testable.** "Fast" is not a target; "p95 first-token latency < 1.5 s on the reference deployment, enforced by a k6 load test in CI" is. "Accessible" is not a target; "axe-core zero critical/serious/moderate, blocking" is.
+3. **Binary enforcement.** Every control is either **AUTO-GATE** (mechanically checkable, merge-blocking in CI) or **REVIEW-GATE** (human judgment, paired with a checklist item and a committed artifact). There is no "aspirational" third category. A control you cannot phrase as one of the two does not belong in a standard.
+4. **Reference, don't repeat.** Generic CI gates, the quality taxonomy, and audit procedures live in `STANDARDS/`. Roadmaps and READMEs link to them and record only project-specific *values* and *findings*.
+5. **Currency stamps.** Any document whose correctness depends on the outside world (laws, broker lists, framework versions, API contracts, scan tool versions) carries a `Last verified: YYYY-MM-DD` line and a `Recheck cadence:` line at the bottom.
+6. **Status is explicit.** Each repo README shows one of: `Spec` · `Scaffolded` · `In build (Mx)` · `Beta` · `Production` · `Maintained` · `Archived`.
+7. **N/A is declared, never silent** (§5). A standard that does not apply is written out with its reason.
+
+---
+
+## 7. How Claude Code should consume these docs
+
+- **Start at the README "For Claude Code" section and the Standards Conformance table.** Together they are the contract: scope, hard guardrails (the lines that must never be crossed), commands, the definition of done, and exactly which standards bind this repo.
+- **Treat `docs/ROADMAP.md` § "Implementation Plan" as the work breakdown.** Execute phases in order. Do not begin a phase until the previous phase's acceptance criteria and merge-blocking metrics pass in CI.
+- **Wire `RESPONSIBLE-TECH-AUDITS.md` checklists and the applicable `STANDARDS/` gates into CI at Phase 0**, not at the end. Audits that only happen at launch are theater. The guardrail tests (no-outing sentinels, grounding/citation guards, consent gate, no-identity-inference AST test) are the *first* CI jobs to land.
+- **Read `STANDARDS/` from the vendored, pinned copy** — never re-derive a rule from memory. If a gate threshold is needed (coverage floor, faithfulness floor, Scorecard minimum), the standard is authoritative.
+- **Record decisions as ADRs** (§3), not as roadmap edits. When the build makes a decision the roadmap didn't anticipate, open `docs/adr/NNNN-*.md`. Touching a guardrail, a `permissions:` block, or a threshold *requires* an ADR.
+- **When the spec and reality conflict** (an API changed, a metric target is infeasible on the chosen tier, a standard's gate cannot pass on the chosen platform), stop and surface the conflict with a recommended resolution and a draft ADR — do not silently diverge.
+- **Keep docs live.** Update `CHANGELOG.md` `Unreleased` in the same PR as the change. Bump `CITATION.cff` `version`/`date-released` on a release PR. Flip a conformance row from "gap tracked in #NN" to "Applies" in the PR that closes the gap.
+
+---
+
+## 8. Definition of "production-ready" (portfolio-wide)
+
+A system is production-ready when, and only when:
+
+1. All acceptance criteria in `ROADMAP.md` pass.
+2. Every applicable AUTO-GATE across `STANDARDS/` 1–7 is green on `main` (code quality, supply-chain, CI/CD, observability tier, accessibility, i18n where applicable, AI-eval where applicable), and every REVIEW-GATE has its committed artifact.
+3. Every merge-blocking gate in `QUALITY-AND-METRICS-STANDARD.md` is green on `main`.
+4. Every applicable audit in `RESPONSIBLE-TECH-AUDITS.md` has a committed, passing, release-regenerated report.
+5. The README Standards Conformance table (§5) has zero open-gap rows; every row is `Applies` or `N/A — reason`.
+6. The supply-chain floor holds: all `uses:` SHA-pinned, OpenSSF Scorecard Pinned-Dependencies ≥ 9/10 and Token-Permissions = 10/10, SBOM + signing on release artifacts.
+7. The doc set is complete and current: `README`, `docs/ROADMAP.md`, `docs/RESPONSIBLE-TECH-AUDITS.md`, `docs/adr/`, `CHANGELOG.md`, `CITATION.cff` (or declared N/A), `SECURITY.md`, `CONTRIBUTING.md`, all carrying valid currency stamps where required.
+8. There is a runnable `make verify` (or equivalent) that reproduces 1–4 locally and in CI — byte-for-byte identical invocation to the CI job, eliminating local/remote drift.
+9. There is an operations section a tired on-call human could follow at 2 a.m.
+
+A repo at `Spec` status (`self-osint-monitor`) is exempt from 1–9 except the requirement to vendor `STANDARDS/` and carry the ADR log skeleton; its ADR-0001 commits to scaffolding the standards before any M1 code.
+
+---
+
+Last verified: 2026-06-21 · Recheck cadence: per major framework change, on any `STANDARDS/` minor-version bump, or quarterly — whichever is first.

--- a/docs/standards/INTERNATIONALIZATION-STANDARD.md
+++ b/docs/standards/INTERNATIONALIZATION-STANDARD.md
@@ -1,0 +1,270 @@
+# Internationalization & Localization Standard
+
+Canonical rules for any repo that renders, stores, or transmits human-language text to a user. This is **decision-dense, not a survey**: the chosen tool and target are stated with a one-line rationale; rejected alternatives carry a "rejected because" note. A control is either **AUTO-GATE** (mechanically checkable, merge-blocking in CI) or **REVIEW-GATE** (human judgment, paired with a checklist item and a committed artifact). There is no aspirational third category. Cross-cutting rigor (coverage, SAST, supply-chain, a11y browser-engine gates) lives in its own STANDARD and is referenced, not repeated.
+
+> **Why this exists.** Eight bilingual repos store EN/ES as Python dicts or regex — `civic-rag-starter-kit`, `fare-assistant`, `ledger`, `nearmiss`, `swelter` — with no extraction tooling, no plural handling, no translator workflow, and no key-parity check. Only `trans-docs-navigator` (TS `LocaleBundle`), `personal-site` (i18next), and `habitable` (JSON catalogs) have real infra. For civic multilingual RAG explicitly targeting Spanish-dominant California populations, a hand-rolled dict is a correctness and equity defect, not a shortcut. This standard makes the catalog, the gates, and the disaggregated-quality tie-in mandatory for the surfaces that owe it, and makes "we don't need i18n" a **declared decision** rather than a silent omission.
+
+---
+
+## 1. Applicability — who owes i18n and who declares N/A
+
+i18n is **required** for any repo with a user-facing civic / public-sector / multilingual surface. Concretely, in scope today:
+
+| Repo | Surface | Required because |
+|---|---|---|
+| `civic-rag-starter-kit` | RAG answer UI/API | Civic RAG, Spanish-dominant CA users; LEP populations |
+| `trans-docs-navigator` | TS/React frontend | Public legal-doc navigation; already has `LocaleBundle` |
+| `govchat-eval` | Eval HTML reports + any served prompts/UI | Civic chat eval; user-facing report output |
+| `fare-assistant` | Transit fare answers (EN/ES dicts today) | Public transit + PII; LEP riders |
+| `gtfs-scorecard` | Transit scorecard UI | Civic transit data, public-facing |
+| `davis-bike-hazard-map` | TS/React map UI | Public civic map |
+| `personal-site` | i18next frontend | Already bilingual; reference implementation |
+| `habitable` | JSON catalogs | Already bilingual; reference for catalog parity |
+| `ledger`, `nearmiss`, `swelter` | EN/ES user-facing strings | Currently bespoke dicts → must migrate |
+
+**Explicitly out of scope** — a repo MAY declare i18n N/A when **all** hold: (a) no natural-language output to a human other than the single developer-operator; (b) English-only by design with no civic/public obligation; (c) no localized dates/numbers/currency shown to an end user. Candidate N/A repos: pure libraries/CLIs with English-only operator output (`tods-validate`, `olive-bark-logger`), single-user privacy tools (`self-osint-monitor`, `women-artist-discovery` where output is operator-only), the `queer-the-stacks`/`queer-specfic-reader` pair (reconcile the fork first — see §11).
+
+**N/A is a committed decision, never a silent skip.** A repo claiming N/A MUST ship `docs/I18N.md` containing exactly:
+
+```markdown
+# i18n status: N/A
+Reason: <one of the three out-of-scope conditions, named>
+Entry point if this changes: wrap user-facing strings in `_()` (gettext) for
+Python or `intl.formatMessage` (@formatjs) for TS; then this standard's
+AUTO-GATEs apply. See STANDARDS/INTERNATIONALIZATION-STANDARD.md §3.
+Declared: 2026-06-21 · Reviewer: <name>
+```
+
+| Control | Gate | Mechanism |
+|---|---|---|
+| In-scope repo has no catalog infra | AUTO-GATE | CI fails if repo is on the in-scope list (§1 table, mirrored in `STANDARDS/applicability.yml`) and ships no `locales/` catalog dir |
+| N/A repo missing `docs/I18N.md` | AUTO-GATE | CI greps for `docs/I18N.md` with `i18n status: N/A` and a non-empty Reason; absence fails |
+
+---
+
+## 2. Canonical stack (chosen, with rejected alternatives)
+
+| Concern | Python repos | TS/React frontends | Rationale / rejected |
+|---|---|---|---|
+| Message catalog | **gettext `.po`/`.pot`** via Babel `pybabel` | **MF2 via `@messageformat/core` + `@formatjs/cli`** | gettext is legacy-appropriate for Python and has `xgettext`/`msgfmt` CI tooling. MF2 is the **normative successor to ICU MF1** (Stable in CLDR 47, LDML TR35 Part 9). *Rejected: ICU MF1 for new TS work — superseded; bespoke dicts — no extraction/plural/parity tooling.* |
+| Message syntax (new strings) | gettext plural `Plural-Forms` header | **MF2** (`.match`, `{$count :number}`, required `*` wildcard) | New code MUST NOT introduce ICU MF1 resources. Any MF1 repo files `MIGRATION_MF2.md` (§9). |
+| Locale data | **ICU/CLDR 48.2** (`PyICU`/`babel` CLDR tables) | **Ecma-402 `Intl.*`** (CLDR-backed in V8) + `@formatjs` for messages | CLDR is the single canonical source for numbers/currency/dates/plurals/collation/lists. *Rejected: hardcoded date patterns and `%` string formatting — locale-incorrect.* |
+| Number/currency/date | `babel.numbers` / `babel.dates` (CLDR) | `Intl.NumberFormat`, `Intl.DateTimeFormat`, `Intl.RelativeTimeFormat`, `Intl.ListFormat` | Use CLDR **semantic skeletons**, not literal patterns. CLDR 48 relative date+time combos ("tomorrow at 12:30") must render. |
+| Language tags | **BCP 47 / RFC 5646** everywhere | same | Validate well-formed at input boundary; valid (registry-checked) at authoring. *Rejected: custom locale enums — drift from IANA registry.* |
+| HTTP negotiation | **RFC 9110 `Accept-Language`** + RFC 4647 lookup | same (server/Lambda) | `Vary: Accept-Language` mandatory for CDN correctness. MUST NOT use IP geolocation as sole signal. |
+| Translation interchange | **XLIFF 2.2** (OASIS CS, Mar 2025) on any TMS round-trip | same | Stable segment IDs preserve TM. *Rejected: XLIFF 1.2 for new integrations.* |
+| TMS (if/when human translation scales) | **Crowdin** (single source of truth) | same | 700+ integrations, XLIFF 2.2 + pseudolocale built-in. *Rejected: ad-hoc PRs from translators — no review state machine.* |
+| IDE lint | **i18n-ally** (VS Code), mandatory dev dep for localized-UI work | same | Flags hardcoded strings + missing keys inline before CI. |
+
+**Version pins (AUTO-GATE, §10):** CLDR/ICU ≥ **48.2**, lag ≤ 1 major release behind current stable; tzdata ≥ **2026a** (bundled in CLDR 48.2). MF2 runtime at **LDML 48.2** level. MF2 `u:` namespace functions are Draft — MUST NOT be used in shipping resources; `:number :integer :string :datetime :date :time :currency :percent :offset` are Stable and permitted.
+
+---
+
+## 3. The one-line entry point
+
+This is the migration seam every bespoke-dict repo crosses. It is intentionally trivial so "no i18n yet" is never justified by setup cost.
+
+**Python** (`civic-rag-starter-kit`, `fare-assistant`, `ledger`, `nearmiss`, `swelter`):
+
+```python
+# i18n.py — install once
+import gettext
+def get_translation(lang: str) -> gettext.NullTranslations:
+    return gettext.translation("messages", localedir="locales",
+                               languages=[lang], fallback=True)
+_ = get_translation(negotiate_lang(request)).gettext      # see §6
+ngettext = get_translation(...).ngettext                  # plural-correct
+
+# usage: replace  f"Found {n} stops"  with:
+_("Found {n} stops").format(n=n)         # extracted by pybabel
+ngettext("{n} stop", "{n} stops", n).format(n=n)
+```
+
+**TS/React** (`trans-docs-navigator`, `davis-bike-hazard-map`, `gtfs-scorecard`, `govchat-eval` reports):
+
+```tsx
+import { useIntl } from "react-intl";              // FormatJS, MF2 migration path
+const { formatMessage } = useIntl();
+formatMessage({ id: "stops.found", defaultMessage: "Found {count, number} stops" },
+              { count });
+```
+
+Extraction (`pybabel extract` / `formatjs extract`) then populates the catalog. The no-hardcoded-strings gate (§4) keeps it honest thereafter.
+
+---
+
+## 4. AUTO-GATES (merge-blocking)
+
+Every in-scope repo wires these into `make verify` (Python) or the npm `verify` script (TS) so local == CI, matching the portfolio's no-drift discipline. Each row is mechanically checkable; failure blocks merge.
+
+| # | Metric | Target | Measured by | Gate |
+|---|---|---|---|---|
+| G1 | UTF-8 encoding | 0 non-UTF-8 files/strings | `git ls-files -z \| xargs -0 file --mime-encoding` asserts `utf-8`/`us-ascii`; DB columns asserted UTF-8 in migration test | merge-blocking |
+| G2 | No hardcoded UI strings | 0 natural-language strings outside an i18n call | Python: `pybabel extract` + ratchet on count; TS: `formatjs extract` + `i18n-ally`/`eslint-plugin-formatjs` `no-literal-string` | merge-blocking |
+| G3 | BCP 47 tag validity | 0 malformed tags | Validate every tag in code/config/headers/HTML via `Intl.Locale(tag)` (TS) / `babel.Locale.parse` (PY); registry-check authored locales | merge-blocking |
+| G4 | HTML root `lang` (WCAG 3.1.1 A) | 100% pages valid `lang` | axe-core rule `html-has-lang` + `html-lang-valid` in CI (graduate from advisory — see ACCESSIBILITY-STANDARD) | merge-blocking |
+| G5 | Translation completeness + placeholder parity | 0 missing keys, 0 broken/renamed placeholders, full CLDR plural categories | `i18n-check`/custom script: every source key in every target locale; plural categories `zero/one/two/few/many/other` present where the locale requires; placeholder set identical source↔target | merge-blocking |
+| G6 | **EN/ES key-parity** (every shipping bilingual repo) | `keys(en) == keys(es)` exactly | Catalog diff in CI; symmetric-difference must be empty | merge-blocking |
+| G7 | PO compilation | 0 `msgfmt` errors/warnings | `msgfmt --check --check-format --check-domain *.po` | merge-blocking (Python) |
+| G8 | XLIFF schema validity | 0 invalid files | Apache Okapi / OASIS 2.2 schema validation on any committed `.xlf` | merge-blocking (if XLIFF present) |
+| G9 | Pseudolocale overflow | 0 clipped/overlapping nodes under ~40% expansion | `formatjs` pseudo-locale (`en-XA` analogue) + Playwright DOM-overflow assertion on key views | merge-blocking (frontends) |
+| G10 | RTL: no physical-direction CSS | 0 `margin-left/right`, `padding-left/right`, `left/right` in layout components | stylelint `csstools/use-logical` (require `margin-inline-*`, `padding-inline-*`); `ar`/`he` `dir=rtl` Playwright mirror smoke | merge-blocking (frontends) |
+| G11 | `Vary: Accept-Language` | 100% localized endpoints set it | curl/Playwright header assertion in integration test; also assert `Content-Language` present on negotiated responses | merge-blocking (servers/Lambdas) |
+| G12 | CLDR/tzdata freshness | CLDR lag ≤ 1 major, tzdata ≥ 2026a | Assert pinned version in `pyproject.toml`/`package.json` ≥ 48.2 | merge-blocking |
+
+### Pseudolocale + extraction gate — copy-paste (TS frontends)
+
+```yaml
+# .github/workflows/i18n.yml  (pin uses: to full SHAs per SECURITY-AND-SUPPLY-CHAIN-STANDARD)
+name: i18n
+on: { pull_request: { paths: ["src/**", "locales/**", "lang/**"] } }
+permissions: { contents: read }      # CI-CD-STANDARD: no default-write token
+jobs:
+  i18n:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<40-char-sha>          # v4.x.x
+      - uses: actions/setup-node@<40-char-sha>         # v4.x.x
+      - run: npm ci
+      - name: Extract — fail on hardcoded strings
+        run: |
+          npx formatjs extract 'src/**/*.{ts,tsx}' --out-file /tmp/extracted.json \
+            --throws --id-interpolation-pattern '[sha512:contenthash:base64:6]'
+          npx tsx scripts/assert-catalog-parity.ts   # G5/G6: keys + placeholders
+      - name: Generate pseudolocale (en-XA, ~40% expansion)
+        run: npx formatjs compile lang/en.json --ast --out-file lang/en-XA.json --pseudo-locale en-XA
+      - name: Pseudolocale overflow + RTL mirror smoke
+        run: npx playwright test tests/i18n/pseudo-overflow.spec.ts tests/i18n/rtl-mirror.spec.ts
+```
+
+### PO gate — copy-paste (Python repos, into `make verify`)
+
+```makefile
+.PHONY: i18n
+i18n:
+	pybabel extract -F babel.cfg -o locales/messages.pot src/      # regenerate template
+	git diff --exit-code locales/messages.pot                       # G2: POT committed & current
+	pybabel update  -i locales/messages.pot -d locales --no-fuzzy-matching
+	msgfmt --check --check-format --check-domain locales/*/LC_MESSAGES/messages.po
+	python scripts/check_catalog_parity.py        # G5/G6 keys + plural cats + placeholders
+	python scripts/check_bcp47.py                 # G3 tag well-formedness/validity
+verify: lint type test i18n                       # same target CI runs — no local/CI drift
+```
+
+---
+
+## 5. REVIEW-GATES (human judgment + committed artifact)
+
+Each is paired with a checklist item in `docs/RESPONSIBLE-TECH-AUDITS.md` (or `docs/I18N.md`) and a dated, committed artifact regenerated per release. No "aspirational."
+
+| # | Review-gate | Committed artifact | Cadence |
+|---|---|---|---|
+| R1 | **Language-of-Parts audit** (WCAG 3.1.2 AA) — every foreign-language passage carries `lang`; exceptions (proper names, technical terms) justified | `docs/audits/lang-of-parts.md` | per release + quarterly |
+| R2 | **Full-RTL QA** — human tester runs `ar`/`he`/`fa` in a real RTL browser: layout mirroring, bidi in mixed content, form-field alignment, icon directionality, date/number formatting | signed-off RTL QA checklist | per release |
+| R3 | **Translation review workflow** — every human string passes `initial → translated → reviewed → final` in the TMS before merge; no unreviewed MT in civic prod without a documented MQM/BLEU threshold | TMS export + MT-QA policy in `docs/I18N.md` | per string change |
+| R4 | **Locale-acceptance test** — per new locale, dev verifies number (decimal/grouping/negative), currency (symbol position/spacing), date/time (calendar/era/field order), address formatting against CLDR | `tests/locale_acceptance/<tag>.md` | per new locale |
+| R5 | **Language-negotiation correctness** — send `Accept-Language` for each supported locale + one unsupported; verify fallback chain (e.g. `es-MX → es → site default`) | `docs/LANGUAGE_POLICY.md` | per release + quarterly |
+| R6 | **Civic multilingual-obligations review** — map applicable law (EU EN 301 549 / Web Accessibility Directive, Canada OLA, applicable US state LEP mandates) to implementation. **Note: US federal EO 13166 was rescinded by EO 14224 (2025); verify current federal agency obligations independently — do not assume mandatory.** | `docs/compliance-matrix.md` | annual |
+| R7 | **Equitable-quality / disaggregated eval** (see §7) — sign-off that per-language quality deltas are within tolerance | per-language eval report | per model/prompt/retrieval change |
+
+---
+
+## 6. Language negotiation (servers, Lambdas, RAG APIs)
+
+`fare-assistant`, `civic-rag-starter-kit`, `gtfs-scorecard`, `govchat-eval`, `personal-site` Lambda:
+
+- Parse `Accept-Language` (RFC 9110 §12.5.4) into BCP 47 ranges with `q` weights; apply **RFC 4647 lookup**.
+- Honor user preference; MUST NOT decide locale by IP geolocation alone.
+- Set `Content-Language` and `Vary: Accept-Language` (G11) on every negotiated response.
+- Document the fallback chain in `docs/LANGUAGE_POLICY.md` (R5). Default chain: `<requested> → <primary subtag> → site default (en)`.
+- RAG specifics: the **answer locale, the retrieval-corpus locale, and the citation/grounding-guard locale must agree**; a Spanish query answered from English-only context with English citations is a defect — record corpus language coverage in the data card (RESPONSIBLE-TECH-FRAMEWORK §C/D).
+
+---
+
+## 7. Equitable quality across languages — disaggregated eval (responsible-tech tie-in)
+
+This is the link to RESPONSIBLE-TECH-FRAMEWORK §B (bias & fairness) and AI-EVALUATION-STANDARD. **Translating the UI is necessary but not sufficient**; the *answer quality* must hold across languages, or LEP users get a degraded civic service.
+
+For every AI/RAG repo serving more than one language (`civic-rag-starter-kit`, `fare-assistant`, `govchat-eval`, `trans-docs-navigator` if it serves generated text):
+
+| Metric | Target | Measured by | Gate |
+|---|---|---|---|
+| Per-language faithfulness/grounding | EN↔ES delta ≤ **5 pts** absolute, and ES meets the same absolute floor as EN (per AI-EVALUATION-STANDARD: Faithfulness ≥ 0.80) | RAGAS/DeepEval run **disaggregated by query language** on a held-out bilingual benchmark | AUTO-GATE on PRs touching prompts/retrieval/model version |
+| Per-language hallucination rate | ≤ 5% each language; no language > 2× the best | same held-out 100–500 query benchmark, split by language | AUTO-GATE |
+| Citation/grounding-guard coverage | 100% each language (no ungrounded code path — already enforced in the RAG repos) | existing citation guard, exercised with ES fixtures | AUTO-GATE |
+| Representational harm in non-EN output | none unmitigated | targeted probe suite per language | REVIEW-GATE (R7) |
+
+Benchmarks MUST include native (not machine-translated) ES queries for the CA civic domain; an all-MT benchmark hides translation-induced quality loss and is itself a finding to record.
+
+---
+
+## 8. RTL & bidi requirements (frontends)
+
+Per W3C *Additional Requirements for Bidi in HTML and CSS*:
+
+- Every natural-language element carries `dir` (`ltr`/`rtl`/`auto`) or inherits it; **user-generated content of unknown direction uses `dir="auto"`.**
+- `<bdi>` isolates embedded spans of unknown/opposite directionality; inline direction switches use `unicode-bidi: isolate`.
+- Programmatic directionality uses **isolating** controls (RLI/LRI/FSI + PDI), never embedding controls (RLE/LRE).
+- Form inputs use `dirname` to submit typing direction.
+- Layout uses **CSS logical properties only** (`margin-inline-start`, `padding-inline-end`, `border-inline`, `inset-inline`) — enforced by G10. Punctuation at bidi boundaries is tested explicitly with `ar` and `he` fixtures in CI (G10 smoke).
+
+---
+
+## 9. MF1 → MF2 migration
+
+Any repo with existing ICU MF1 resources (audit FormatJS/`react-intl` usage in `personal-site`, `trans-docs-navigator`) ships `MIGRATION_MF2.md` naming the target completion quarter. **REVIEW-GATE:** plan present; **AUTO-GATE:** no new MF1 message resources introduced after plan adoption (lint rule rejecting MF1-only syntax in new keys). gettext repos are exempt (PO is the chosen Python container; MF2 applies to the TS/JSON message layer).
+
+---
+
+## 10. Version pinning & upgrade cadence
+
+```toml
+# pyproject.toml (Python i18n repos)
+[project]
+dependencies = ["babel>=2.16", "pyicu>=2.13"]   # CLDR via ICU >= 78.3 / CLDR >= 48.2
+```
+
+```json
+// package.json (TS frontends)
+"dependencies": {
+  "@messageformat/core": "^3",        // LDML 48.2 level
+  "@formatjs/intl": "^3", "react-intl": "^7"
+}
+```
+
+- AUTO-GATE (G12): pinned CLDR/ICU ≥ 48.2, lag ≤ 1 major; tzdata ≥ 2026a.
+- Documented CLDR upgrade cadence: **at minimum once per major CLDR release cycle**, tracked in `docs/I18N.md`. Renovate/Dependabot (per SECURITY-AND-SUPPLY-CHAIN-STANDARD: digest-pinned actions, `minimumReleaseAge` 72h) opens the bump PR; the i18n gates prove the upgrade is non-breaking.
+
+---
+
+## 11. Repo-specific actions (closing the gap)
+
+| Repo | Action | First gate to land |
+|---|---|---|
+| `civic-rag-starter-kit` | Replace EN/ES dicts → gettext `.po`; add §7 disaggregated eval | G1, G2, G6, then §7 |
+| `fare-assistant` | regex/dict → `.po`; negotiate `Accept-Language`; ES faithfulness parity | G6, G11, §7 |
+| `ledger`, `nearmiss`, `swelter` | dict → `.po`; key-parity gate | G6, G7 |
+| `trans-docs-navigator` | confirm MF2/`LocaleBundle` parity + pseudolocale + RTL gates; fix the one tag-pinned `uses:` in `deploy-aws-preview.yml` (supply-chain, cross-ref) | G5, G9, G10 |
+| `personal-site` | reference i18next repo; audit MF1→MF2 (§9) | G9 (reference) |
+| `habitable` | JSON catalogs → wire G5/G6 parity gate | G6 |
+| `gtfs-scorecard` | add UI catalog; note real `pyproject.toml` lives under `pipeline/` — wire gates there | G1, G2, G4 |
+| `davis-bike-hazard-map` | pseudolocale + RTL gates on the map UI | G9, G10 |
+| `govchat-eval` | served HTML report `lang` + bidi; disaggregated eval | G4, §7 |
+| N/A candidates (`tods-validate`, `olive-bark-logger`, `self-osint-monitor`, `women-artist-discovery`) | commit `docs/I18N.md` N/A declaration | N/A-declaration gate |
+| `queer-the-stacks` / `queer-specfic-reader` | **reconcile the undocumented fork before declaring i18n status** — they share package `queer_the_stacks`; one declaration must not silently cover both | reconcile first |
+| `self-osint-monitor` | i18n decision is part of M0/M1 scaffold, not a retrofit; default N/A (single-user) with declaration | N/A-declaration gate |
+
+---
+
+## 12. Cross-references (reference, don't repeat)
+
+- **Browser-engine a11y gates** (axe/pa11y graduated to blocking, WCAG 2.2 AA, target-size 2.5.8): ACCESSIBILITY-STANDARD. G4 here depends on that graduation.
+- **SHA-pinned `uses:`, `permissions: contents: read`, OIDC, Scorecard** on the i18n workflow: SECURITY-AND-SUPPLY-CHAIN-STANDARD + CI-CD-STANDARD.
+- **Faithfulness/hallucination/judge-calibration thresholds** underpinning §7: AI-EVALUATION-STANDARD.
+- **Coverage floors, ruff/mypy pins, single `pyproject.toml`, `make verify == CI`**: CODE-QUALITY-STANDARD. The i18n target joins `make verify`.
+- **Data card / model card / disaggregated fairness narrative**: RESPONSIBLE-TECH-FRAMEWORK §B, §C, §D.
+- **Metric table shape** (Metric/Target/Measured-by/Gate/Owner) mirrored into each repo's `ROADMAP.md`: QUALITY-AND-METRICS-STANDARD.
+
+---
+
+Last verified: 2026-06-21 · Recheck cadence: per Unicode CLDR/ICU major release (next ≥ 49) and on any WCAG, BCP 47/RFC 5646, RFC 9110, XLIFF, or US/EU/state language-access legal change. Confirm CLDR 48.2 / ICU 78.3 / MF2 LDML 48.2 / WCAG 2.2 are still current at build time.

--- a/docs/standards/OBSERVABILITY-STANDARD.md
+++ b/docs/standards/OBSERVABILITY-STANDARD.md
@@ -1,0 +1,294 @@
+# Observability Standard
+
+This is the canonical definition of how every repo in this portfolio emits, structures, and acts on telemetry. **OpenTelemetry (OTel) is the only instrumentation API** — chosen because it is the 2026 vendor-neutral default with stable Python/JS trace and metric SDKs, so a repo can switch backends (Grafana, Sentry, self-hosted) without re-instrumenting. *Rejected:* per-vendor SDKs (Datadog, raw Sentry tracing) — they lock the instrumentation to a billing relationship; bespoke JSON-lines logging — no correlation IDs, no propagation, no semconv.
+
+The standard is **tiered by deployment shape**, because instrumenting a local-only CLI like a hosted Lambda is waste, and skipping a hosted civic RAG service is negligence. Each repo declares its tier in `docs/ROADMAP.md`. There is no fourth, "aspirational" enforcement category: a control is **AUTO-GATE** (mechanically checkable, merge-blocking in CI) or **REVIEW-GATE** (human judgment, paired with a checklist item and a committed artifact).
+
+> **Reference, don't repeat.** The rigor lives here once. A repo records only its *values*: its `OTEL_SERVICE_NAME`, its SLO targets, its span-coverage artifact, its declared tier. It does not restate the gates.
+
+---
+
+## 0. Tiers — which rules apply
+
+Declare the tier in `docs/ROADMAP.md` under a `## Observability` heading. A repo that skips a tier control must record **N/A-with-reason** in that section; silent omission is a defect caught by the tier-declaration gate (§7).
+
+| Tier | Repos (this portfolio) | What is in scope |
+|------|------------------------|------------------|
+| **A — Hosted service / Lambda** | fare-assistant, jobradar, civic-rag-starter-kit, govchat-eval (hosted eval API), personal-site Lambdas, davis-bike-hazard-map (API tier), gtfs-scorecard (pipeline service) | Full stack: OTel traces+metrics, structured JSON logs with trace correlation, RED/USE, `/livez`+`/readyz`, SLOs, burn-rate alerts, dashboards-as-code, PII-safe-logging gate |
+| **B — Frontend / PWA** | personal-site (SPA), davis-bike-hazard-map (map UI), trans-docs-navigator | Core Web Vitals RUM (LCP/INP/CLS), browser OTel spans on API calls, `traceparent` propagation to the backend, Lighthouse-CI CWV gate |
+| **C — Library / CLI** | ledger, nearmiss, swelter, tods-validate, women-artist-discovery, civic-ai-eval-harness (lib), olive-bark-logger, queer-the-stacks/queer-specfic-reader, self-osint-monitor | Opt-in `--log-format json` (structlog); OTel **optional and documented out-of-scope**; no SLO/health requirement |
+
+A repo with both a service and a CLI (e.g. govchat-eval) applies Tier A to the service surface and Tier C to the CLI surface. State both.
+
+**Repo-specific carries (record values, not gates):**
+- `davis-bike-hazard-map` has Prometheus + Sentry with `tracesSampleRate: 0` — raise to a sampled value and wire OTLP; it is the closest Tier-A/B repo to conformance.
+- `personal-site` already ships a Core Web Vitals RUM beacon — **it is the Tier-B reference implementation**; other frontends copy its `web-vitals` → beacon path.
+- `civic-rag-starter-kit`, `trans-docs-navigator`, `fare-assistant`, `personal-site` Lambdas currently emit bespoke JSON-lines / `console.error` — these are the migration targets for §3.
+
+---
+
+## 1. Traces (Tier A; Tier B for browser spans)
+
+**Tool:** `opentelemetry-distro` zero-code auto-instrumentation (Python) / `@opentelemetry/sdk-web` (TS). *Rejected:* manual span wiring as the baseline — auto-instrumentation covers Flask/FastAPI/httpx/requests/SQLAlchemy/Redis for free; reserve manual spans for business operations the auto-instrumentor can't see (a retrieval step, a judge call).
+
+Run Python services under `opentelemetry-instrument python app.py`. Export via OTLP — gRPC `:4317` or HTTP `:4318` — to an OTel Collector, never directly to a backend. Use `BatchSpanProcessor` in production.
+
+**Required env (in the container manifest, not code):**
+
+```dotenv
+OTEL_SERVICE_NAME=fare-assistant          # non-empty, == service.name resource attr
+OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+OTEL_PROPAGATORS=tracecontext,baggage     # W3C Trace Context Level 1
+OTEL_PYTHON_LOG_CORRELATION=true          # injects trace_id/span_id into logs
+```
+
+**Span attribute contract** (OTel Semantic Conventions **v1.42.0** — pin this version; do not invent attribute names outside the semconv namespace):
+
+| Span kind | Required attributes |
+|-----------|---------------------|
+| HTTP **server** | `http.request.method`, `url.path`, `url.scheme`, `http.route`, `http.response.status_code`, `error.type` (on error) |
+| HTTP **client** | `http.request.method`, `server.address`, `server.port`, `url.full`, `http.response.status_code`, `error.type` (on error) |
+| **All spans** (resource) | `service.name`, `service.version`, `deployment.environment` |
+
+W3C `traceparent` (`00-<32hex>-<16hex>-<2hex>`) and `tracestate` propagate on every inbound/outbound HTTP call. All-zero trace-id or parent-id is forbidden; generate a fresh trace-id when no incoming header exists. For Tier-B frontends, the `fetch`/`axios` layer **must** inject `traceparent` on API requests so browser traces chain to backend traces.
+
+| Metric | Target | Measured by | Gate |
+|--------|--------|-------------|------|
+| `OTEL_SERVICE_NAME` set & non-empty | required | CI asserts env present in container manifest pre-deploy | AUTO-GATE |
+| HTTP route span coverage | every registered route produces ≥1 span with `http.request.method` + `http.response.status_code` | integration test enumerates routes, asserts spans | AUTO-GATE |
+| `traceparent` on cross-service calls | present, valid, non-zero | integration test asserts header on all service-to-service requests | AUTO-GATE |
+| Span attribute names | semconv v1.42.0, no deprecated (`net.peer.ip`→`network.peer.address`) or invented names | semconv linter (OPA/custom) on every PR | AUTO-GATE |
+| Span coverage report | 100% of HTTP routes instrumented | `observability/span-coverage.md`, owner sign-off per release | REVIEW-GATE |
+
+---
+
+## 2. Metrics — RED & USE (Tier A)
+
+**Tool:** OTel metrics SDK + `PeriodicExportingMetricReader` (60 s) → Collector → Prometheus/Mimir. Names follow Prometheus convention: lowercase `snake_case`, base UCUM units (`seconds` not `ms`, `bytes` not `mb`), `_total` on counters.
+
+**RED per public endpoint** — define exactly these:
+
+```text
+<service>_http_requests_total            counter   labels: method, route, status_code
+<service>_http_request_duration_seconds  histogram labels: method, route
+                                         buckets: .005 .01 .025 .05 .1 .25 .5 1 2.5 5 10
+<service>_http_request_errors_total      counter   labels: method, route, error_type
+```
+
+**USE per resource:** `process_cpu_seconds_total`, `process_resident_memory_bytes`, plus a custom saturation gauge per bounded resource (queue depth, connection-pool in-use). For the RAG/eval repos, add domain saturation where it bounds capacity (e.g. embedding-queue depth, LLM-token-budget remaining) — these are the saturation SLIs that actually predict failure.
+
+**Cardinality rule (hard):** labels never carry user IDs, emails, request IDs, or any unbounded value. This is both a cost control and a privacy control — a user-ID label is PII in the metrics store.
+
+| Metric | Target | Measured by | Gate |
+|--------|--------|-------------|------|
+| Metric naming | base units only; `_total` on every monotonic counter; no `_ms`/`_mb`/`_gb` suffix | `promtool lint` + custom linter in CI | AUTO-GATE |
+| Label cardinality | no `user_id`/`email`/`request_id`/unbounded labels | custom linter scans metric definitions | AUTO-GATE |
+| RED present per endpoint | requests_total + duration_seconds + errors_total exist for every public route | metrics-registry test | AUTO-GATE |
+
+---
+
+## 3. Logs — structured JSON with trace correlation & PII redaction (Tier A AUTO-GATE; Tier C opt-in)
+
+The OTel **Logs** Python SDK is still in Development in 2026, so do **not** use the native OTel Logs SDK directly. Use the **Log Bridge pattern**: `structlog` with a JSON renderer → stdout; the OTel Collector `filelog` receiver reads stdout JSON and converts to OTLP LogRecord. *Rejected:* `python-json-logger` as the default — structlog's processor pipeline is richer and is what injects trace context cleanly. *Rejected:* native OTel Logs SDK — not stable; pinning to it now buys churn.
+
+**structlog trace-context processor (the load-bearing snippet):**
+
+```python
+import logging, structlog
+from opentelemetry import trace
+
+def add_trace_context(_, __, event: dict) -> dict:
+    span = trace.get_current_span()
+    ctx = span.get_span_context() if span else None
+    if ctx and ctx.is_valid:
+        event["trace_id"] = format(ctx.trace_id, "032x")  # 32-char hex
+        event["span_id"] = format(ctx.span_id, "016x")    # 16-char hex
+        event["trace_flags"] = ctx.trace_flags
+    return event
+
+structlog.configure(
+    processors=[
+        structlog.contextvars.merge_contextvars,
+        structlog.processors.add_log_level,        # -> severity
+        structlog.processors.TimeStamper(fmt="iso", utc=True),
+        add_trace_context,
+        structlog.processors.EventRenamer("message"),
+        structlog.processors.JSONRenderer(),
+    ],
+)
+```
+
+**Every Tier-A log record MUST contain:** `timestamp` (ISO 8601 UTC), `severity` (SeverityText), `service.name`, `trace_id`, `span_id`, `message`, and a structured attributes map. Never use `%s` format strings for structured fields — always pass `extra={}` / structlog kwargs.
+
+**PII / secrets — the explicit hard gate (OWASP Top 10:2025 A09).** NEVER log: passwords, session/access tokens, API keys, encryption keys, DB connection strings, PII/PHI, payment-card data, government IDs, or — for the civic/transit repos — rider identities and trip endpoints (fare-assistant), or any field that could deanonymize (ledger's no-outing guarantee, women-artist-discovery's no-identity-inference invariant extend *into the log stream*). De-identify (delete/pseudonymize) before logging; encode log data to prevent log injection.
+
+| Metric | Target | Measured by | Gate |
+|--------|--------|-------------|------|
+| Log records are valid JSON | 100% of stdout lines parse | integration test pipes captured stdout through `jq .`; non-zero exit blocks merge | AUTO-GATE |
+| Required field presence | `timestamp`,`severity`,`service.name`,`trace_id`,`span_id`,`message` on every record | `jq` field-presence assertion in the same test | AUTO-GATE |
+| **No secrets/PII in logs** | zero log calls pass a variable named `password`,`token`,`secret`,`api_key`,`ssn`,`dob`,`email`,`credit_card` (extend with repo-specific identity fields) | `bandit` + custom `semgrep` rules on every PR | **AUTO-GATE** |
+| Trace correlation | `trace_id` in response logs == incoming `traceparent` trace-id | integration test | AUTO-GATE |
+| Data-classification audit | no logged field exceeds the service's permitted PII level | `compliance/logging-audit-YYYY-QN.md`, quarterly | REVIEW-GATE |
+
+**Tier C (libraries/CLIs):** offer an opt-in `--log-format json` flag backed by `structlog`; default human-readable is fine. The valid-JSON and required-field gates apply **only when `--log-format json` is selected**. OTel tracing is optional and **documented as out-of-scope** in the repo's `## Observability` section (N/A-with-reason). `olive-bark-logger`, being a logger, is the reference for the structlog JSON renderer config.
+
+**The PII-in-logs gate is the one non-tiered control: it is AUTO-GATE in every repo that logs anything, Tier A/B/C alike.** Privacy-first repos do not get to skip it; they are the reason it exists.
+
+---
+
+## 4. SLOs, SLIs & error budgets (Tier A)
+
+Per the Google SRE Workbook. SLIs are ratio metrics `good_events / total_events`; SLOs are a target % over a **rolling 4-week window**; error budget = `(100% − SLO) × total_events`. **Do not target 100%.** Keep internal SLOs stricter than any public SLA.
+
+**Minimum SLIs per Tier-A service:** availability (1 − HTTP-5xx ratio), latency (p99 ≤ threshold), saturation. For LLM/RAG routes, latency uses the portfolio's existing budgets from `QUALITY-AND-METRICS-STANDARD.md §2`: **p95 first-token < 1.5 s, full-response < 6 s**; non-LLM routes **p95 < 500 ms**.
+
+**Default SLO targets by service shape** (a repo overrides values, not structure):
+
+| Service shape | Availability SLO | Latency SLI/SLO | Notes |
+|---------------|------------------|-----------------|-------|
+| Civic/benefits hosted (fare-assistant, civic-rag, govchat) | 99.5% / 4wk | p99 < 500 ms non-LLM; p95 first-token < 1.5 s LLM | benefits tooling — error budget spends conservatively |
+| Internal/eval API (govchat-eval, jobradar) | 99.0% / 4wk | p99 < 1 s | tolerant; not user-facing-critical |
+| Static-ish edge (personal-site Lambdas) | 99.9% / 4wk | p99 < 300 ms | trivially cheap to keep high |
+
+**Committed SLO file** — `slos/*.yaml`, schema-validated:
+
+```yaml
+name: fare-assistant-availability
+sli_query: 1 - (sum(rate(fare_assistant_http_request_errors_total[5m])) / sum(rate(fare_assistant_http_requests_total[5m])))
+target_percentage: 99.5
+window_days: 28
+error_budget_policy: freeze-features-on-50pct-burn
+```
+
+| Metric | Target | Measured by | Gate |
+|--------|--------|-------------|------|
+| SLO definition exists | `slos/*.yaml` present, passes JSON-Schema (`name`,`sli_query`,`target_percentage`,`window_days`,`error_budget_policy`) | schema validation in CI; no SLO file = no prod deploy | AUTO-GATE |
+| Quarterly SLO review | error-budget consumption vs target reviewed; SLI-vs-complaint alignment checked | ADR committed within 5 business days | REVIEW-GATE |
+
+---
+
+## 5. Alerting — multi-window multi-burn-rate (Tier A)
+
+Per the SRE Workbook. For each SLO, **both** the long- and short-window conditions must be true to fire (kills flapping). Implement with Prometheus recording rules; validate with `promtool`.
+
+| Tier | Burn rate | Long window | Short window | Budget consumed | Route |
+|------|-----------|-------------|--------------|-----------------|-------|
+| Page (critical) | > 14.4× | 1h | 5m | 2% / month | PagerDuty |
+| Page (high) | > 6× | 6h | 30m | 5% / month | PagerDuty |
+| Ticket | > 1× | 3d | 6h | 10% / month | ticketing |
+
+```yaml
+# alerts/burn-rate.yml  (promtool check rules MUST pass)
+groups:
+  - name: fare-assistant-slo-burn
+    rules:
+      - alert: ErrorBudgetBurnCritical
+        expr: |
+          (slo:error_rate:ratio_rate1h{service="fare-assistant"} > (14.4 * 0.005))
+          and
+          (slo:error_rate:ratio_rate5m{service="fare-assistant"} > (14.4 * 0.005))
+        labels: { severity: page }
+      - alert: ErrorBudgetBurnHigh
+        expr: |
+          (slo:error_rate:ratio_rate6h{service="fare-assistant"} > (6 * 0.005))
+          and
+          (slo:error_rate:ratio_rate30m{service="fare-assistant"} > (6 * 0.005))
+        labels: { severity: page }
+```
+
+| Metric | Target | Measured by | Gate |
+|--------|--------|-------------|------|
+| Alert rules valid | zero errors | `promtool check rules alerts/*.yml` in CI | AUTO-GATE |
+| Burn-rate tiers complete | critical (14.4×, 1h+5m) **and** high (6×, 6h+30m) defined per SLO | rule-presence linter | AUTO-GATE |
+
+---
+
+## 6. Health & readiness endpoints (Tier A)
+
+Distinct endpoints, distinct semantics (Kubernetes probe contract):
+
+- `GET /livez` — process alive, not deadlocked. **No external calls.** Returns `200 {"status":"ok"}` in **< 200 ms**.
+- `GET /readyz` — ready for traffic, **including** dependency checks. `200 {"status":"ok","checks":{"db":"ok","cache":"ok"}}` or `503` with failing component detail.
+- Both **unauthenticated** and **excluded from access logs** (no auth middleware, no log noise).
+
+A Lambda/serverless Tier-A repo without a long-lived process declares `/livez`+`/readyz` **N/A-with-reason** (cold-start health is the platform's; readiness is the dependency check it runs on init).
+
+```yaml
+# k8s probes (OPA Conftest rejects a Deployment missing either, or pointing both at one path)
+livenessProbe:  { httpGet: { path: /livez,  port: 8080 }, periodSeconds: 10, failureThreshold: 3 }
+readinessProbe: { httpGet: { path: /readyz, port: 8080 }, periodSeconds: 5 }
+```
+
+| Metric | Target | Measured by | Gate |
+|--------|--------|-------------|------|
+| Both probes present, distinct paths | `livenessProbe`+`readinessProbe` defined, different paths | `kubeval` + OPA Conftest on manifest changes | AUTO-GATE |
+| `/livez` semantics | < 200 ms, no dependency calls | contract test | AUTO-GATE |
+| `/readyz` semantics | reflects dependency health (503 on failure) | contract test with dependency stubbed down | AUTO-GATE |
+
+---
+
+## 7. Local-dev parity & tier declaration
+
+Observability must be reproducible locally or it rots. `make verify` runs the same JSON-log, semconv, metric-naming, and `promtool` lints CI runs — byte-for-byte where the repo already mirrors CI in its Makefile (the portfolio's existing `make verify` discipline extends to telemetry checks; no new mechanism).
+
+Ship a `docker-compose.observability.yml` bringing up an OTel Collector + Grafana LGTM stack (Tempo/Mimir/Loki/Pyroscope) so a developer sees their own traces. The Collector pipeline is fixed:
+
+```yaml
+receivers:  [otlp, filelog]            # otlp: grpc 4317 + http 4318; filelog: stdout JSON
+processors: [memory_limiter, batch, resource]   # memory_limiter FIRST
+exporters:  [otlphttp/tempo, prometheusremotewrite/mimir, loki, otlphttp/pyroscope]
+# TLS on all exporter connections in prod.
+```
+
+| Metric | Target | Measured by | Gate |
+|--------|--------|-------------|------|
+| Tier declared | `## Observability` section names tier A/B/C and lists any N/A-with-reason | doc-lint asserts heading + tier token present | AUTO-GATE |
+| Local telemetry parity | `make verify` runs the same telemetry lints as CI | CI diff of lint invocations | AUTO-GATE |
+
+---
+
+## 8. Frontends / PWAs — Core Web Vitals (Tier B)
+
+Instrument with `@opentelemetry/sdk-web` (stable spans for interactions + API calls) plus `@opentelemetry/browser-instrumentation` (experimental: navigation/resource timing). Emit Core Web Vitals via the `web-vitals` library as OTel metric events with `trace_id` for correlation. **`personal-site` already does the RUM beacon — copy it into davis-bike-hazard-map and trans-docs-navigator.**
+
+**Field SLI (p75 of real-user sessions) and the Lighthouse-CI lab gate share thresholds:**
+
+| Metric | Target (p75 field SLI = lab gate) | Measured by | Gate |
+|--------|-----------------------------------|-------------|------|
+| LCP | < 2500 ms | Lighthouse CI on main routes (lab); RUM p75 in Grafana (field) | AUTO-GATE (lab) |
+| INP | < 200 ms | as above | AUTO-GATE (lab) |
+| CLS | < 0.1 | as above | AUTO-GATE (lab) |
+| ≥75% of sessions "good" per CWV | met | RUM dashboard | REVIEW-GATE |
+
+Lighthouse-CI lab numbers are the merge gate; field p75 RUM data is tracked separately (lab is a regression tripwire, not ground truth). This extends, and shares the budget envelope with, the existing Lighthouse gates in `QUALITY-AND-METRICS-STANDARD.md §2`.
+
+---
+
+## 9. Continuous profiling (REVIEW-GATE only — alpha, do not auto-gate)
+
+The OTel **Profiles** signal is alpha in 2026; **do not depend on its API stability** and do not make it merge-blocking. Where a Tier-A service has profiling appetite, use `pyroscope-otel` → Pyroscope 2.0 / Grafana Cloud Profiles, correlated to traces via `trace_id`. Pin the profiler client version.
+
+| Metric | Target | Measured by | Gate |
+|--------|--------|-------------|------|
+| Profiling runbook | CPU+heap collected in prod, overhead ≤ 1%, profiles trace-correlated, endpoint configured | runbook entry per service onboarding | REVIEW-GATE |
+
+---
+
+## 10. When this standard does NOT apply
+
+- **Tier C OTel tracing/metrics/SLOs/health:** N/A for libraries and local-only CLIs (ledger, nearmiss, swelter, tods-validate, women-artist-discovery, queer-the-stacks/queer-specfic-reader, self-osint-monitor as a CLI). Declare it: `Observability: Tier C — OTel tracing out-of-scope (no network surface). Opt-in --log-format json only.`
+- **`/livez`/`/readyz`:** N/A for non-long-lived serverless surfaces — declare with reason.
+- **CWV / Lighthouse:** N/A for non-UI repos.
+- **The PII/secrets-in-logs gate is NEVER N/A** for any repo that logs.
+- **`self-osint-monitor`** is spec-only today: this standard is authored into its **M0/M1 scaffold** (structlog JSON, tier declaration, PII-log gate) before feature code, not retrofitted — and only after its consent gate per `RESPONSIBLE-TECH-FRAMEWORK.md`.
+
+Any skipped control is recorded as **N/A-with-reason** in the repo's `## Observability` section. Silent omission fails the tier-declaration gate (§7).
+
+---
+
+## Metrics ledger (per repo)
+
+Each Tier-A/B repo's `docs/ROADMAP.md` carries an **Observability** table in the portfolio-standard shape (`Metric | Target | Measured by | Gate | Owner`), filled with that repo's *values* — its service name, its SLO targets, its span-coverage artifact path. The gates themselves are not restated; they live here.
+
+Last verified: 2026-06-21 · Recheck cadence: per OpenTelemetry Semantic Conventions release (currently v1.42.0), OTel Python Logs SDK GA, Core Web Vitals threshold revision, and OWASP Top 10 revision — confirm all four at build time.

--- a/docs/standards/QUALITY-AND-METRICS-STANDARD.md
+++ b/docs/standards/QUALITY-AND-METRICS-STANDARD.md
@@ -1,0 +1,189 @@
+# Quality & Metrics Standard
+
+This is the canonical definition of the quality attributes every project targets and the mechanism by which their metrics are **enforced** rather than merely measured. It is the **spine** of `STANDARDS/`: it owns the vocabulary (ISO/IEC 25010:2023), the delivery-health backbone (DORA), and the merge-gate model. The cross-cutting depth for each domain lives in a dedicated sibling standard — this document **points to** them and does not restate them.
+
+Projects override the *values* (a hobby logger needs less than a public benefits tool) but not the *structure*.
+
+> **On "100% enforcement."** A metric is enforced when failing it **blocks the merge** — not when a dashboard shows it red after the fact. The honest ceiling: everything mechanically checkable is a hard CI gate; everything requiring judgment (genuine bias, accessibility-of-experience, ethical edge cases) is a *required human sign-off gate* with a checklist and a committed artifact. We enforce 100% of the checkable set automatically and 100% of the judgment set via blocking review. We never pretend a judgment call is fully automatable, and there is **no third "aspirational" category**.
+
+## Sibling standards (reference, don't repeat)
+
+This document is the index. Each row below is enforced **in** the named standard; the cell here states only the one-line interface this spine depends on.
+
+| Domain | Owning standard | Interface this spine depends on |
+|--------|-----------------|---------------------------------|
+| Code quality / toolchain | `CODE-QUALITY-STANDARD.md` | ruff ≥0.15.x, mypy `--strict`, branch coverage ≥85% (libs ≥90%), single `pyproject.toml`, `uv sync --frozen`, `make verify` byte-equal to CI |
+| CI/CD hardening | `CI-CD-STANDARD.md` | top-level `permissions: contents: read`, OIDC-only cloud creds, `zizmor` on workflow PRs, concurrency groups, committed CODEOWNERS + branch ruleset |
+| Security & supply chain | `SECURITY-AND-SUPPLY-CHAIN-STANDARD.md` | ASVS 5.0 L2; SHA-pinned actions; Semgrep/CodeQL/gitleaks/pip-audit/Trivy blocking on HIGH+CRITICAL; SBOM + cosign + SLSA L2 |
+| Release & versioning | `RELEASE-AND-VERSIONING-STANDARD.md` | SemVer 2.0.0; signed tags; CHANGELOG entry per release; tag-triggered `make verify` re-run; Trusted Publishing (OIDC, no stored tokens); version-consistency gate |
+| Observability | `OBSERVABILITY-STANDARD.md` | structured JSON logs, OTel spans, `/livez` + `/readyz`, SLOs + burn-rate alerts (tiered by deployment shape) |
+| Accessibility | `ACCESSIBILITY-STANDARD.md` | WCAG 2.2 AA floor; axe zero critical/serious/moderate; pa11y **blocking**; screen-reader walkthrough + ACR per release |
+| Internationalization | `INTERNATIONALIZATION-STANDARD.md` | portable catalogs (gettext `.po` / MF2-ICU); EN/ES key-parity + placeholder-parity + pseudolocale gates |
+| AI evaluation | `AI-EVALUATION-STANDARD.md` | RAGAS faithfulness ≥0.80; hallucination ≤5%; Garak/Promptfoo OWASP-LLM red-team; judge-calibration agreement ≥0.80 / κ ≥0.60 |
+
+**Rule:** a repo records project-specific *values and findings* (its measured coverage, its ACR rows, its red-team results) in its own `ROADMAP.md` / audit artifacts. It does **not** restate the rigor — it cites the standard.
+
+---
+
+## The enforcement model (binary, no exceptions)
+
+Every control in every standard is exactly one of:
+
+- **AUTO-GATE** — mechanically checkable, **merge-blocking in CI**, required status check under branch protection. Example: `pytest --cov-fail-under=85`.
+- **REVIEW-GATE** — requires human judgment, paired with **(a)** a checklist item in the PR template and **(b)** a committed artifact (signed walkthrough, ACR, threat model, risk register). The transition is blocked until the box is checked and the artifact is in the diff or linked.
+
+A control that is "run but `|| true`," "advisory," or "on the roadmap" is a **defect**. The portfolio has live instances of this defect (`pip-audit || true` in `ledger`/`nearmiss`; `continue-on-error` pa11y in the eval harnesses; `tracesSampleRate: 0` in `davis`); the owning standards close each one.
+
+---
+
+## Quality-attribute taxonomy — ISO/IEC 25010:2023
+
+**Updated to the 2023 second edition** (replaces 2011). Nine top-level product-quality characteristics; the deltas from 2011 are load-bearing and called out. Each feature/story **must** map to ≥1 measurable acceptance criterion under ≥1 characteristic; an untested characteristic is an **out-of-scope violation** and must be declared N/A-with-reason (see *Scoping*). **Recheck the standard version at build time.**
+
+> 2023 deltas you must use the new vocabulary for: *Usability* → **Interaction Capability** (adds inclusivity, self-descriptiveness, user-engagement); *Portability* → **Flexibility** (adds **scalability**); Security adds **resistance**; and **Safety** is a brand-new ninth characteristic. ISO 25010:2023 also defines a *Quality-in-Use* model (Effectiveness, Efficiency, Satisfaction, Freedom-from-Risk, Context-Coverage) — used in REVIEW-GATE acceptance criteria for civic/public-facing repos.
+
+### 1. Functional Suitability *(completeness, correctness, appropriateness)*
+- **Targets:** all acceptance criteria pass; no `P0`/`P1` open at release; acceptance tests mapped 1:1 to roadmap features.
+- **Gate (AUTO):** full suite green; mapping checked in CI.
+
+### 2. Performance Efficiency *(time behaviour, resource utilization, capacity)*
+- **Targets (web/API default):** p95 server response <500 ms (non-LLM routes); p95 first-token <1.5 s and full-response <6 s (LLM routes); Lighthouse Performance ≥90; critical-path JS <200 KB gzip. Regression budget: no numeric regression >10% vs committed baseline without product-owner sign-off.
+- **Gate (AUTO):** k6/Locust asserts p95 budgets; Lighthouse CI asserts score + bundle budgets; baseline artifact committed per PR touching latency-sensitive paths.
+
+### 3. Compatibility *(co-existence, interoperability)*
+- **Targets:** two latest versions of Chrome/Firefox/Safari/Edge; documented minimum Node/Python runtimes; no undeclared global state; declared, versioned API contracts.
+- **Gate (AUTO):** Playwright cross-browser smoke; runtime/dependency matrix in CI.
+
+### 4. Interaction Capability *(recognizability, learnability, operability, user-error protection, engagement, inclusivity, self-descriptiveness, user assistance)* — *formerly Usability*
+- **Targets:** **WCAG 2.2 AA** floor (AAA where already achieved, e.g. `personal-site`); keyboard-only completion of every primary task; visible focus; `prefers-reduced-motion` respected; readable at 200% zoom / 320 px; 2.5.8 target-size ≥24×24 CSS px; real EN/ES where civic.
+- **Gate:** **see `ACCESSIBILITY-STANDARD.md` and `INTERNATIONALIZATION-STANDARD.md`.** AUTO: axe zero critical/serious/moderate; pa11y-ci **blocking**; Lighthouse a11y ≥0.9 (≥95 where self-declared, e.g. `gtfs-scorecard` MUST wire it). REVIEW: screen-reader walkthrough + ACR per release.
+
+### 5. Reliability *(faultlessness, availability, fault tolerance, recoverability)*
+- **Targets:** declared SLO (default 99.5% monthly for hosted services); graceful degradation on dependency failure; no data loss on crash; idempotent writes; MTTR clock starts at alert-fire, not customer report.
+- **Gate:** AUTO: chaos/fault-injection test for top dependency failure; restart-recovery test; `/livez` + `/readyz` (**see `OBSERVABILITY-STANDARD.md`**). REVIEW: error-budget burn reviewed at release.
+
+### 6. Security *(confidentiality, integrity, non-repudiation, accountability, authenticity, **resistance**)* — *`resistance` new in 2023*
+- **Targets:** ASVS 5.0 **L2** for anything touching sensitive PII (`fare-assistant` transit PII, civic RAG), L1 floor elsewhere; no HIGH/CRITICAL SAST/SCA findings; secrets never in source; least-privilege tokens; signed commits + signed releases.
+- **Gate:** **see `SECURITY-AND-SUPPLY-CHAIN-STANDARD.md` + `CI-CD-STANDARD.md`.** AUTO: Semgrep/CodeQL, gitleaks (pre-commit **and** CI, **no `|| true`**), pip-audit/OSV/Trivy blocking on **CRITICAL,HIGH**, SHA-pinned `uses:`, SBOM+cosign+SLSA L2. REVIEW: threat model per new attack surface; Scorecard ≥8/10 with critical checks 10/10.
+
+### 7. Maintainability *(modularity, reusability, analysability, modifiability, testability)*
+- **Targets:** branch coverage ≥85% (libraries ≥90%); cyclomatic complexity ≤10 (`ruff C90`); typed (TS strict / `mypy --strict` or `pyright`); lint/format clean; duplication ≤3% on new code; no `TODO` without a linked issue.
+- **Gate:** **see `CODE-QUALITY-STANDARD.md`.** AUTO: coverage/complexity/type/lint all merge-blocking via `make verify` (byte-equal to CI).
+
+### 8. Flexibility *(adaptability, **scalability**, installability, replaceability)* — *formerly Portability; adds scalability*
+- **Targets:** one-command local bring-up; containerized; IaC where hosted; documented teardown; horizontal-scale path documented for hosted services; no machine-specific assumptions.
+- **Gate (AUTO):** CI builds container + runs from-scratch bring-up; IaC `plan` validates.
+
+### 9. Safety — **NEW in 2023** *(operational constraint, risk identification, fail-safe, hazard warning, safe integration)*
+- **Definition:** "acceptable levels of risk to human life, health, property, or environment." For our **non-safety-critical-but-high-stakes** repos (civic benefits, transit, OSINT, identity), Safety applies via **fail-safe** and **safe-integration** sub-characteristics. This is where the portfolio's signature responsible-tech guards live.
+- **Targets / measured-by per repo (illustrative, values live in-repo):**
+  - `ledger`: no-outing guarantee — injected sentinel identities never surface (isolated CI job). **AUTO.**
+  - `women-artist-discovery`: "no identity inference ever" via AST-level static test. **AUTO.**
+  - civic RAG / `fare-assistant`: no ungrounded code path; citation/grounding guards. **AUTO** (see `AI-EVALUATION-STANDARD.md`).
+  - `nearmiss`: reproducibility tamper-tripwire. **AUTO.**
+  - `self-osint-monitor`: consent gate sequenced before any feature. **AUTO** gate + **REVIEW** consent artifact.
+- **Gate:** AUTO where the guard is code-enforced (the above); REVIEW: residual-risk register + fail-safe walkthrough per release. For genuinely safety-critical features, the acceptance criteria must address all five Safety sub-characteristics explicitly.
+
+### 10. Data quality & lineage *(portfolio addendum — civic/transit ingest)*
+- **Targets:** every record traceable to source + fetch timestamp; schema-validated on ingest; staleness alarms; per-source freshness SLA. Applies to `gtfs-scorecard`, `tods-validate`, `davis-bike-hazard-map`, `jobradar`, civic RAG.
+- **Gate (AUTO):** ingest-validation tests; a committed **data card** per source (license, refresh cadence). Untrusted external zips/subprocess paths (`gtfs-scorecard` fetches external GTFS + runs a Java subprocess) carry a Safety + Security note.
+
+---
+
+## DORA — portfolio-level delivery-health signal
+
+ISO 25010 says *what* quality is; DORA says *how fast and safely* it ships. This is a **portfolio-level health signal**, not a per-PR gate — measured automatically from CI/CD + incident events, reviewed quarterly. Manual tracking is prohibited for any repo claiming a performance tier.
+
+**Five-metric model (2024, supersedes the original four keys):**
+
+| DORA metric | Portfolio floor (alert if breached) | Elite reference | Measured by | Gate |
+|-------------|-------------------------------------|-----------------|-------------|------|
+| Deployment Frequency | ≥ weekly per active repo; alert if < deploy for 14 d | on-demand / multiple per day | release/deploy events from GH Actions | health signal (REVIEW quarterly) |
+| Change Lead Time (commit→prod) | P90 < 1 day; alert if > 1 day | < 1 hour | commit→deploy timestamps | health signal |
+| Change Fail Rate | < 15%; alert if > 10% (14-d rolling) | ≤ 5% | failed-deploy / incident events | health signal |
+| Failed-Deployment Recovery Time | < 1 day; alert if any incident > 4 h | < 1 hour | incident open→resolve | health signal |
+| Deployment Rework Rate *(new 2024)* | < 10%; alert if > 5% (30-d) | low | unplanned-fix deploy ratio | health signal |
+
+**Reference implementation:** `dora-team/fourkeys` (Google OSS) ingesting GH Actions deploy events; incidents from GitHub issues labelled `incident`. Hosted repos with Lambdas (`personal-site`, `jobradar`, `fare-assistant`) feed real deploy events; library/CLI repos report DF/LT only.
+
+**2024/2025 findings we act on (not survey trivia):**
+- AI adoption is **positively** associated with throughput but **negatively** with stability — so automated safety nets (coverage gate, SAST, merge queue, red-team) are **prerequisite infrastructure**, not optional hygiene. This directly justifies the AUTO-GATE-everything stance.
+- **DORA 2025 AI Capabilities Model** is a REVIEW-GATE governance checklist before expanding AI tooling scope in any AI/RAG repo: (1) written AI policy acknowledged, (2) AI grounded in internal context, (3) foundational CI/CD at elite tier, (4) safety nets operational, (5) internal-platform health scored, (6) user-centric metrics defined, (7) **AI-generated code segmented in DORA metrics**. Do not expand scope until all seven hold.
+- High-performance tier shrank (31%→22%) and AI amplifies existing gaps → the standard sets **minimum floors**, not just elite targets (above).
+
+---
+
+## Definition of Done (per-repo `DEFINITION_OF_DONE.md`)
+
+Every repo ships a checked-in `DEFINITION_OF_DONE.md` at root, CODEOWNER-protected (engineering-leadership approval to modify), reviewed quarterly. Three tiers:
+
+**AUTO-GATE (CI on every PR — required status checks under branch protection):**
+
+```
+1. format + lint            → ruff/eslint, zero errors            [CODE-QUALITY]
+2. type-check               → mypy --strict / tsc strict, zero    [CODE-QUALITY]
+3. unit + integration       → coverage branch ≥85% (libs ≥90%),   [CODE-QUALITY]
+                              complexity ≤10, --cov-fail-under
+4. security                 → semgrep+codeql+gitleaks+pip-audit/   [SECURITY]
+                              osv+trivy, blocking HIGH+CRITICAL,
+                              SHA-pinned uses:, SBOM+cosign+SLSA
+5. workflow SAST            → zizmor on any .github/workflows/ PR  [CI-CD]
+6. accessibility            → axe 0 crit/serious/mod; pa11y BLOCK; [ACCESSIBILITY]
+                              Lighthouse a11y ≥0.9 / ≥95 declared
+7. i18n (bilingual repos)   → key-parity + placeholder-parity +   [I18N]
+                              msgfmt --check + pseudolocale
+8. ai-eval (prompt/retr.)   → faithfulness ≥0.80, hallucination   [AI-EVALUATION]
+                              ≤5%, red-team, judge κ ≥0.60
+9. observability            → structured-JSON log shape (jq test), [OBSERVABILITY]
+                              secret-in-logs SAST rule
+10. performance             → k6/Lighthouse budgets, ≤10% regress  [this doc §2]
+11. build + container + IaC plan
+```
+
+`make verify` runs stages 1–4 (and 6–9 where applicable) locally, **byte-for-byte identical to CI** — the portfolio's drift-killing discipline; propagate it to every Python repo.
+
+**REVIEW-GATE (human sign-off committed as PR attestation + artifact):**
+- PR template checklist: acceptance criteria linked to issue; observability added (OTel spans on new paths); docs updated; rollback plan for schema/infra changes; ISO 25010 characteristic(s) named.
+- New external attack surface → threat-model sign-off (`SECURITY`).
+- New custom interactive component → ARIA APG audit; screen-reader walkthrough (`ACCESSIBILITY`).
+- New AI feature → NIST AI RMF risk register + EU AI Act / ISO 42001 impact assessment (`AI-EVALUATION`).
+
+**RELEASE-GATE:** performance baseline regression passed; runbook updated; ACR + SBOM + provenance regenerated ("audit-as-artifact"); rollback documented.
+
+**Branch protection (per `CI-CD-STANDARD.md`, org rulesets preferred):** PR required (≥1 approval, ≥2 for Safety/Security-critical paths), last-pusher cannot self-approve, stale reviews dismissed, CODEOWNERS routing `.github/workflows/` + Safety-critical files to a required reviewer, required status checks in **strict** mode, **signed commits**, **linear history**, **block force-pushes**, **no admin bypass on `main`**. Merge queue on high-velocity branches.
+
+---
+
+## Metrics ledger (per repo)
+
+Each repo's `ROADMAP.md` carries a **Metrics** table with this exact shape so enforcement is unambiguous. Project-specific *values* go here; the *rigor* is cited to the owning standard.
+
+| Metric | Target | Measured by | Gate | Owner |
+|--------|--------|-------------|------|-------|
+| Branch coverage | ≥ 85% (libs ≥ 90%) | `pytest --cov` in CI | AUTO | — |
+| axe violations | 0 crit/serious/mod | `axe-core` / `pa11y-ci` | AUTO | — |
+| p95 first-token | < 1.5 s | k6 load test | AUTO | — |
+| SHA-pinned `uses:` | 100% | `zizmor` / Scorecard Pinned-Deps ≥9 | AUTO | — |
+| RAG faithfulness | ≥ 0.80 | RAGAS in CI | AUTO | — |
+| EN/ES key parity | 100% | extract + parity check | AUTO | — |
+| Screen-reader walkthrough | per release | committed checklist + ACR | REVIEW | — |
+| Threat model | per new surface | committed `THREATS.md`/ADR | REVIEW | — |
+
+A metric is **AUTO-GATE** or **REVIEW-GATE** — never "aspirational." If it cannot be made merge-blocking, it is review-gated with a checklist item and a committed artifact.
+
+---
+
+## Scoping: declare N/A, never silently skip
+
+A standard that does not apply to a repo must be recorded as **N/A-with-reason** in that repo's `ROADMAP.md` — a silent skip is a defect. Common cases:
+
+- **i18n N/A** for single-user / English-only libraries — but the repo must still record the one-line entry point (wrap strings in `_()`). EN/ES key-parity is AUTO-GATE for **every** shipping bilingual repo (civic RAG, `fare-assistant`, `ledger`, `nearmiss`, `swelter`, `trans-docs-navigator`, `personal-site`, `habitable`).
+- **Observability (OTel/SLO) out-of-scope** for libraries/CLIs — but `--log-format json` opt-in must exist and the out-of-scope decision must be documented.
+- **Accessibility (browser-engine) N/A** for headless libraries — but tools whose own HTML output is user-facing (eval harnesses: `civic-ai-eval-harness`, `govchat-eval`) **must** gate on their report's a11y.
+- **AI-eval N/A** for non-AI repos.
+
+**`self-osint-monitor`** is spec-only (no CI, Makefile, pyproject, or tests). It is the one repo where these standards are authored as the **M0/M1 scaffold**, not retrofitted: `CODE-QUALITY` toolchain + `make verify` + consent-gate (Safety) before any M1 code. **`queer-the-stacks` / `queer-specfic-reader`** share a package and must be reconciled (documented fork or merge) before standards work is counted, to avoid double-counting and independent drift.
+
+---
+
+Last verified: 2026-06-21 · Recheck cadence: quarterly, or on any new revision of ISO/IEC 25010, the DORA annual report, WCAG, OWASP ASVS, or OpenSSF Baseline — whichever is sooner.

--- a/docs/standards/README.md
+++ b/docs/standards/README.md
@@ -1,0 +1,43 @@
+# Portfolio Standards
+
+The cross-cutting rigor for every repo in this portfolio, stated **once**. A repo references these documents and records only its own project-specific *values and findings*; it never restates the rigor. This is the "reference, don't repeat" rule, and it is load-bearing — when a target moves (an OWASP/WCAG/ISO revision), it moves in one place.
+
+## The enforcement model (binary, no exceptions)
+
+Every control in every standard is exactly one of two kinds. There is no third "aspirational" category.
+
+- **AUTO-GATE** — mechanically checkable and **merge-blocking** in CI. No `|| true`, no `continue-on-error`, no admin bypass on `main`.
+- **REVIEW-GATE** — requires human judgment; paired with a checklist line and a **committed, dated artifact** that is regenerated on release.
+
+`QUALITY-AND-METRICS-STANDARD.md` is the **spine**: it owns the ISO/IEC 25010:2023 vocabulary, the DORA delivery-health backbone, and the merge-gate model, and it points to each domain standard below rather than restating it.
+
+## The documents
+
+| Standard | Owns | Applies to |
+|----------|------|------------|
+| [`QUALITY-AND-METRICS-STANDARD.md`](./QUALITY-AND-METRICS-STANDARD.md) | The quality-attribute taxonomy (ISO 25010:2023), DORA metrics, the per-repo metrics ledger, and the reference CI pipeline. The index every other standard hangs off. | All repos |
+| [`CODE-QUALITY-STANDARD.md`](./CODE-QUALITY-STANDARD.md) | Languages & versions, ruff/mypy/pytest + coverage floors, complexity limits, `uv`/`hatch` + lockfiles, src layout, ADRs; TS strict + ESLint flat + Vitest for frontends. | All repos |
+| [`SECURITY-AND-SUPPLY-CHAIN-STANDARD.md`](./SECURITY-AND-SUPPLY-CHAIN-STANDARD.md) | OWASP ASVS 5.0 level, SAST/SCA/secret/container scanning, Action SHA-pinning, SBOM + Sigstore + SLSA, token-permission model. | All repos that ship code |
+| [`CI-CD-STANDARD.md`](./CI-CD-STANDARD.md) | The merge-blocking pipeline, least-privilege `GITHUB_TOKEN`, OIDC (no long-lived secrets), branch rulesets + CODEOWNERS, `zizmor`, reusable workflows, `make verify` parity. | All repos with CI |
+| [`RELEASE-AND-VERSIONING-STANDARD.md`](./RELEASE-AND-VERSIONING-STANDARD.md) | SemVer + public-API contract, signed tags, CHANGELOG, the tag-triggered release pipeline, Trusted Publishing (PyPI OIDC), yank/deprecation/security-release policy. | All repos that produce a release |
+| [`ACCESSIBILITY-STANDARD.md`](./ACCESSIBILITY-STANDARD.md) | WCAG 2.2 AA floor, axe/pa11y/Lighthouse auto-gates, keyboard & reflow tests, screen-reader walkthrough + ACR. | Any repo emitting HTML (3 frontends + Python report/answer output) |
+| [`OBSERVABILITY-STANDARD.md`](./OBSERVABILITY-STANDARD.md) | OpenTelemetry, structured JSON logging with PII redaction, `/livez`+`/readyz`, SLO/error-budget + burn-rate alerts, Core Web Vitals RUM. Tiered by deployment shape. | Servers; lighter tier for libraries/frontends |
+| [`INTERNATIONALIZATION-STANDARD.md`](./INTERNATIONALIZATION-STANDARD.md) | Externalized strings, ICU/MessageFormat 2 + gettext catalogs, BCP-47, key/placeholder-parity + pseudolocale gates, RTL. Explicit opt-out for English-only personal tools. | Public-facing civic surfaces |
+| [`AI-EVALUATION-STANDARD.md`](./AI-EVALUATION-STANDARD.md) | Eval-driven development; RAG faithfulness/recall/precision, hallucination + refusal gates, red-team suites, judge calibration, model/data cards. NIST AI RMF + EU AI Act framing. | AI/RAG/eval repos |
+| [`DOCUMENTATION-STANDARD.md`](./DOCUMENTATION-STANDARD.md) | What every repo documents, the per-document responsibility split, authoring rules, currency stamps, status, and the definition of production-ready. | All repos |
+| [`RESPONSIBLE-TECH-FRAMEWORK.md`](./RESPONSIBLE-TECH-FRAMEWORK.md) | The audit *methodology* (Ethics, Bias, Privacy/DPIA, Transparency, Accessibility, Security) each repo instantiates as committed findings. | All repos |
+
+## Living deliverables
+
+- [`AUDIT-2026-06-21.md`](./AUDIT-2026-06-21.md) — the current conformance snapshot of all 18 repos against these standards: portfolio-wide gaps, cross-repo inconsistencies, and per-repo findings.
+- [`IMPROVEMENTS-BACKLOG.md`](./IMPROVEMENTS-BACKLOG.md) — the prioritized "what to fix next," with quick wins called out. Re-run the audit and refresh both after each uplift PR.
+
+## How a repo declares conformance
+
+1. The repo `README.md` states **which standards apply** and marks any as `N/A` **with a one-line reason** — silent omission is a defect.
+2. Per-repo *values* (measured coverage, ASVS level, ACR rows, eval thresholds, SLOs) live in that repo's `docs/ROADMAP.md` Metrics table and `docs/RESPONSIBLE-TECH-AUDITS.md`, not here.
+3. `make verify` reproduces the full AUTO-GATE set locally, byte-for-byte with CI. A standard is met when its gates are green on `main` and its review-gated artifacts are committed and current.
+
+The portfolio already proves every target here is achievable — `civic-ai-eval-harness`, `govchat-eval`, `habitable`, and `trans-docs-navigator` ship most of the maximized posture today. The work these standards describe is **propagation, not invention**.
+
+Last verified: 2026-06-21 · Recheck cadence: per ISO 25010 / WCAG / OWASP ASVS / NIST AI RMF revision, or quarterly.

--- a/docs/standards/RELEASE-AND-VERSIONING-STANDARD.md
+++ b/docs/standards/RELEASE-AND-VERSIONING-STANDARD.md
@@ -1,0 +1,176 @@
+# Release & Versioning Standard
+
+This is the canonical definition of **how a repo cuts a release and how it numbers one**. It owns the *process and policy*: SemVer rules, the public-API contract, tag and CHANGELOG discipline, the tag-triggered release pipeline, and Trusted Publishing. The cryptographic *machinery* a release invokes — SBOM generation, cosign signing, SLSA provenance, OpenSSF Scorecard — lives in `SECURITY-AND-SUPPLY-CHAIN-STANDARD.md` §6 and is referenced here, not restated. CI hardening of the release job (token scope, OIDC, concurrency, cache rules) lives in `CI-CD-STANDARD.md`. Reference, don't repeat.
+
+> **Enforcement is binary.** A control is **AUTO-GATE** (mechanically checkable, merge- or tag-blocking in CI; no `|| true`, no `continue-on-error`) or **REVIEW-GATE** (human judgment, paired with a checklist line and a committed, dated artifact). There is no aspirational third category. The portfolio already proves this is achievable: `civic-ai-eval-harness`/`govchat-eval` ship the full OIDC-Trusted-Publishing + SLSA-attested release today. The work is propagation, not invention.
+
+---
+
+## 1. When this standard applies
+
+| Repo class | Produces a release? | Examples |
+|---|---|---|
+| Published library / package (PyPI, npm) | **Yes — mandatory** | `civic-ai-eval-harness` (`govchat-eval` on PyPI), `civic-rag-starter-kit`, `nearmiss`, `tods-validate`, `swelter`, `ledger` |
+| Deployed service / app (container or hosted) | **Yes** — the deployed artifact is the release | `trans-docs-navigator`, `davis-bike-hazard-map`, `personal-site`, `fare-assistant`, `olive-bark-logger`, `queer-the-stacks` |
+| Reference/starter kit consumed by copy | **Yes** — versioned so consumers can pin | `civic-rag-starter-kit` |
+| Pure internal tool, never consumed downstream | `N/A (not consumed downstream)` with that exact reason in the README | rare — most repos are consumed by *something* |
+
+**There is no silent default.** A repo with no release pipeline and no `N/A (reason)` declaration **fails review**. This explicitly closes the current gap in `civic-rag-starter-kit`, `ledger`, `olive-bark-logger`, and `queer-the-stacks`, which produce artifacts but ship no release workflow or CHANGELOG.
+
+A repo that publishes to PyPI **always** produces a release — "library, so no release" is a contradiction, not an exemption.
+
+---
+
+## 2. Versioning policy — SemVer 2.0.0
+
+Every release-producing repo uses **[SemVer 2.0.0](https://semver.org/)**: `MAJOR.MINOR.PATCH`, with `MAJOR` for breaking changes, `MINOR` for backward-compatible additions, `PATCH` for backward-compatible fixes.
+
+| Rule | Requirement | Gate |
+|---|---|---|
+| Single source of version truth | Version lives in exactly one place (`pyproject.toml` `project.version` or `package.json` `version`); package `__version__` derives from it (`importlib.metadata.version` / build-time inject), never hand-copied | AUTO-GATE (duplicate-version-string check) |
+| Tag ⇔ metadata consistency | The git tag, the `pyproject`/`package.json` version, and the published artifact version are **identical** at release time | AUTO-GATE (version-consistency check, §4) |
+| Public API is declared | Each library's `README`/`docs` names what *is* the public API (the SemVer contract surface) — everything else is private and may change without a major bump | REVIEW-GATE |
+| Pre-1.0 (`0.y.z`) | Allowed, but the repo states its 0ver intent: `MINOR` may break. Graduate to `1.0.0` when the public API is stable. A library at `0.y.z` for >12 months with external users is a review finding | REVIEW-GATE |
+| Breaking change ⇒ MAJOR + migration note | Any breaking change to the declared public API bumps `MAJOR` and ships a migration note in the CHANGELOG | REVIEW-GATE; AUTO-GATE assist via API-diff (`griffe` for Python, `api-extractor`/`are-the-types-wrong` for TS) flagging removed/changed public symbols |
+| No re-publish of a version | A published `X.Y.Z` is immutable; defects are fixed forward in `X.Y.(Z+1)`. Yanking (§7) removes availability but never reuses the number | AUTO-GATE (registry rejects; tag is protected) |
+
+**Data products** (`gtfs-scorecard`, `tods-validate`, transit datasets) additionally version their **schema/dataset** independently of the code: a `data-vN` tag or a `dataset_version` field, with a data card recording source, fetch timestamp, and refresh cadence (see `QUALITY-AND-METRICS-STANDARD.md` §Data quality).
+
+### Calendar versioning (`CalVer`) — when permitted
+A repo whose value is "the state of the world on a date" (a periodically-regenerated dataset, a snapshot site) **may** use `YYYY.MM.DD` CalVer instead of SemVer, but must declare it and still satisfy every tag/CHANGELOG/provenance gate below. Default is SemVer; CalVer is opt-in with a one-line rationale.
+
+---
+
+## 3. Tags & CHANGELOG
+
+### 3.1 Tags — annotated, signed, immutable — AUTO-GATE
+- Format `vX.Y.Z` (the `v` prefix; CalVer repos use `vYYYY.MM.DD`).
+- **Annotated and signed.** Use a signed git tag (`git tag -s`) or Sigstore **gitsign** (keyless, OIDC identity — preferred, no long-lived GPG key to manage). An unsigned release tag fails the release job.
+- The tag points at the **exact commit** that was tested and built. No re-tagging, no force-push to a release tag — release tags are covered by a branch/tag protection ruleset (`CI-CD-STANDARD.md`).
+- Tag is created **only** on `main` after all merge gates are green.
+
+```bash
+# keyless signed tag via gitsign (preferred — no GPG key management)
+git tag -s v1.4.0 -m "v1.4.0"
+git push origin v1.4.0    # triggers the release workflow (§4)
+```
+
+### 3.2 CHANGELOG — Keep a Changelog 1.1.0 — AUTO-GATE on presence, REVIEW-GATE on quality
+Every release-producing repo keeps a `CHANGELOG.md` in **[Keep a Changelog 1.1.0](https://keepachangelog.com/)** format with an `## [Unreleased]` section, reverse-chronological entries, and `Added/Changed/Deprecated/Removed/Fixed/Security` groupings. SemVer links at the bottom.
+
+| Control | Requirement | Gate |
+|---|---|---|
+| CHANGELOG exists & parses | File present, parseable, has `Unreleased` | AUTO-GATE |
+| Released version has an entry | The tag being released has a matching `## [X.Y.Z] - YYYY-MM-DD` section (no empty releases) | AUTO-GATE (release job greps for the version heading; fails if absent) |
+| Security fixes are called out | Any release closing a CVE/advisory has a `Security` entry referencing the advisory | REVIEW-GATE |
+| Entry is human-meaningful | Describes user-visible impact, not commit subjects | REVIEW-GATE |
+
+Conventional Commits + an automated changelog generator (`git-cliff`, `release-please`) is **permitted and encouraged** to draft entries, but a human curates the released section — generated commit dumps are not a changelog.
+
+---
+
+## 4. The release pipeline (tag-triggered)
+
+A push of a `vX.Y.Z` tag triggers a single hardened release workflow. Every stage is AUTO-GATE unless marked; a red stage aborts the release before anything is published.
+
+```
+on: push: tags: ['v*']
+permissions: contents: read          # escalate per-job only (CI-CD-STANDARD §token model)
+
+1. version-consistency   tag == pyproject/package version == __version__   → fail on mismatch
+2. re-run make verify    full lint+type+test+coverage+security AT THE TAGGED COMMIT (never trust the PR run)
+3. build                 reproducible build; deterministic artifact (uv build / vite build)
+4. SBOM                  CycloneDX 1.7 generated + schema-validated      → SECURITY §6.2
+5. sign + attest         cosign sign + SLSA provenance (keyless, OIDC)   → SECURITY §6.4
+6. publish               Trusted Publishing (§5) / GHCR / GitHub Release
+7. GitHub Release        attach SBOM + provenance + CHANGELOG section as release notes
+8. verify-published      pull the published artifact, verify signature + provenance end-to-end
+```
+
+Non-negotiables (cross-referenced, enforced here):
+- **Caching is disabled** in any job that builds, signs, or publishes — cache poisoning violates SLSA build isolation (`CI-CD-STANDARD.md`; validated by the Feb 2026 cache-poisoning campaign against Microsoft/DataDog/CNCF repos).
+- **Concurrency group** on the release workflow so two tags can't publish simultaneously.
+- The release job re-runs `make verify` at the **tagged commit** — it does not reuse the PR's green checkmark. This closes the "main drifted after the PR passed" hole.
+- **OIDC only.** No long-lived PyPI/registry tokens stored as secrets. A new long-lived publish secret appearing in repo settings is an audit-log alarm (`SECURITY-AND-SUPPLY-CHAIN-STANDARD.md` §7).
+
+---
+
+## 5. Publishing channels
+
+### 5.1 PyPI — Trusted Publishing (OIDC) — AUTO-GATE
+Python packages publish via **[PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/)** using the workflow's OIDC identity through `pypa/gh-action-pypi-publish`. **No API token is ever stored.** A repo publishing to PyPI with a stored `PYPI_API_TOKEN` secret is a finding — migrate it. `govchat-eval` already does this; propagate to every PyPI repo.
+
+```yaml
+publish:
+  environment: pypi            # required-reviewer gate (CI-CD-STANDARD §environments)
+  permissions:
+    id-token: write            # OIDC — the only credential
+  steps:
+    - uses: pypa/gh-action-pypi-publish@<40-char-sha>   # release/v1.x
+```
+
+### 5.2 Containers — GHCR, versioned + signed
+Images publish to GHCR tagged with the **immutable digest** plus `vX.Y.Z` and `X.Y` moving tags. The deployed reference is the **digest**, never `:latest`. Image is cosign-signed and Trivy-scanned (`CRITICAL,HIGH` blocking) before the digest is promoted — see `SECURITY-AND-SUPPLY-CHAIN-STANDARD.md` §3/§6. Applies to every repo with a `Dockerfile` (`trans-docs-navigator`, `olive-bark-logger`, `queer-the-stacks`, `civic-rag-starter-kit`, `davis-bike-hazard-map`, the eval harnesses).
+
+### 5.3 Deployed apps / frontends
+`personal-site`, `davis-bike-hazard-map` (PWA), and the `trans-docs-navigator` frontend release a **versioned, provenance-attested build artifact** mapped to the git tag. Requirements: build provenance via `actions/attest-build-provenance`; source maps generated but access-controlled (not served publicly for repos handling sensitive flows); the deployed version surfaced at a `/version` endpoint or build-stamped meta tag so a running deployment is traceable to a commit (ties to `OBSERVABILITY-STANDARD.md`).
+
+---
+
+## 6. Release artifacts committed/attached — REVIEW-GATE on completeness
+
+Each release attaches (to the GitHub Release) and, where regenerated, commits:
+
+1. **SBOM** (`*.cdx.json`) — CycloneDX 1.7.
+2. **Provenance** (`*.intoto.jsonl`) — SLSA L2 minimum, L3 for public packages.
+3. **CHANGELOG section** as the release notes.
+4. **AI/RAG repos additionally:** the regenerated **model card** + **data card** and the eval-run report for the released version (`AI-EVALUATION-STANDARD.md`) — a model's release is not complete without its current eval evidence.
+5. **L2 PII repos:** confirmation the residual-risk register is current as of the tag (`RESPONSIBLE-TECH-FRAMEWORK.md` §F).
+
+This is the same "audit as committed build artifact" principle as the responsible-tech reports: the release evidence lives *in* the repo/release, not in a person's memory.
+
+---
+
+## 7. Deprecation, yank, and security releases
+
+| Situation | Policy | Gate |
+|---|---|---|
+| Deprecating a public API | Mark deprecated in the release that introduces the replacement; keep ≥1 MINOR cycle (libraries: ≥1 MAJOR) with a runtime `DeprecationWarning`; document in CHANGELOG `Deprecated` | REVIEW-GATE |
+| Yanking a bad release | Yank on the registry (PyPI yank / `npm deprecate`); never delete (consumers with pins must still resolve); ship the fix as a new PATCH; CHANGELOG `Security`/`Fixed` note | REVIEW-GATE + AUTO-GATE (no version reuse) |
+| Security release (CVE) | Fix forward; if supported older majors exist, backport to each; publish within the disclosure SLA in `SECURITY.md`; reference the advisory (GHSA) in the CHANGELOG `Security` entry and the release notes | REVIEW-GATE |
+| Supported-version policy | The README states which majors receive security fixes (default: latest major only for pre-1.0 portfolio repos) | REVIEW-GATE |
+
+---
+
+## 8. Per-repo posture (current state → target)
+
+| Repo | Today | Action |
+|---|---|---|
+| `civic-ai-eval-harness` / `govchat-eval` | Full OIDC Trusted Publishing + SLSA attestation + version-check | **Reference implementation** — lift its `release.yml` into the others |
+| `swelter`, `nearmiss`, `tods-validate` | SBOM/signing present, release maturity varies | Add version-consistency + CHANGELOG-entry gates; confirm Trusted Publishing |
+| `trans-docs-navigator` | Strong supply-chain posture, deployed app | Add `/version` stamp; ensure tag-triggered provenance on the deployed build |
+| `civic-rag-starter-kit`, `ledger`, `olive-bark-logger`, `queer-the-stacks` | **No release workflow / CHANGELOG** | **Primary gap** — scaffold `release.yml` + `CHANGELOG.md` from the reference repo |
+| `davis-bike-hazard-map`, `personal-site` | Frontend builds, no versioned release artifact | Add build-provenance + versioned artifact + `/version` |
+| `fare-assistant`, `women-artist-discovery`, `habitable`, `jobradar` | Mixed | Declare release-or-`N/A(reason)`; adopt the pipeline if consumed |
+| `gtfs-scorecard` | Data product | Adopt dataset versioning (§2) + the standard release gates |
+| `self-osint-monitor` | Spec-only, no CI | Release pipeline lands with its M0 CI scaffold, not before M1 |
+
+---
+
+## 9. Metrics ledger (per release-producing repo)
+
+| Metric | Target | Measured by | Gate |
+|--------|--------|-------------|------|
+| Tag ⇔ version consistency | exact match | version-check step in `release.yml` | AUTO-GATE |
+| Released version in CHANGELOG | present, dated | grep for `[X.Y.Z]` heading | AUTO-GATE |
+| Signed release tag | 100% of releases | gitsign/`git tag -v` verification | AUTO-GATE |
+| Publish credential | OIDC, zero stored tokens | secret-inventory audit | AUTO-GATE |
+| `make verify` re-run at tag | green at tagged commit | release job stage 2 | AUTO-GATE |
+| SBOM + provenance attached | every release | release assets present + `slsa-verifier` | AUTO-GATE |
+| End-to-end verify of published artifact | passes | stage 8 pull-and-verify | AUTO-GATE |
+| Public-API SemVer correctness | no undeclared breaking change in MINOR/PATCH | `griffe`/`api-extractor` diff + human review | REVIEW-GATE |
+| Migration note on MAJOR | present | release review | REVIEW-GATE |
+
+---
+
+Last verified: 2026-06-21 · Recheck cadence: per SemVer, Keep a Changelog, PyPI Trusted Publishing, SLSA, and Sigstore release; and immediately on any disclosed registry or GitHub Actions supply-chain compromise. Confirm current action versions (`gh-action-pypi-publish`, `attest-build-provenance`, gitsign) at build time.

--- a/docs/standards/RESPONSIBLE-TECH-FRAMEWORK.md
+++ b/docs/standards/RESPONSIBLE-TECH-FRAMEWORK.md
@@ -1,0 +1,176 @@
+# Responsible-Tech Framework
+
+**Doc index: 9**
+
+This is the *methodology* behind every repo's `docs/RESPONSIBLE-TECH-AUDITS.md`. It is deliberately **not** a gate catalog. The mechanically-enforced thresholds live in the sibling standards and are referenced here once, never restated:
+
+| Concern | Owning standard | This doc's role |
+| --- | --- | --- |
+| Lint / types / coverage / toolchain floors | `CODE-QUALITY-STANDARD.md` | references |
+| DORA, DoD, merge gates | `QUALITY-AND-METRICS-STANDARD.md` | references |
+| CI/CD hardening, token perms, OIDC, branch rulesets | `CI-CD-STANDARD.md` | references |
+| SAST / SCA / secret-scan / SBOM / signing / SHA-pinning | `SECURITY-AND-SUPPLY-CHAIN-STANDARD.md` | references (audit F narrative) |
+| WCAG gates, axe/pa11y/Lighthouse, SR matrix | `ACCESSIBILITY-STANDARD.md` | references (audit E narrative) |
+| OTel, structured logs, SLOs, health probes | `OBSERVABILITY-STANDARD.md` | references |
+| Catalogs, key-parity, pseudolocale, BCP-47 | `INTERNATIONALIZATION-STANDARD.md` | references (audit B/D narrative) |
+| RAG faithfulness, red-team, hallucination, model cards | `AI-EVALUATION-STANDARD.md` | references (audits B/D narrative) |
+
+**Reference, don't repeat.** When an audit needs a number — coverage %, axe impact level, faithfulness floor, SHA-pin requirement — it cites the owning standard. This document supplies the *frame* (what could go wrong, who is hurt, what we commit to) and the *governance scaffolding* (NIST AI RMF, ISO 42001, EU AI Act) that no single gate standard owns. If you find a numeric threshold duplicated here, it is a defect: delete it and link.
+
+Each project instantiates these audits with concrete findings and commits the resulting reports into its own repo, so the responsible-tech work is *in* the codebase, version-controlled and reviewable, not in a slide deck nobody reads.
+
+Each audit answers four questions in the same order: **What could go wrong? · How do we test for it? · What do we commit to? · How is that commitment enforced (auto-gate or review-gate)?**
+
+There is no third category. A control is **AUTO-GATED** (mechanically checkable, merge-blocking in CI) or **REVIEW-GATED** (requires human judgment, paired with a checklist item and a dated committed artifact). "Aspirational" is not an enforcement model; it is an unfinished audit.
+
+---
+
+## How to apply this framework to a repo
+
+1. Open `docs/RESPONSIBLE-TECH-AUDITS.md` in the repo (scaffold it from the template below if absent).
+2. For each audit A–F, decide **applies** or **N/A-with-reason**. N/A is a first-class decision and must be written down — a one-line justification, not silence. "No audit B section" is a defect; "Audit B N/A: single-user local tool, no ranking/classification of people" is conformant.
+3. For each applicable audit, fill the four questions and mark every commitment AUTO or REVIEW.
+4. Wire the AUTO commitments into `make verify` / CI per the owning standard. Generate the REVIEW artifacts and commit them dated.
+5. Re-run on every release; artifacts are regenerated, never hand-edited stale.
+
+### The applicability matrix (declare this per repo)
+
+| Repo archetype (this portfolio) | A Ethics | B Bias | C Privacy | D Transparency | E A11y | F Security | AI-EVAL | I18N |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| AI/RAG/eval (`govchat-eval`, `civic-ai-eval-harness`, `civic-rag-starter-kit`, `fare-assistant`, `women-artist-discovery`, `jobradar`) | yes | yes | yes | yes | if HTML/UI output | yes | **yes** | civic ⇒ yes |
+| Privacy-first / local-first (`ledger`, `self-osint-monitor`, `nearmiss`, `swelter`) | yes | case-by-case | **yes** | yes | if UI | yes | if LLM | declare |
+| Civic transit data (`gtfs-scorecard`, `tods-validate`, `fare-assistant`, `davis-bike-hazard-map`) | yes | yes (geographic/linguistic) | yes | yes | yes | yes | if LLM | **yes (EN/ES)** |
+| Frontend (`personal-site`, `davis-bike-hazard-map`, `trans-docs-navigator`) | yes | if personalization | yes | yes | **yes** | yes | if LLM | yes |
+| Pure library / CLI | yes (lite) | usually N/A | usually N/A | yes | N/A (declare) | yes | N/A | N/A (declare entry point) |
+
+> `self-osint-monitor` is spec-only (M0). These audits are authored as the **M0/M1 scaffold**, not retrofitted. Its consent gate (audit A/C) must sequence *before* any feature work, per its own spec.
+> `queer-the-stacks` / `queer-specfic-reader` share a package and are an undocumented fork. Reconcile to one repo before duplicating audit work; until then, the audit lives in the canonical repo and the fork carries a one-line "audit upstream" pointer.
+
+---
+
+## A. Ethics & responsibility audit
+**Frame:** map stakeholders (users, non-users affected, the people *in* the data), name the worst plausible misuse and the worst plausible failure, and state the line the product will not cross.
+
+- **Method:** a one-page consequence scan — primary users, bystanders, worst-case individual harm, and a "who could be hurt if this works exactly as intended?" question (the most useful one). For AI features, cross-reference the **12 NIST AI 600-1 GenAI risks** (CBRN, confabulation, dangerous/violent/hateful content, data privacy, environmental, harmful bias/homogenization, human-AI configuration, information integrity, information security, IP, obscene/degrading, value-chain) and record which apply.
+- **Commitments:** an explicit non-goals / "this is not for" statement; a misuse-resistance design note; a kill-switch or rollback plan for harmful behavior; a named accountable owner (ISO 42001 Clause 6.2 — owner, timeline, success metric).
+- **Enforcement:**
+  - **REVIEW-GATE** — sign-off on the consequence scan + non-goals statement, committed dated.
+  - **AUTO-GATE** — misuse-resistance unit tests where the misuse is *mechanical*. This portfolio already ships exemplary instances; treat them as the bar:
+    - `ledger` — no-outing guarantee tested with injected sentinel identities as an isolated CI job.
+    - `women-artist-discovery` — "no identity inference ever" enforced by an **AST-level static test**.
+    - `self-osint-monitor` — consent gate sequenced before any feature (CI fails if feature code lands without the gate).
+
+## B. Bias & fairness audit
+**Frame:** wherever the system ranks, recommends, classifies, or serves different groups differently, measure whether it does so equitably.
+
+- **Method:** define the relevant groups/segments up front (states, languages — **EN vs ES is a first-class segment** for the California-serving civic repos — neighborhoods, identities); run disaggregated tests (does quality hold across segments?); for AI, run targeted probe suites and per-group eval breakdowns; check for **representational** harms (stereotyping, erasure) not just allocational ones.
+- **Commitments:** documented segments, measured disparities, mitigations; a stance on inferred attributes — **default: never infer sensitive attributes**; use self-identification or omit (`women-artist-discovery`'s AST gate is the enforcement pattern; `self-osint-monitor`/`ledger` inherit it).
+- **Enforcement:**
+  - **AUTO-GATE** — where a metric exists. Per-segment eval pass rates and per-group fairness breakdowns live in `AI-EVALUATION-STANDARD.md` (model-card per-group eval rows). EN/ES parity of *capability* (not just strings) is checked against the catalog gate in `INTERNATIONALIZATION-STANDARD.md`.
+  - **REVIEW-GATE** — representational-harm review (stereotyping/erasure), committed dated. Maps to NIST AI 600-1 Risk 6 (Harmful Bias & Homogenization).
+
+## C. Privacy & data-protection audit (DPIA-style)
+**Frame:** know exactly what data exists, why, where, and for how long — then minimize all four.
+
+- **Method:** a data inventory (what is collected, lawful basis/justification, storage, retention, who can access); a threat model for the *specific people* in the data (a hostile-jurisdiction model for some projects, an abusive-ex model for others, a transit-rider-PII model for `fare-assistant`); a data-flow diagram; check against data-minimization and purpose-limitation. For AI, this maps to NIST AI 600-1 Risk 4 (Data Privacy) and ISO 42001 Annex A data-quality controls.
+- **Commitments:** retention limits, encryption at rest/in transit, local-first where feasible, no third-party exfiltration, subject-access/deletion paths, and a plain-language privacy notice. The **DPIA is a committed, regenerated artifact**, not a one-time doc.
+- **Enforcement:**
+  - **AUTO-GATE** — no-PII-in-logs (the secret-in-logs SAST rule lives in `OBSERVABILITY-STANDARD.md`: no password/token/email field values; validated by `jq` on structured logs in an integration test); encryption asserted in tests; retention jobs tested; secret scanning (gitleaks pre-commit **and** CI, no `|| true`) per `SECURITY-AND-SUPPLY-CHAIN-STANDARD.md`.
+  - **REVIEW-GATE** — DPIA sign-off, committed dated. For AI features processing personal data, this is also the **ISO 42001 Clause 6.1.4 AI System Impact Assessment** (see Governance §).
+
+## D. Transparency & explainability audit
+**Frame:** a person should be able to understand what the system did and how far to trust it.
+
+- **Method:** inventory every place the system makes a claim or a recommendation; verify each is attributable (source + last-verified date) and carries appropriate uncertainty; for AI, produce a **model card** (Hugging Face spec — YAML: `language`, `license`, `datasets`, `base_model`, `pipeline_tag`, `library_name`, ≥1 `model-index` eval result, CO2/environmental row, intended/out-of-scope use) and a **datasheet for datasets** (7 mandatory sections: Motivation, Composition, Collection, Preprocessing, Uses, Distribution, Maintenance).
+- **Commitments:** visible sourcing/citations, confidence or limitation signposting, clear "AI-generated / not legal-or-medical advice" labeling where relevant, open documentation of what the system *cannot* do, and **EU AI Act Art. 50** machine-readable AI-content labeling where applicable.
+- **Enforcement:**
+  - **AUTO-GATE** — citation/grounding guards (the portfolio's signature: `fare-assistant` and the civic RAG repos code-enforce citation coverage with **no ungrounded code path**; this is now codified portfolio-wide in `AI-EVALUATION-STANDARD.md`). Disclosure-string presence tests. Model-card / datasheet YAML completeness lint (JSON-Schema step — see AI-EVAL standard).
+  - **REVIEW-GATE** — honesty-of-framing review; model card approved by the accountable owner before production deploy.
+
+## E. Accessibility audit
+**Frame:** **WCAG 2.2 AA is the floor, not the goal** (AAA where already achieved, e.g. `personal-site`); the goal is that the primary task is completable by someone using a screen reader, a keyboard, magnification, or reduced motion. Tools whose *own HTML output* is user-facing (the eval harnesses) must gate on their output's a11y, not only their UI's.
+
+- **Method:** automated (`axe-core --tags wcag2a,wcag2aa,wcag22aa`, Lighthouse, `pa11y-ci`) for the mechanical ~30–57%, plus a manual pass: keyboard-only walkthrough, screen-reader walkthrough (VoiceOver + NVDA), 200% zoom, 320 px reflow, contrast, motion, form-error clarity, and the **WCAG 2.2 additions** (2.4.11 Focus Not Obscured, 2.5.7 Dragging, **2.5.8 Target Size 24×24 px**, 3.2.6 Consistent Help, 3.3.7 Redundant Entry, 3.3.8 Accessible Authentication).
+- **Commitments:** zero automated violations at AA, a recorded manual walkthrough per primary task, and an accessibility statement (ACR/VPAT 2.4 format).
+- **Enforcement:** thresholds and the SR-matrix checklist are owned by `ACCESSIBILITY-STANDARD.md`; this audit supplies the narrative. In summary:
+  - **AUTO-GATE** — axe zero critical/serious/moderate; Lighthouse a11y ≥ 0.9 (≥ 95 where self-declared, e.g. `gtfs-scorecard` MUST wire it); **`pa11y-ci` graduated from advisory to blocking** with a curated, justified ignore list — this kills the `continue-on-error`/`|| true` pattern in `civic-ai-eval-harness`, `govchat-eval`, `civic-rag`, `fare-assistant`. The structural Python/lint checker remains the hard gate; the browser engine is now also blocking.
+  - **REVIEW-GATE** — committed screen-reader walkthrough (NVDA+Firefox/Chrome, VoiceOver+Safari macOS/iOS) + ACR per release; ARIA APG pattern audit for any custom widget. Resolve the pending NVDA/VoiceOver rows in `habitable`, `nearmiss`, `queer-the-stacks`.
+
+## F. Security audit
+**Frame:** this audit adds the *narrative* threat model and the residual-risk register on top of the mechanical scanners. Gates live in `SECURITY-AND-SUPPLY-CHAIN-STANDARD.md` and `CI-CD-STANDARD.md`; target posture is **OWASP ASVS 5.0 Level 2** for any PII-holding or externally-exposed system.
+
+- **Method:** STRIDE-style threat model of the data flows; abuse-case tests; dependency, secret, and supply-chain hygiene. Pay special attention to the high-sensitivity / thin-scanning repos: `fare-assistant` (transit PII), `gtfs-scorecard` (fetches external zips + spawns a Java subprocess).
+- **Commitments:** documented threat model, **no fixed HIGH/CRITICAL findings**, encrypted sensitive stores, least-privilege, and a residual-risk register with owners.
+- **Enforcement:** owned by the security standard; narrative summary here:
+  - **AUTO-GATE** — Semgrep `ci --sarif` blocking on HIGH/CRITICAL + CodeQL nightly/required; gitleaks pre-commit **and** CI (drop every `|| true` — currently neutered in `ledger`, `nearmiss`); `pip-audit`/`npm audit --audit-level=high`/OSV-Scanner blocking on fixed HIGH+CRITICAL; Trivy/Grype image scan blocking on **CRITICAL,HIGH** (standardized portfolio-wide — close the gaps in `davis`, `habitable`, `civic-rag`, `queer-the-stacks`, `trans-docs`) for every repo with a Dockerfile; **every `uses:` pinned to a full 40-char SHA**; CycloneDX 1.7 SBOM + cosign keyless signing + SLSA L2 provenance on every release artifact/image. `habitable`, `trans-docs-navigator`, and `civic-ai-eval-harness`/`govchat-eval` already demonstrate this full posture — it is the propagation target.
+  - **REVIEW-GATE** — threat-model + residual-risk-register sign-off, committed dated; `zizmor` workflow-SAST review for any PR touching `.github/workflows/` (the required status check itself is AUTO).
+
+---
+
+## Governance scaffolding for AI systems (the part no gate standard owns)
+
+The gate standards measure faithfulness, red-team findings, and model-card completeness. They do **not** establish the management-system spine that NIST AI RMF, ISO 42001, and the EU AI Act require. That spine lives here, as REVIEW-GATES, with committed artifacts.
+
+| Governance artifact | Frame / source | Trigger | Gate | Owner artifact path |
+| --- | --- | --- | --- | --- |
+| **AI system inventory + risk register** | NIST AI RMF MAP; ISO 42001 Clause 6.1 | before any AI feature ships; quarterly review | REVIEW-GATE | `docs/audits/ai-risk-register.md` (signed) |
+| **AI System Impact Assessment** | ISO 42001 Clause 6.1.4 | any AI feature processing personal data, making consequential decisions, or exposed to external users | REVIEW-GATE | `docs/audits/ai-impact-assessment.md` |
+| **Statement of Applicability** (42 Annex A controls) | ISO 42001 | production AI system; annual + post-architecture-change | REVIEW-GATE | `docs/audits/iso42001-soa.md` |
+| **EU AI Act risk classification** | EU AI Act Annex III + GPAI | every AI feature; re-run on material change | REVIEW-GATE | `docs/audits/eu-ai-act-classification.md` |
+| **Conformity-assessment package** | EU AI Act Art. 17/18/47 | only if classified high-risk (Annex III) | REVIEW-GATE | gated artifact bundle |
+| **Red-team report** | OWASP LLM Top 10 v2.0; PyRIT/Garak | before each major model release; after prompt/arch change | REVIEW-GATE | `docs/audits/redteam-<date>.md` |
+| **Environmental footprint** | NIST AI 600-1 Risk 5; EU AI Act GPAI | within one sprint of any training/fine-tune run | REVIEW-GATE | model-card CO2 row |
+
+**Current framework versions (verify at build time):**
+
+| Framework | Version / status as of 2026-06-21 | Relevance to this portfolio |
+| --- | --- | --- |
+| NIST AI RMF | 1.0 (Jan 2023) + **GenAI Profile NIST AI 600-1** (Jul 2024); Agentic Profile concept note Apr 2026 | living risk register; 12 GenAI risks; 72 subcategories |
+| ISO/IEC 42001 | :2023 (Dec 2023) — only certifiable AIMS | SoA, impact assessments, risk register |
+| EU AI Act | Reg. (EU) 2024/1689 — **full high-risk application Aug 2, 2026**; GPAI obligations live since Aug 2025; Annex III conformity deadline Dec 2, 2027 | classify every AI feature; most portfolio AI is **not** high-risk, but the classification decision must be written down |
+| OWASP Top 10 for LLM Apps | **v2.0 (Nov 2024)**, LLM01–LLM10:2025 | red-team checklist (see AI-EVAL standard) |
+| WCAG | **2.2 AA** (Oct 2023, upd. Dec 2024) — floor; WCAG 3.0 still Working Draft, no compliance action | audit E (see A11Y standard) |
+| OWASP ASVS | **5.0** | audit F target = L2 (see security standard) |
+| Model Cards / Datasheets | Mitchell et al. / Gebru et al.; HF Hub spec current | audit D transparency artifacts |
+
+> **Most repos in this portfolio are not EU-AI-Act-high-risk and not ISO-42001-certified.** The obligation is not certification; it is the *decision artifact*. A two-line "EU AI Act classification: minimal-risk, not Annex III, rationale: …" committed file satisfies the REVIEW-GATE. Silence does not.
+
+---
+
+## What gets committed into each repo
+
+For each applicable audit, the repo's `docs/RESPONSIBLE-TECH-AUDITS.md` (and, where the audit is machine-generated, `docs/audits/*.md` or `*.json` artifacts) contains:
+
+1. The **findings** (risks specific to this project).
+2. The **checklist** (each item marked AUTO-GATED or REVIEW-GATED, with the owning standard linked for the numeric threshold).
+3. The **committed report/artifact** (the eval run, the axe report, the DPIA, the model card, the risk register), regenerated by `make verify` / release CI and updated on every release.
+
+This is the literal meaning of "baking the reports into the repo": the audit is a **build artifact**, regenerated and re-committed, never a one-time PDF. This "audit-as-artifact" discipline — DPIA, ACR/VPAT, threat models, data/model cards, residual-risk registers, regenerated on release — is already this portfolio's signature strength and is rare even in regulated industries. The work ahead is propagating it to the repos that lag, not inventing it.
+
+### Scaffold template (`docs/RESPONSIBLE-TECH-AUDITS.md`)
+
+```markdown
+# Responsible-Tech Audits — <repo>
+Instantiates STANDARDS/RESPONSIBLE-TECH-FRAMEWORK.md. Last regenerated: <date>.
+
+## Applicability
+- A Ethics:        applies
+- B Bias:          N/A — single-user local tool, ranks no people
+- C Privacy:       applies (DPIA: docs/audits/dpia.md)
+- D Transparency:  applies
+- E Accessibility: applies (ACR: docs/audits/acr.md)  | or: N/A — no UI, headless CLI
+- F Security:      applies (threat model: docs/audits/threat-model.md)
+- AI-EVAL:         N/A — no LLM in the stack
+- I18N:            N/A — English-only personal tool; entry point: wrap strings in _()
+
+## A. Ethics  — [findings] [checklist: AUTO/REVIEW] [artifact]
+## B. Bias    — ...
+...
+## Governance (AI repos only) — risk register / impact assessment / SoA / EU classification
+```
+
+Every `N/A` line carries a reason. A missing audit section is a defect; a justified `N/A` is conformance.
+
+---
+
+Last verified: 2026-06-21 · Recheck cadence: quarterly, and immediately on any revision to NIST AI RMF / AI 600-1, ISO 42001, EU AI Act enforcement phases, WCAG, or OWASP ASVS / LLM Top 10. (Confirm current framework versions at build time.)

--- a/docs/standards/SECURITY-AND-SUPPLY-CHAIN-STANDARD.md
+++ b/docs/standards/SECURITY-AND-SUPPLY-CHAIN-STANDARD.md
@@ -1,0 +1,310 @@
+# Security & Supply-Chain Standard
+
+This is the canonical definition of application-security and software-supply-chain rigor for every repo in this portfolio. It owns the *machinery*: ASVS level, SAST/SCA/secret-scanning configuration, Action SHA-pinning, SBOM/signing/provenance, and the token-permission model. Repos record only project-specific *values and findings* — the threat model narrative, the residual-risk register, the per-repo ASVS level declaration — in `docs/RESPONSIBLE-TECH-AUDITS.md` (methodology: `RESPONSIBLE-TECH-FRAMEWORK.md` §F) and their `ROADMAP.md` Metrics table. Reference, don't repeat.
+
+> **Enforcement is binary.** A control is **AUTO-GATE** (mechanically checkable, merge-blocking in CI, no `|| true`, no `continue-on-error`) or **REVIEW-GATE** (human judgment, paired with a checklist line and a committed, dated artifact regenerated on release). There is no aspirational third category. The portfolio already proves every target here is achievable: `habitable`, `trans-docs-navigator`, and `civic-ai-eval-harness`/`govchat-eval` already ship the full SHA-pin + SBOM + Sigstore + OIDC posture. The work is propagation, not invention.
+
+CI/CD-pipeline hardening (token permissions, OIDC, branch rulesets, workflow SAST) lives in `CI-CD-STANDARD.md`; this document covers it only where it is load-bearing for supply-chain integrity and cross-references the rest. Toolchain floors (ruff/mypy/coverage) live in `CODE-QUALITY-STANDARD.md`.
+
+---
+
+## 1. ASVS level per repo (the floor and the PII tier)
+
+Target framework is **OWASP ASVS 5.0.0** (May 2025). Every repo declares its level in `docs/RESPONSIBLE-TECH-AUDITS.md` §F. There is no silent default — a repo with no declaration fails review.
+
+| Repo class | ASVS target | Rationale | Examples |
+|---|---|---|---|
+| Default floor | **L1** | ASVS 5.0 states L1 is achievable with automated tooling alone; that maps exactly to our AUTO-GATE set. | every repo, minimum |
+| Touches PII / identity / location | **L2** | Field-level authz (BOPLA V8.2.1), cross-tenant isolation, breached-password checks, OIDC `acr`/`amr` validation. | `fare-assistant` (transit PII), `self-osint-monitor`, `olive-bark-logger`, `trans-docs-navigator`, `ledger` |
+| Catastrophic-breach surface | L3 *(none today)* | Hardware phishing-resistant factor, adaptive authz, annual threat-model + leadership justification. No current repo hosts auth at this blast radius; if one does, it declares L3 and adopts the V6/V8/V10 L3 review-gates. | — |
+
+L1 is satisfied entirely by §3–§4 AUTO-GATEs (parameterized queries, output encoding, TLS 1.2+, server-side function- and object-level authz). L2 adds the authz integration tests in §5 and the OAuth/OIDC review-gate. `ledger`'s no-outing guarantee and `women-artist-discovery`'s "no identity inference" AST test are project-specific ASVS-V8 abuse-case controls — keep them; they are exemplars, not exceptions.
+
+### When this section does NOT apply
+A repo with **no authentication, no authorization surface, and no network ingress** (a pure offline CLI or library, e.g. `tods-validate`, `swelter` as a library) declares `ASVS: N/A (no auth/authz/ingress surface)` with that exact reason. It still inherits all of §3, §4, §6, §7 — supply-chain and scanning are never N/A for a repo that ships code.
+
+---
+
+## 2. Privacy-first repos: hardened posture (olive-bark-logger, self-osint-monitor, trans-docs-navigator)
+
+These three carry the highest individual-harm blast radius (a logger of sensitive activity, an OSINT self-monitor, and trans-resource navigation). They adopt **every** AUTO-GATE below as merge-blocking with **zero waivers**, plus:
+
+| Control | Target | Measured by | Gate |
+|---|---|---|---|
+| No-secret/no-PII in logs | zero matches for password/token/email/`Authorization` field values | Semgrep custom rule + log-assertion integration test (`jq` over emitted JSON) | AUTO-GATE |
+| Consent gate before feature code | sequenced before any M1 feature; CI asserts gate module imported on every entrypoint | static import test | AUTO-GATE (`self-osint-monitor`) |
+| No third-party exfiltration | StepSecurity Harden-Runner egress allowlist in every job; deny-by-default | Harden-Runner `block` mode + audit | AUTO-GATE |
+| Sentinel-identity tripwire | injected sentinel survives full pipeline without leaking | isolated CI job (lift `ledger`'s no-outing test pattern) | AUTO-GATE |
+| ASVS L2 | full §5 authz tests | integration suite | AUTO-GATE |
+
+`self-osint-monitor` is spec-only today (no CI, no `pyproject`, no tests). It **scaffolds this standard as its M0 deliverable** before any M1 feature code — Harden-Runner, gitleaks pre-commit + CI, SHA-pinned actions, top-level `permissions: contents: read`, and the consent gate land first.
+
+---
+
+## 3. Static analysis (SAST): Semgrep + CodeQL
+
+**Semgrep** for fast diff-aware PR coverage (~10 s, SARIF to Code Scanning); **CodeQL** for deep cross-file taint/dataflow on a nightly schedule + required check on `main`. Rejected: Semgrep alone (misses multi-file auth bypasses); CodeQL alone (too slow for every PR, no IaC breadth).
+
+| Metric | Target | Measured by | Gate |
+|---|---|---|---|
+| Semgrep findings | zero unwaived **HIGH/CRITICAL** at merge | `semgrep ci --sarif` | AUTO-GATE |
+| CodeQL findings | zero unwaived HIGH/CRITICAL on `main` | `github/codeql-action`, nightly + required on push to `main` | AUTO-GATE (graduate `davis-bike-hazard-map` from advisory) |
+| Workflow SAST | zero high/critical | CodeQL `language: actions` + `zizmor` (see §7) | AUTO-GATE |
+| Waiver hygiene | every waiver has expiry + reason | committed `.semgrep-waivers.yml`, reviewed quarterly | REVIEW-GATE |
+
+```yaml
+# .github/workflows/sast.yml — Semgrep PR gate
+permissions:
+  contents: read
+jobs:
+  semgrep:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write   # upload SARIF only
+    steps:
+      - uses: actions/checkout@<40-char-sha> # v4.2.2
+        with: { persist-credentials: false }
+      - uses: semgrep/semgrep-action@<40-char-sha> # v1.x
+      - run: semgrep ci --sarif --output=semgrep.sarif --severity=ERROR --severity=WARNING
+      - uses: github/codeql-action/upload-sarif@<40-char-sha> # v3.x
+        with: { sarif_file: semgrep.sarif }
+```
+
+`make verify` runs `semgrep ci` locally so the gate is byte-for-byte reproducible (matches the portfolio's `make verify` == CI discipline).
+
+---
+
+## 4. Dependency scanning (SCA) + secret scanning
+
+### SCA — pip-audit / npm audit / OSV-Scanner + Dependabot/Renovate
+
+OSV-Scanner is the portfolio baseline (queries the same OSV DB as Scorecard's Vulnerabilities check, covers 20+ ecosystems incl. transitive lockfile deps). pip-audit / npm audit run additionally per ecosystem. **The `|| true` on `pip-audit` in `ledger` and `nearmiss` is deleted — that neuter defeats the gate entirely.**
+
+| Metric | Target | Measured by | Gate |
+|---|---|---|---|
+| Python vulns | zero **HIGH+CRITICAL with a fix available** | `pip-audit` (no `\|\| true`) + `osv-scanner -r .` over `uv.lock` | AUTO-GATE |
+| Node vulns | zero HIGH+CRITICAL | `npm audit --audit-level=high` | AUTO-GATE (frontends + `personal-site` Lambda) |
+| Transitive coverage | lockfile present & scanned | `osv-scanner` fails if no `uv.lock`/`package-lock.json` | AUTO-GATE |
+| Update automation | Dependabot or Renovate config present (Scorecard `Dependency-Update-Tool`) | committed `dependabot.yml`/`renovate.json` | AUTO-GATE |
+| Open critical alerts | none merge-able | branch ruleset blocks merge on open Dependabot alert CVSS ≥ 7.0 | AUTO-GATE |
+| Unfixable HIGH/CRITICAL waiver | tracked + VEX-justified | committed `vex.json` (CycloneDX 1.7 VEX), quarterly review | REVIEW-GATE |
+
+`gtfs-scorecard` (fetches external GTFS zips, runs a Java subprocess) and `fare-assistant` (transit PII) currently have the **thinnest** scanning despite the highest sensitivity — they adopt the full SCA + secret-scan set first.
+
+### Secret scanning — gitleaks (Gate 1+2) + TruffleHog (Gate 3)
+
+Two-gate gitleaks: **pre-commit** (Gate 1) and **CI diff** (Gate 2). TruffleHog runs a scheduled full-history scan (Gate 3) with live-credential verification.
+
+| Gate | Tool | Target | Gate |
+|---|---|---|---|
+| 1 pre-commit | gitleaks `v8.30.1` | zero unredacted matches | AUTO-GATE |
+| 2 CI diff | gitleaks `--exit-code 1 --redact` (no `\|\| true`) | zero matches | AUTO-GATE |
+| 3 scheduled | `trufflehog git --object-discovery --results=verified,unknown --fail` | zero verified live creds | AUTO-GATE (page on hit) |
+
+```yaml
+# .pre-commit-config.yaml — Gate 1 (also closes the pre-commit adoption gap)
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks: [{ id: gitleaks }]
+```
+
+Pre-commit adoption is currently the minority (~6 of 19 repos). This config is now **mandatory** in every repo; the gitleaks + ruff + mypy hooks are the required floor.
+
+---
+
+## 5. Input validation & authz testing (ASVS V8 / L2)
+
+L1 floor (AUTO-GATE, all repos with ingress): parameterized queries only (no string-built SQL — Semgrep rule), output encoding on all user-controlled HTML sinks (XSS), TLS 1.2+ asserted, server-side function-level authz (V8.1.1) and object-level authz (V8.1.2).
+
+L2 (AUTO-GATE, PII repos): an integration suite asserting **every protected endpoint returns 403 to an unauthorized principal** and that object-level (BOLA/IDOR) and field-level (BOPLA) access is denied cross-tenant. Block deploy if any protected route lacks a negative-path test.
+
+```python
+# tests/test_authz.py — the negative-path assertion, every protected route
+@pytest.mark.parametrize("route", PROTECTED_ROUTES)
+def test_unauthorized_principal_gets_403(client, route):
+    assert client.get(route, headers=other_tenant_token()).status_code == 403
+```
+
+| Metric | Target | Measured by | Gate |
+|---|---|---|---|
+| Injection / XSS | zero | Semgrep taint rules + DAST in staging | AUTO-GATE |
+| Function-level authz | every protected route 403s unauth | parametrized integration test | AUTO-GATE (L2) |
+| Object-level authz (BOLA) | cross-tenant access denied | integration test w/ second principal | AUTO-GATE (L2) |
+| OAuth/OIDC (V10) | PKCE enforced; `acr`/`amr` validated; sender-constrained tokens | security architecture review | REVIEW-GATE (identity-critical services) |
+| Annual pentest (BOLA/BOPLA/tenant) | report attached to release | manual + human triage | REVIEW-GATE (L2 PII repos) |
+
+---
+
+## 6. Supply chain: pin Actions, SBOM, signing, provenance, Scorecard
+
+This is the portfolio's largest open gap (~13 of 19 repos non-conformant on SHA-pinning) and the most active threat — the **March 2026 trivy-action force-push** and **tj-actions** compromises were real exfiltration events, not hypotheticals.
+
+> This section owns the supply-chain **machinery** (SBOM, signing, provenance) that a release *invokes*. The release **process and policy** — SemVer, signed tags, CHANGELOG, the tag-triggered pipeline, and Trusted Publishing — lives in `RELEASE-AND-VERSIONING-STANDARD.md`. When that standard says "sign + attest → SECURITY §6," this is the section it means.
+
+### 6.1 Pin every Action to a full 40-char commit SHA — AUTO-GATE
+
+Every `uses:` — third-party actions, `actions/*`, **reusable workflows, and the deploy path** — is pinned to a full 40-char commit SHA with a trailing `# vX.Y.Z` comment. Tags and branches are immutable-reference failures. This explicitly closes `nearmiss` (0/17 SHA), `gtfs-scorecard` (0/2), and `trans-docs-navigator`'s single straggler in `deploy-aws-preview.yml`.
+
+```yaml
+# correct — immutable, human-readable
+- uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+- uses: astral-sh/setup-uv@<40-char-sha> # v5.x
+# WRONG — mutable, exploitable
+- uses: actions/checkout@v4
+- uses: gitleaks/gitleaks-action@v2
+```
+
+Renovate keeps SHAs current and survivable:
+
+```json
+// renovate.json
+{
+  "extends": ["config:recommended", "helpers:pinGitHubActionDigestsToSemver"],
+  "minimumReleaseAge": "72 hours"
+}
+```
+
+Migration: run StepSecurity Action-Advisor (app.stepsecurity.io) or `pin-github-action` over each workflow to auto-generate SHA-pinned stubs.
+
+```bash
+npx pin-github-action .github/workflows/*.yml   # rewrites tags -> SHA + comment
+```
+
+| Metric | Target | Measured by | Gate |
+|---|---|---|---|
+| Every `uses:` SHA-pinned | 100% incl. reusable + deploy | Scorecard `Pinned-Dependencies` **≥ 9/10** on default branch | AUTO-GATE |
+| SHAs kept current | Renovate active, 72h cooldown | committed `renovate.json` | AUTO-GATE |
+
+### 6.2 SBOM — CycloneDX 1.7 — AUTO-GATE on every release
+
+Generate a **CycloneDX 1.7** (ECMA-424) SBOM for every release artifact and every container image; validate against schema before signing; fail the build on schema failure. Rejected SPDX-only: CycloneDX 1.7's attestation + VEX + ML-BOM `modelCard` shapes fit our SLSA and AI-repo needs better; both are NTIA/CISA/EU-CRA accepted.
+
+```bash
+syft . -o cyclonedx-json=sbom.cdx.json            # or: cdxgen -t python -o sbom.cdx.json
+cyclonedx-cli validate --input-file sbom.cdx.json --input-version v1_7
+grype sbom:sbom.cdx.json --fail-on high            # gate the SBOM itself
+```
+
+Required component fields: `name`, `version`, `purl`, `hashes` (SHA-256). AI/RAG repos additionally emit an ML-BOM `modelCard` component for each model dependency (ties to the model-card lint in `AI-EVALUATION-STANDARD.md`).
+
+### 6.3 Container CVE scanning — AUTO-GATE for every Dockerfile repo
+
+Trivy/Grype image scan, threshold standardized to **CRITICAL,HIGH** portfolio-wide (the eval harnesses' CRITICAL-only setting is raised). Closes the missing scans in `davis-bike-hazard-map`, `habitable`, `civic-rag-starter-kit`, `queer-the-stacks`, `trans-docs-navigator`.
+
+```bash
+trivy image --severity CRITICAL,HIGH --ignore-unfixed --exit-code 1 $IMAGE
+```
+
+### 6.4 Signing + provenance — Sigstore cosign + SLSA — AUTO-GATE on release
+
+Keyless cosign (OIDC via the workflow identity; Fulcio cert + Rekor log; no long-lived keys). Target **SLSA Build L2** minimum (signed provenance, hosted build, consumer-verifiable); **L3** for public/critical packages via `slsa-framework/slsa-github-generator` (signing key inaccessible to build steps, isolated ephemeral build). Provenance predicate `https://slsa.dev/provenance/v1`.
+
+```yaml
+# release signing — keyless, OIDC identity
+permissions:
+  id-token: write    # OIDC
+  contents: write    # attach release assets
+  attestations: write
+steps:
+  - uses: sigstore/cosign-installer@<40-char-sha> # v3.x
+  - run: cosign sign --yes $IMAGE
+  - run: cosign attest --yes --predicate sbom.cdx.json --type cyclonedx $IMAGE
+  - uses: actions/attest-build-provenance@<40-char-sha> # v2.x  (SLSA L2 + Source Track)
+    with: { subject-path: 'dist/*' }
+```
+
+Caching is **disabled** in any job that signs/publishes/generates provenance (cache poisoning violates SLSA isolation). Concurrency group on release jobs. Both rules cross-reference `CI-CD-STANDARD.md`.
+
+Deployment-side: consumers verify before install.
+
+```bash
+cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp='^https://github.com/<org>/<repo>/' $IMAGE
+slsa-verifier verify-artifact --source-uri github.com/<org>/<repo> dist/<artifact>
+```
+
+### 6.5 OpenSSF Scorecard — required check
+
+`ossf/scorecard-action` nightly + on PRs to default branch; SARIF to Code Scanning.
+
+| Scorecard check | Target | Gate |
+|---|---|---|
+| `Pinned-Dependencies` | ≥ 9/10 | AUTO-GATE |
+| `Token-Permissions` | 10/10 | AUTO-GATE |
+| `Dangerous-Workflow` | 10/10 | AUTO-GATE |
+| `Branch-Protection` | ≥ 8/10 | AUTO-GATE |
+| `Signed-Releases` | 10/10 (`.intoto.jsonl` on last 5) | AUTO-GATE (release repos) |
+| `Vulnerabilities` | 10/10 | AUTO-GATE |
+| Aggregate | ≥ 8/10 | AUTO-GATE |
+| Monthly Scorecard report committed | present, dated | REVIEW-GATE |
+
+---
+
+## 7. Least-privilege tokens, OIDC, branch protection, workflow SAST
+
+Owned in detail by `CI-CD-STANDARD.md`; the supply-chain-load-bearing minimums repeated here so a repo author can't miss them:
+
+| Control | Target | Measured by | Gate |
+|---|---|---|---|
+| Top-level `permissions` | `contents: read`, per-job escalation only | present in every workflow (closes `gtfs-scorecard`, `jobradar`, `personal-site`, `tods-validate`) | AUTO-GATE |
+| Cloud creds | OIDC only, no long-lived secrets, sub scoped to `repo:…:environment:…` | audit-log alert on new long-lived secret | AUTO-GATE |
+| Workflow SAST | `zizmor` required check on any PR touching `.github/workflows/` | merge-blocked on high/critical | AUTO-GATE |
+| `persist-credentials: false` | on every `actions/checkout` | zizmor / grep | AUTO-GATE |
+| No direct push to `main` | branch ruleset, no admin bypass, ≥1 required review | committed ruleset export | AUTO-GATE |
+| CODEOWNERS routes `.github/workflows/` + security-critical files | required reviewer | committed `CODEOWNERS` | AUTO-GATE |
+| Branch ruleset + CODEOWNERS as committed artifacts | present | repo files | REVIEW-GATE (close portfolio-wide absence) |
+
+```yaml
+# zizmor as a required check
+permissions: { contents: read }
+jobs:
+  zizmor:
+    if: contains(toJSON(github.event.pull_request.changed_files), '.github/workflows/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<40-char-sha> # v4.2.2
+        with: { persist-credentials: false }
+      - uses: zizmorcore/zizmor-action@<40-char-sha> # v0.x
+```
+
+---
+
+## 8. Per-repo declarations (no silent skips)
+
+Every repo's `docs/RESPONSIBLE-TECH-AUDITS.md` §F records, with no blanks:
+
+1. **ASVS level** (L1 / L2 / L3 / `N/A (reason)`).
+2. **Container scanning**: enabled, or `N/A (no Dockerfile)`.
+3. **SBOM + signing**: enabled on release, or `N/A (not a release-producing repo)` — note this is rare; libraries published to PyPI **do** produce releases.
+4. **Secret-management policy** (OSPS-BR-07.02): storage, rotation, revocation — committed once, reviewed annually.
+5. **VEX** for any unfixable HIGH/CRITICAL dependency CVE.
+
+An N/A is a *declared decision with a one-line reason*, reviewed like any other. A blank is a defect.
+
+### Cross-repo reconciliation (blocking on the affected repos)
+- `queer-the-stacks` / `queer-specfic-reader` share the `queer_the_stacks` package — an undocumented fork/rename. Reconcile to one canonical repo before applying this standard, or both drift and double-count. **REVIEW-GATE.**
+- `gtfs-scorecard` has no repo-root config; its project lives at `pipeline/`. CI here must target `pipeline/` (or hoist config to root) so portfolio tooling does not silently skip it. **AUTO-GATE** (CI path declared).
+
+---
+
+## 9. The blocking security pipeline (reference)
+
+Ordered, all blocking; `make verify` runs the local-runnable subset byte-for-byte:
+
+```
+1. secret scan        → gitleaks pre-commit (Gate 1) + CI diff (Gate 2)
+2. SAST               → semgrep ci (HIGH/CRITICAL) ; CodeQL nightly + required on main
+3. SCA                → pip-audit / npm audit --audit-level=high / osv-scanner (no || true)
+4. authz tests        → 403-on-unauth + BOLA/BOPLA (L2 repos)
+5. container scan     → trivy image --severity CRITICAL,HIGH (Dockerfile repos)
+6. workflow SAST      → zizmor (PRs touching .github/workflows/)
+7. supply chain (rel) → SBOM (CycloneDX 1.7) -> validate -> cosign sign + attest -> SLSA provenance
+8. scorecard          → ossf/scorecard-action, aggregate >= 8, criticals at target
+9. (human) review     → threat-model sign-off, VEX, secrets policy, pentest (L2)
+```
+
+---
+
+Last verified: 2026-06-21 · Recheck cadence: per OWASP ASVS, SLSA, CycloneDX, OpenSSF Scorecard/Baseline, and Sigstore release; and immediately on any disclosed GitHub Actions supply-chain compromise. Confirm current tool versions (gitleaks, TruffleHog, Scorecard, cosign, CycloneDX spec) at build time.

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", "helpers:pinGitHubActionDigestsToSemver"],
+  "minimumReleaseAge": "72 hours",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/docs/standards/\\.standards-version$/"],
+      "matchStrings": ["standards_version=(?<currentValue>v[0-9.]+)"],
+      "depNameTemplate": "ChelseaKR/portfolio-standards",
+      "datasourceTemplate": "github-releases"
+    }
+  ]
+}


### PR DESCRIPTION
Vendors the generic portfolio standards into docs/standards/ (public-repo model, no audit findings) and hardens all 3 workflows: every external action pinned to a full commit SHA, top-level least-privilege `permissions: contents: read` with job-level grants preserved for the CD/OIDC jobs. No action versions, deploy logic, or app code changed.