### PR TITLE
chore(seo): fix dead-domain canonicals/sitemap + maximize repo findability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,18 @@
 # Family Greenhouse
 
-A collaborative plant-care app for households. People share a household, add plants, schedule recurring tasks (water, fertilize, prune…), and get reminders across browser, email, and SMS so nobody has to ask "did you water the Monstera?" ever again.
+[![CI](https://github.com/ChelseaKR/family-greenhouse/actions/workflows/ci.yml/badge.svg)](https://github.com/ChelseaKR/family-greenhouse/actions/workflows/ci.yml)
+[![Live](https://img.shields.io/badge/live-familygreenhouse.net-639922)](https://familygreenhouse.net)
+[![License: Elastic-2.0](https://img.shields.io/badge/license-Elastic--2.0-2f6f4e)](LICENSE)
+[![PWA](https://img.shields.io/badge/PWA-installable-639922)](https://familygreenhouse.net)
+![React](https://img.shields.io/badge/React-19-61dafb)
+![TypeScript](https://img.shields.io/badge/TypeScript-strict-3178c6)
+![AWS](https://img.shields.io/badge/AWS-Lambda%20%2B%20DynamoDB%20%2B%20Cognito-ff9900)
 
-Built with React + TypeScript on the frontend and AWS Lambda + DynamoDB + Cognito on the backend, plus a local Express dev server that mirrors the API surface so you can develop entirely offline.
+**A shared plant-care journal for the whole household** — a collaborative houseplant tracker with per-plant watering schedules, recurring care tasks (water, fertilize, prune…), and reminders that find the right person across browser, email, and SMS, so nobody has to ask "did you water the Monstera?" ever again.
+
+🌿 **Live demo:** **[familygreenhouse.net](https://familygreenhouse.net)** &nbsp;·&nbsp; 📚 **Docs:** [`docs/`](docs/) &nbsp;·&nbsp; 🧭 **Start here:** [`docs/development.md`](docs/development.md)
+
+Built with React + TypeScript on the frontend and AWS Lambda + DynamoDB (single-table) + Cognito on the backend, plus a local Express dev server that mirrors the API surface so you can develop entirely offline — no AWS account or third-party keys required to run it locally.
 
 > _In loving memory of my mom, Joyce - who taught us to keep growing. 🌱_
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,7 @@
 {
   "name": "backend",
   "version": "0.1.0",
+  "description": "Family Greenhouse API — AWS Lambda + DynamoDB single-table + Cognito, with a local Express mock that mirrors the handlers.",
   "license": "Elastic-2.0",
   "private": true,
   "type": "module",

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -14,19 +14,45 @@
       content="A collaborative plant care app for households. Add plants, schedule recurring care, share tasks, and grow together."
     />
 
+    <!-- NOTE: no static <link rel="canonical"> or og:url here. This single
+         index.html serves every SPA route, so a hardcoded homepage canonical
+         would wrongly canonicalize /pricing, /care, /blog, … to "/" and drop
+         them from the index. Canonical + og:url are set PER ROUTE via
+         useMetaTags; routes that don't set one fall back to URL-as-canonical
+         (the safe default). -->
+
     <!-- Open Graph + Twitter Card. v2 brand kit ships purpose-built PNGs
-         (1200×630 OG, 1600×800 Twitter) in /brand/. -->
+         (1200×630 OG, 1600×800 Twitter) in /brand/. Image URLs are ABSOLUTE —
+         social scrapers (Facebook/LinkedIn/Slack) reject a relative og:image.
+         These are HOMEPAGE defaults; per-route pages override title/description
+         via useMetaTags. -->
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="Family Greenhouse" />
+    <meta property="og:site_name" content="Family Greenhouse" />
+    <meta
+      property="og:title"
+      content="Family Greenhouse — collaborative plant care for households"
+    />
     <meta
       property="og:description"
-      content="Collaborative plant care for households — share tasks, get reminders, grow together."
+      content="Collaborative plant care for households — share tasks, get reminders, and keep a care log everyone can see, so nobody asks 'did you water the Monstera?' again."
     />
-    <meta property="og:image" content="/brand/og-image.png" />
+    <meta property="og:image" content="https://familygreenhouse.net/brand/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
+    <meta
+      property="og:image:alt"
+      content="Family Greenhouse — a shared plant-care journal for the whole household"
+    />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:image" content="/brand/twitter-card.png" />
+    <meta
+      name="twitter:title"
+      content="Family Greenhouse — collaborative plant care for households"
+    />
+    <meta
+      name="twitter:description"
+      content="Share tasks, get reminders, and keep a care log everyone can see — so nobody asks 'did you water the Monstera?' again."
+    />
+    <meta name="twitter:image" content="https://familygreenhouse.net/brand/twitter-card.png" />
 
     <!-- Icons. v2 brand kit covers favicon (.ico + 32px PNG), apple-touch
          (180×180), and the PWA manifest icons (192/512). All ship from

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "frontend",
   "private": true,
   "version": "0.1.0",
+  "description": "Family Greenhouse web app — React + TypeScript + Vite PWA for collaborative household plant care.",
   "license": "Elastic-2.0",
   "type": "module",
   "scripts": {

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -29,4 +29,4 @@ Disallow: /forgot-password
 Disallow: /join/
 Disallow: /coming-soon
 
-Sitemap: https://app.familygreenhouse.com/sitemap.xml
+Sitemap: https://familygreenhouse.net/sitemap.xml

--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -1,142 +1,142 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://app.familygreenhouse.com/</loc>
+    <loc>https://familygreenhouse.net/</loc>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://app.familygreenhouse.com/pricing</loc>
+    <loc>https://familygreenhouse.net/pricing</loc>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://app.familygreenhouse.com/blog</loc>
+    <loc>https://familygreenhouse.net/blog</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://app.familygreenhouse.com/care</loc>
+    <loc>https://familygreenhouse.net/care</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://app.familygreenhouse.com/pet-safe</loc>
+    <loc>https://familygreenhouse.net/pet-safe</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://app.familygreenhouse.com/changelog</loc>
+    <loc>https://familygreenhouse.net/changelog</loc>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://app.familygreenhouse.com/status</loc>
+    <loc>https://familygreenhouse.net/status</loc>
     <changefreq>daily</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
-    <loc>https://app.familygreenhouse.com/legal/privacy</loc>
+    <loc>https://familygreenhouse.net/legal/privacy</loc>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
-    <loc>https://app.familygreenhouse.com/legal/terms</loc>
+    <loc>https://familygreenhouse.net/legal/terms</loc>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
-    <loc>https://app.familygreenhouse.com/blog/how-to-remember-to-water-plants</loc>
+    <loc>https://familygreenhouse.net/blog/how-to-remember-to-water-plants</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <lastmod>2026-05-05</lastmod>
   </url>
   <url>
-    <loc>https://app.familygreenhouse.com/blog/sharing-plant-care-without-becoming-the-nag</loc>
+    <loc>https://familygreenhouse.net/blog/sharing-plant-care-without-becoming-the-nag</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <lastmod>2026-05-13</lastmod>
   </url>
   <url>
-    <loc>https://app.familygreenhouse.com/blog/low-maintenance-houseplants-for-forgetful-people</loc>
+    <loc>https://familygreenhouse.net/blog/low-maintenance-houseplants-for-forgetful-people</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <lastmod>2026-05-21</lastmod>
   </url>
   <url>
-    <loc>https://app.familygreenhouse.com/blog/how-to-move-plants-without-killing-them</loc>
+    <loc>https://familygreenhouse.net/blog/how-to-move-plants-without-killing-them</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <lastmod>2026-05-28</lastmod>
   </url>
   <url>
-    <loc>https://app.familygreenhouse.com/blog/pet-safe-houseplants-that-are-hard-to-kill</loc>
+    <loc>https://familygreenhouse.net/blog/pet-safe-houseplants-that-are-hard-to-kill</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <lastmod>2026-06-15</lastmod>
   </url>
   <url>
-    <loc>https://app.familygreenhouse.com/blog/most-common-toxic-houseplants-and-safer-swaps</loc>
+    <loc>https://familygreenhouse.net/blog/most-common-toxic-houseplants-and-safer-swaps</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <lastmod>2026-06-16</lastmod>
   </url>
   <url>
-    <loc>https://app.familygreenhouse.com/care/pothos</loc>
+    <loc>https://familygreenhouse.net/care/pothos</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <lastmod>2026-06-08</lastmod>
   </url>
   <url>
-    <loc>https://app.familygreenhouse.com/care/snake-plant</loc>
+    <loc>https://familygreenhouse.net/care/snake-plant</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <lastmod>2026-06-08</lastmod>
   </url>
   <url>
-    <loc>https://app.familygreenhouse.com/care/monstera</loc>
+    <loc>https://familygreenhouse.net/care/monstera</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <lastmod>2026-06-08</lastmod>
   </url>
   <url>
-    <loc>https://app.familygreenhouse.com/care/spider-plant</loc>
+    <loc>https://familygreenhouse.net/care/spider-plant</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <lastmod>2026-06-12</lastmod>
   </url>
   <url>
-    <loc>https://app.familygreenhouse.com/care/peace-lily</loc>
+    <loc>https://familygreenhouse.net/care/peace-lily</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <lastmod>2026-06-17</lastmod>
   </url>
   <url>
-    <loc>https://app.familygreenhouse.com/care/heartleaf-philodendron</loc>
+    <loc>https://familygreenhouse.net/care/heartleaf-philodendron</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <lastmod>2026-06-17</lastmod>
   </url>
   <url>
-    <loc>https://app.familygreenhouse.com/care/zz-plant</loc>
+    <loc>https://familygreenhouse.net/care/zz-plant</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <lastmod>2026-06-17</lastmod>
   </url>
   <url>
-    <loc>https://app.familygreenhouse.com/care/aloe-vera</loc>
+    <loc>https://familygreenhouse.net/care/aloe-vera</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <lastmod>2026-06-17</lastmod>
   </url>
   <url>
-    <loc>https://app.familygreenhouse.com/care/dieffenbachia</loc>
+    <loc>https://familygreenhouse.net/care/dieffenbachia</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <lastmod>2026-06-17</lastmod>
   </url>
   <url>
-    <loc>https://app.familygreenhouse.com/care/calathea</loc>
+    <loc>https://familygreenhouse.net/care/calathea</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <lastmod>2026-06-17</lastmod>

--- a/frontend/scripts/build-sitemap.mjs
+++ b/frontend/scripts/build-sitemap.mjs
@@ -25,7 +25,11 @@ const POSTS = join(ROOT, 'src', 'features', 'blog', 'posts', 'index.ts');
 const CARE = join(ROOT, 'src', 'features', 'care', 'careGuides.ts');
 const OUT = join(ROOT, 'public', 'sitemap.xml');
 
-const SITE = process.env.SITE_URL || 'https://app.familygreenhouse.com';
+// Canonical production origin. MUST match src/config/site.ts (SITE_URL) — this
+// is a vanilla Node script so it can't import the TS const. The prior default
+// (app.familygreenhouse.com) doesn't resolve, so every generated <loc> pointed
+// search engines at a dead domain.
+const SITE = process.env.SITE_URL || 'https://familygreenhouse.net';
 
 const STATIC_ROUTES = [
   { path: '/', priority: 1.0, changefreq: 'weekly' },

--- a/frontend/src/config/site.ts
+++ b/frontend/src/config/site.ts
@@ -1,0 +1,18 @@
+/**
+ * The canonical production origin — the single source of truth for absolute
+ * URLs in SEO surfaces (canonical links, JSON-LD `@id`, Open Graph image URLs).
+ *
+ * Previously each page hardcoded `https://app.familygreenhouse.com`, which
+ * drifted from the live domain (`familygreenhouse.net`) and silently pointed
+ * every sitemap entry, canonical signal, and structured-data URL at a host that
+ * doesn't resolve — telling Google the "real" version of each page lived on a
+ * dead domain. One constant keeps that from happening again. The two static
+ * SEO assets that can't import this (`public/robots.txt`, `public/sitemap.xml`)
+ * must use the same value.
+ */
+export const SITE_URL = 'https://familygreenhouse.net';
+
+/** Build an absolute site URL from a root-relative path (e.g. `/care/pothos`). */
+export function siteUrl(path = '/'): string {
+  return `${SITE_URL}${path.startsWith('/') ? path : `/${path}`}`;
+}

--- a/frontend/src/features/blog/BlogIndex.tsx
+++ b/frontend/src/features/blog/BlogIndex.tsx
@@ -3,6 +3,7 @@ import { BrandMark } from '@/components/BrandMark';
 import { Footer } from '@/components/Footer';
 import { POSTS } from './posts';
 import { useMetaTags } from '@/hooks/useMetaTags';
+import { siteUrl } from '@/config/site';
 
 const PAGE_TITLE = 'Blog — Family Greenhouse';
 const PAGE_DESCRIPTION =
@@ -17,6 +18,7 @@ export function BlogIndex() {
   useMetaTags({
     title: PAGE_TITLE,
     description: PAGE_DESCRIPTION,
+    canonical: siteUrl('/blog'),
   });
 
   return (

--- a/frontend/src/features/blog/BlogPost.tsx
+++ b/frontend/src/features/blog/BlogPost.tsx
@@ -5,6 +5,7 @@ import { Footer } from '@/components/Footer';
 import { Button } from '@/components/Button';
 import { findPost, POSTS } from './posts';
 import { useMetaTags } from '@/hooks/useMetaTags';
+import { SITE_URL } from '@/config/site';
 
 /**
  * Single-post page. The post itself is a self-contained TSX component;
@@ -20,6 +21,7 @@ export function BlogPost() {
       ? {
           title: `${post.title} — Family Greenhouse`,
           description: post.description,
+          canonical: `${SITE_URL}/blog/${post.slug}`,
           // Article schema makes the post eligible for Google's article
           // rich-results treatment. We don't have author photos or a
           // publisher logo URL set up yet — those are nice-to-haves that
@@ -37,12 +39,12 @@ export function BlogPost() {
               name: 'Family Greenhouse',
               logo: {
                 '@type': 'ImageObject',
-                url: 'https://app.familygreenhouse.com/brand/icon-512.png',
+                url: `${SITE_URL}/brand/icon-512.png`,
               },
             },
             mainEntityOfPage: {
               '@type': 'WebPage',
-              '@id': `https://app.familygreenhouse.com/blog/${post.slug}`,
+              '@id': `${SITE_URL}/blog/${post.slug}`,
             },
           },
         }

--- a/frontend/src/features/care/CareGuidePage.tsx
+++ b/frontend/src/features/care/CareGuidePage.tsx
@@ -4,9 +4,10 @@ import { BrandMark } from '@/components/BrandMark';
 import { Footer } from '@/components/Footer';
 import { Button } from '@/components/Button';
 import { useMetaTags } from '@/hooks/useMetaTags';
+import { SITE_URL } from '@/config/site';
 import { CARE_GUIDES, findCareGuide, type CareGuide } from './careGuides';
 
-const SITE = 'https://app.familygreenhouse.com';
+const SITE = SITE_URL;
 
 function Paragraphs({ items }: { items: string[] }) {
   return (
@@ -35,6 +36,7 @@ export function CareGuidePage() {
       ? {
           title: guide.metaTitle,
           description: guide.metaDescription,
+          canonical: `${SITE}/care/${guide.slug}`,
           jsonLd: {
             '@context': 'https://schema.org',
             '@graph': [

--- a/frontend/src/features/care/CareIndex.tsx
+++ b/frontend/src/features/care/CareIndex.tsx
@@ -2,6 +2,7 @@ import { Link } from 'react-router-dom';
 import { BrandMark } from '@/components/BrandMark';
 import { Footer } from '@/components/Footer';
 import { useMetaTags } from '@/hooks/useMetaTags';
+import { siteUrl } from '@/config/site';
 import { CARE_GUIDES } from './careGuides';
 
 /**
@@ -14,6 +15,7 @@ export function CareIndex() {
     title: 'Plant Care Guides — How Often to Water Common Houseplants',
     description:
       'Straight, no-nonsense care guides for common houseplants: how often to water, how much light, and why yours might be dying.',
+    canonical: siteUrl('/care'),
   });
 
   return (

--- a/frontend/src/features/landing/LandingPage.tsx
+++ b/frontend/src/features/landing/LandingPage.tsx
@@ -326,7 +326,7 @@ function AppMockup({ className }: { className?: string }) {
               <div className="w-3 h-3 rounded-full bg-primary-400/80" />
             </div>
             <div className="flex-1 text-center text-sm text-primary-900/70">
-              app.familygreenhouse.com
+              familygreenhouse.net
             </div>
           </div>
 

--- a/frontend/src/features/petsafe/PetSafePage.tsx
+++ b/frontend/src/features/petsafe/PetSafePage.tsx
@@ -5,6 +5,7 @@ import { Footer } from '@/components/Footer';
 import { Alert } from '@/components/Alert';
 import { Input } from '@/components/Input';
 import { useMetaTags } from '@/hooks/useMetaTags';
+import { siteUrl } from '@/config/site';
 import { useDebounce } from '@/hooks/useDebounce';
 import { petToxicityService, type ToxicityMatch } from '@/services/petToxicityService';
 
@@ -23,6 +24,7 @@ export function PetSafePage() {
     title: 'Is This Plant Safe for Pets? — Cat & Dog Toxicity Checker',
     description:
       'Free, no-signup checker: type a houseplant name and see whether it’s toxic to cats and dogs, in plain language. Based on the ASPCA’s plant safety data.',
+    canonical: siteUrl('/pet-safe'),
   });
 
   const [query, setQuery] = useState('');

--- a/frontend/src/features/pricing/PricingPage.tsx
+++ b/frontend/src/features/pricing/PricingPage.tsx
@@ -2,6 +2,7 @@ import { Link } from 'react-router-dom';
 import { BrandMark } from '@/components/BrandMark';
 import { Footer } from '@/components/Footer';
 import { useMetaTags } from '@/hooks/useMetaTags';
+import { siteUrl } from '@/config/site';
 import { PricingGrid } from './PricingGrid';
 
 /**
@@ -16,6 +17,7 @@ export function PricingPage() {
     title: 'Pricing — Family Greenhouse',
     description:
       'Family Greenhouse pricing: free for up to 10 plants, paid plans for larger households and households that want care analytics, API access, and unlimited plants.',
+    canonical: siteUrl('/pricing'),
   });
 
   return (

--- a/frontend/src/hooks/useMetaTags.ts
+++ b/frontend/src/hooks/useMetaTags.ts
@@ -17,6 +17,10 @@ export interface MetaTags {
   description?: string;
   /** Path under /og-cards/ for a per-post OG image, if shipped. */
   ogImage?: string;
+  /** Absolute canonical URL for this route. Sets <link rel="canonical"> + og:url
+   *  so Google (which renders the SPA) attributes the page to the right URL
+   *  instead of guessing — important for the indexable marketing routes. */
+  canonical?: string;
   /** Optional JSON-LD payload (Article, FAQ, etc.). The shape isn't
    *  validated here — caller is responsible for emitting valid schema.org. */
   jsonLd?: Record<string, unknown>;
@@ -33,6 +37,25 @@ function setMeta(name: string, content: string, attr: 'name' | 'property' = 'nam
   const tag = document.createElement('meta');
   tag.setAttribute(attr, name);
   tag.setAttribute('content', content);
+  document.head.appendChild(tag);
+  return () => tag.remove();
+}
+
+/** Set (or create) a <link rel="canonical">, restoring the prior href on
+ *  cleanup so leaving the route doesn't leak its canonical onto the next. */
+function setCanonical(href: string): () => void {
+  const existing = document.querySelector<HTMLLinkElement>('link[rel="canonical"]');
+  if (existing) {
+    const previous = existing.getAttribute('href');
+    existing.setAttribute('href', href);
+    return () => {
+      if (previous === null) existing.removeAttribute('href');
+      else existing.setAttribute('href', previous);
+    };
+  }
+  const tag = document.createElement('link');
+  tag.setAttribute('rel', 'canonical');
+  tag.setAttribute('href', href);
   document.head.appendChild(tag);
   return () => tag.remove();
 }
@@ -61,6 +84,10 @@ export function useMetaTags(meta: MetaTags): void {
     if (meta.ogImage) {
       cleanups.push(setMeta('og:image', meta.ogImage, 'property'));
     }
+    if (meta.canonical) {
+      cleanups.push(setCanonical(meta.canonical));
+      cleanups.push(setMeta('og:url', meta.canonical, 'property'));
+    }
     if (jsonLdKey) {
       // JSON-LD goes in a dedicated <script type="application/ld+json">.
       // We tag it with a data attribute we own so we can clean up on
@@ -76,5 +103,5 @@ export function useMetaTags(meta: MetaTags): void {
     return () => {
       for (const cleanup of cleanups) cleanup();
     };
-  }, [meta.title, meta.description, meta.ogImage, jsonLdKey]);
+  }, [meta.title, meta.description, meta.ogImage, meta.canonical, jsonLdKey]);
 }

--- a/frontend/tests/unit/hooks/useMetaTags.test.tsx
+++ b/frontend/tests/unit/hooks/useMetaTags.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useMetaTags } from '@/hooks/useMetaTags';
+
+describe('useMetaTags canonical', () => {
+  it('creates a canonical link + og:url, and removes the link it created on unmount', () => {
+    const { unmount } = renderHook(() =>
+      useMetaTags({ title: 'Pothos Care', canonical: 'https://familygreenhouse.net/care/pothos' })
+    );
+
+    expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+      'https://familygreenhouse.net/care/pothos'
+    );
+    expect(document.querySelector('meta[property="og:url"]')?.getAttribute('content')).toBe(
+      'https://familygreenhouse.net/care/pothos'
+    );
+
+    unmount();
+    // The link/meta this hook created are cleaned up so the next route doesn't
+    // inherit a stale canonical.
+    expect(document.querySelector('link[rel="canonical"]')).toBeNull();
+    expect(document.querySelector('meta[property="og:url"]')).toBeNull();
+  });
+
+  it('overrides a pre-existing homepage canonical and restores its href on unmount', () => {
+    // If a canonical link already exists (e.g. one route navigating to another
+    // before cleanup), the hook overrides its href and restores it on unmount
+    // rather than removing a link it didn't create.
+    const pre = document.createElement('link');
+    pre.setAttribute('rel', 'canonical');
+    pre.setAttribute('href', 'https://familygreenhouse.net/');
+    document.head.appendChild(pre);
+
+    const { unmount } = renderHook(() =>
+      useMetaTags({
+        canonical: 'https://familygreenhouse.net/blog/how-to-remember-to-water-plants',
+      })
+    );
+    expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+      'https://familygreenhouse.net/blog/how-to-remember-to-water-plants'
+    );
+
+    unmount();
+    expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+      'https://familygreenhouse.net/'
+    );
+    pre.remove();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -3,7 +3,33 @@
   "version": "0.1.0",
   "license": "Elastic-2.0",
   "private": true,
-  "description": "A collaborative plant care management application for families",
+  "description": "A shared plant-care journal for the whole household — per-plant schedules, reminders that find the right person across browser/email/SMS, and a care log everyone can see. React + TypeScript on AWS Lambda + DynamoDB + Cognito.",
+  "keywords": [
+    "plant-care",
+    "houseplants",
+    "gardening",
+    "plant-tracker",
+    "plant-reminder",
+    "watering-reminder",
+    "household",
+    "family",
+    "pwa",
+    "react",
+    "typescript",
+    "serverless",
+    "aws-lambda",
+    "dynamodb",
+    "terraform"
+  ],
+  "homepage": "https://familygreenhouse.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ChelseaKR/family-greenhouse.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ChelseaKR/family-greenhouse/issues"
+  },
+  "author": "Chelsea Kelly-Reif",
   "workspaces": [
     "frontend",
     "backend"


### PR DESCRIPTION
Deep research pass over the README and every findability surface (repo metadata, SEO `<head>`, sitemap, robots, structured data). One **critical bug**, plus hygiene + discoverability enrichment.

## 🔴 Critical — the entire public SEO surface pointed at a dead domain
`robots.txt`, the generated `sitemap.xml`, every care-guide & blog-post **canonical + JSON-LD `@id`**, and the landing mock all used **`app.familygreenhouse.com`** — which **does not resolve**. The live site is **`familygreenhouse.net`** (verified: `.net` serves the sitemap and all ~26 SEO routes 200; `.com` → no DNS).

Impact: the sitemap served at `.net` listed every indexable page under a domain Google can't reach (cross-domain sitemap URLs are ignored), and each care/blog page's canonical told Google the "real" version lived on a host that 404s — self-deindexing the best SEO pages.

**Root cause:** `scripts/build-sitemap.mjs` defaulted `SITE_URL` to the dead domain (a `prebuild` step regenerates the sitemap, so editing the output alone wasn't enough). Fixed:
- Centralized the origin in **`src/config/site.ts`** (`SITE_URL = https://familygreenhouse.net`) — one source of truth, since per-file hardcoding is exactly what drifted.
- Fixed the generator default + regenerated; swept all `src`/`public` references.

## 🟡 Canonical / Open Graph hygiene
- Added `canonical` to `useMetaTags` (sets `<link rel="canonical">` + `og:url`, restored on route change); wired through care guides, blog posts, and `/care` `/blog` `/pricing` `/pet-safe`.
- **Deliberately did NOT** add a static homepage canonical to `index.html`: one HTML serves every SPA route, so a hardcoded `/` canonical would mis-canonicalize sub-routes and drop them. Routes without an explicit canonical fall back to URL-as-canonical (safe).
- `index.html`: **absolute** `og:image`/`twitter:image` (scrapers reject relative), plus `og:site_name`, `og:image:alt`, `twitter:title`/`twitter:description`.

## 🟢 Repo & README findability
- **package.json** (root): real description, `keywords`, `homepage`, `repository`, `bugs`, `author`; frontend/backend get descriptions.
- **GitHub topics** 9 → 19 (added dynamodb, cognito, vite, tailwindcss, stripe, web-push, plant-tracker, plant-reminder, household, single-table-design).
- **README**: badge row (CI · live · license · PWA · stack), a live-demo callout, keyword-rich intro.

## Tests
`useMetaTags` canonical create+remove and override+restore. Frontend typecheck, lint, **344 tests**, build (sitemap regenerates to `.net`) all green.

## One manual follow-up (can't be done via API)
The repo's **social preview image** still uses GitHub's default. You have a perfect `frontend/public/brand/og-image.png` — upload it under **Settings → General → Social preview** to finish the GitHub-share polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)