### PR TITLE
fix(pet-safety): stop false non-toxic verdict on "asparagus fern" queries

### DIFF
--- a/backend/src/models/petToxicity.ts
+++ b/backend/src/models/petToxicity.ts
@@ -160,6 +160,20 @@ export const PET_TOXICITY: PetToxicityEntry[] = [
     note: 'Non-toxic to cats and dogs per the ASPCA — true ferns are a reliably safe group. Pets sometimes bat at the fronds; no harm done beyond a bit of mess.',
   },
   {
+    slug: 'asparagus-fern',
+    commonName: 'Asparagus fern',
+    scientificName: 'Asparagus densiflorus',
+    // Despite the name, this is NOT a true fern (it's in the asparagus/lily
+    // family) — critically, it does NOT belong in the "true ferns are safe"
+    // group above. Deliberately no bare "fern" alias: that would collide
+    // with boston-fern's "fern" alias in the word-overlap matching tier and
+    // reintroduce the exact false-negative this entry exists to close.
+    aliases: ['sprenger fern', 'emerald fern', 'foxtail fern', 'asparagus densiflorus'],
+    cats: 'toxic',
+    dogs: 'toxic',
+    note: 'Toxic to cats and dogs per the ASPCA — the berries carry sapogenins that cause vomiting, diarrhea and abdominal pain, and repeated skin contact with the sap can cause allergic dermatitis. Keep it well out of reach.',
+  },
+  {
     slug: 'african-violet',
     commonName: 'African violet',
     scientificName: 'Saintpaulia',
@@ -253,7 +267,11 @@ function toMatch(entry: PetToxicityEntry): PetToxicityMatch {
  *   1. exact name/alias hit
  *   2. query is a prefix of a name/alias (typeahead)
  *   3. any name/alias contains the query (substring)
- *   4. any query word appears in a name/alias (loose word overlap)
+ *   4. every query word (individually) appears in some name/alias (loose
+ *      word overlap) — deliberately requires ALL words, not just one: a
+ *      single generic alias word (e.g. Boston fern's bare "fern" alias)
+ *      must not alone satisfy a multi-word query like "asparagus fern" and
+ *      hand back an unrelated species' (possibly wrong) toxicity verdict.
  */
 export function lookupToxicity(query: string, limit = 5): PetToxicityMatch[] {
   const q = normalizeName(query);
@@ -277,7 +295,7 @@ export function lookupToxicity(query: string, limit = 5): PetToxicityMatch[] {
       prefix.push(entry);
     } else if (names.some((n) => n.includes(q))) {
       substring.push(entry);
-    } else if (qWords.length > 0 && names.some((n) => qWords.some((w) => n.includes(w)))) {
+    } else if (qWords.length > 0 && qWords.every((w) => names.some((n) => n.includes(w)))) {
       word.push(entry);
     }
   }

--- a/backend/tests/unit/models/petToxicity.test.ts
+++ b/backend/tests/unit/models/petToxicity.test.ts
@@ -152,6 +152,36 @@ describe('lookupToxicity', () => {
       expect(m.note.length).toBeGreaterThan(0);
     }
   });
+
+  it('flags asparagus fern as toxic, not the unrelated non-toxic Boston fern', () => {
+    // Regression: "asparagus fern" used to word-overlap-match Boston fern's
+    // bare "fern" alias and return a confident (wrong) non-toxic verdict for
+    // a genuinely toxic plant.
+    const slugs = lookupToxicity('asparagus fern', 5).map((m) => m.slug);
+    expect(slugs).toContain('asparagus-fern');
+    expect(slugs).not.toContain('boston-fern');
+    const [hit] = lookupToxicity('asparagus fern');
+    expect(hit?.cats).toBe('toxic');
+    expect(hit?.dogs).toBe('toxic');
+  });
+
+  it('emerald fern and foxtail fern (asparagus fern aliases) also resolve to the toxic entry', () => {
+    expect(lookupToxicity('emerald fern')[0]?.slug).toBe('asparagus-fern');
+    expect(lookupToxicity('foxtail fern')[0]?.slug).toBe('asparagus-fern');
+  });
+
+  it('a bare single-word query still matches via the loose word-overlap tier', () => {
+    // The tightened word tier requires ALL query words to match — for a
+    // single-word query that's unchanged behavior (every === some here).
+    const slugs = lookupToxicity('fern', 5).map((m) => m.slug);
+    expect(slugs).toContain('boston-fern');
+  });
+
+  it('the word-overlap tier requires every query word to appear, not just one', () => {
+    // A query combining a real word from one entry with a nonsense word
+    // should NOT match on the strength of the one real word alone.
+    expect(lookupToxicity('zzznotaword fern').map((m) => m.slug)).not.toContain('boston-fern');
+  });
 });
 
 // Type-only guard: keeps the exported entry type exercised by the suite.


### PR DESCRIPTION
## Summary
- The public, unauthenticated `GET /species/toxicity` lookup returned Boston fern ("non-toxic") as the sole result for "asparagus fern" — a real, common houseplant that's actually toxic to cats and dogs per the ASPCA (sapogenins; vomiting/diarrhea/dermatitis).
- Root cause: asparagus fern was never in the catalog, so the loose word-overlap matching tier fell back to matching Boston fern's bare `"fern"` alias against one word of the two-word query, returning a confident but wrong verdict.
- Fix: (1) add the missing `asparagus-fern` catalog entry, and (2) tighten the word-overlap tier to require **every** query word to match some name/alias, not just one — this closes the whole class of false match for any other species that might share a generic single-word alias.

Found by an automated repo-wide audit (see the pre-existing "field a wrong answer does real harm on" comment at the top of `petToxicity.ts` — this is exactly that failure mode).

## Test plan
- [x] Added regression tests: "asparagus fern" resolves to the toxic entry and no longer surfaces Boston fern; its aliases ("emerald fern", "foxtail fern") also resolve correctly
- [x] Added tests confirming single-word queries (e.g. bare "fern") are unaffected by the tightened word-tier logic
- [x] Full backend suite: 1009/1009 passing
- [x] Full frontend suite: 344/344 passing
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)