### PR TITLE
fix(billing): cap-check plant reactivation, correct stale seedling member-cap doc

### DIFF
--- a/backend/src/handlers/plants/handler.ts
+++ b/backend/src/handlers/plants/handler.ts
@@ -202,7 +202,29 @@ export const updatePlant = createHandler(
       }
     }
 
-    const plant = await plantService.updatePlant(user.householdId!, plantId, validatedBody);
+    // Reactivating a plant (died/gave_away -> active) is cap-checked exactly
+    // like createPlant — see plantService.updatePlant for why this can't be
+    // left uncapped now that the active-plant count is an atomic counter.
+    const sub = await billing.getHouseholdSubscription(user.householdId!);
+    const plan = getPlan(sub.planId);
+
+    let plant: Awaited<ReturnType<typeof plantService.updatePlant>>;
+    try {
+      plant = await plantService.updatePlant(
+        user.householdId!,
+        plantId,
+        validatedBody,
+        plan.maxPlants
+      );
+    } catch (err) {
+      if (err instanceof Error && err.name === 'PlanLimitError') {
+        throw createHttpError(
+          402,
+          `Your ${plan.name} plan is limited to ${plan.maxPlants} plants. Upgrade to add more.`
+        );
+      }
+      throw err;
+    }
 
     if (!plant) {
       throw createHttpError(404, 'Plant not found');

--- a/backend/src/services/plantService.ts
+++ b/backend/src/services/plantService.ts
@@ -262,7 +262,8 @@ export async function getPlants(
 export async function updatePlant(
   householdId: string,
   plantId: string,
-  input: UpdatePlantInput
+  input: UpdatePlantInput,
+  maxPlants: number
 ): Promise<Plant | null> {
   const updateExpressions: string[] = [];
   const expressionAttributeNames: Record<string, string> = {};
@@ -373,10 +374,13 @@ export async function updatePlant(
 
   // Status transitions move the active-plant counter on the household
   // METADATA row (the plan cap counts ACTIVE plants — see createPlant):
-  // leaving 'active' decrements, returning to 'active' increments. Note the
-  // semantics are deliberately identical to the pre-counter cap check:
-  // re-activating a plant is NOT cap-checked (it never was), it just makes
-  // the counter reflect reality for the next create.
+  // leaving 'active' decrements, returning to 'active' increments.
+  // Reactivation (delta===1) is cap-checked exactly like createPlant: die a
+  // plant, create a replacement under the freed cap, then reactivate the
+  // died one nets +1 active plant above the cap if left unchecked — a real
+  // bypass introduced by the atomic counter (the old count-then-write check
+  // recomputed the active count from scratch on every create, so nothing
+  // could be "banked" this way).
   //
   // The plant write and the counter move ride one TransactWriteCommand,
   // conditioned on the status we just read, so a concurrent transition can't
@@ -432,17 +436,28 @@ export async function updatePlant(
                   delta === 1
                     ? 'SET plantCount = if_not_exists(plantCount, :zero) + :one'
                     : 'SET plantCount = if_not_exists(plantCount, :one) - :one',
-                ConditionExpression: 'attribute_exists(PK)',
-                ExpressionAttributeValues: delta === 1 ? { ':zero': 0, ':one': 1 } : { ':one': 1 },
+                // Reactivation (delta===1) is cap-checked, same as createPlant;
+                // the decrement (delta===-1) is never capped — leaving 'active'
+                // can only reduce the count.
+                ConditionExpression:
+                  delta === 1
+                    ? 'attribute_exists(PK) AND (attribute_not_exists(plantCount) OR plantCount < :max)'
+                    : 'attribute_exists(PK)',
+                ExpressionAttributeValues:
+                  delta === 1 ? { ':zero': 0, ':one': 1, ':max': maxPlants } : { ':one': 1 },
               },
             },
           ],
         })
       );
     } catch (err) {
-      if (transactCancellationReasons(err)[0]?.Code === 'ConditionalCheckFailed') {
+      const reasons = transactCancellationReasons(err);
+      if (reasons[0]?.Code === 'ConditionalCheckFailed') {
         // Concurrent status change beat us — re-read and retry once.
         continue;
+      }
+      if (delta === 1 && reasons[1]?.Code === 'ConditionalCheckFailed') {
+        throw new PlanLimitError(`Plant limit of ${maxPlants} reached`);
       }
       throw err;
     }

--- a/backend/tests/unit/handlers/plantShare.test.ts
+++ b/backend/tests/unit/handlers/plantShare.test.ts
@@ -247,9 +247,12 @@ describe('plants handler — propagation + shares', () => {
       const res = (await updatePlant(event, fakeContext, () => {})) as APIGatewayProxyResult;
       expect(res.statusCode).toBe(200);
       expect(plantService.getPlant).not.toHaveBeenCalled();
-      expect(plantService.updatePlant).toHaveBeenCalledWith('hh-1', CHILD_ID, {
-        parentPlantId: null,
-      });
+      expect(plantService.updatePlant).toHaveBeenCalledWith(
+        'hh-1',
+        CHILD_ID,
+        { parentPlantId: null },
+        500 // garden plan's maxPlants, per the billing.js mock above
+      );
     });
   });
 

--- a/backend/tests/unit/services/plantService.test.ts
+++ b/backend/tests/unit/services/plantService.test.ts
@@ -533,7 +533,7 @@ describe('plantService', () => {
       const { dynamodb } = await import('../../../src/utils/dynamodb');
       const { updatePlant } = await import('../../../src/services/plantService');
       vi.mocked(dynamodb.send).mockResolvedValueOnce({ Attributes: plantRow('active').Item });
-      const result = await updatePlant('hh', 'p1', { name: 'Renamed' });
+      const result = await updatePlant('hh', 'p1', { name: 'Renamed' }, 10);
       expect(result?.id).toBe('p1');
       const calls = vi.mocked(dynamodb.send).mock.calls;
       expect(calls).toHaveLength(1);
@@ -547,7 +547,7 @@ describe('plantService', () => {
       vi.mocked(dynamodb.send).mockResolvedValueOnce({}); // TransactWrite
       vi.mocked(dynamodb.send).mockResolvedValueOnce(plantRow('died')); // re-read
 
-      const result = await updatePlant('hh', 'p1', { status: 'died' });
+      const result = await updatePlant('hh', 'p1', { status: 'died' }, 10);
       expect(result?.status).toBe('died');
 
       const transact = vi.mocked(dynamodb.send).mock.calls[1][0] as unknown as TransitionTransact;
@@ -573,7 +573,7 @@ describe('plantService', () => {
       vi.mocked(dynamodb.send).mockResolvedValueOnce({});
       vi.mocked(dynamodb.send).mockResolvedValueOnce(plantRow('active'));
 
-      const result = await updatePlant('hh', 'p1', { status: 'active' });
+      const result = await updatePlant('hh', 'p1', { status: 'active' }, 10);
       expect(result?.status).toBe('active');
 
       const transact = vi.mocked(dynamodb.send).mock.calls[1][0] as unknown as TransitionTransact;
@@ -585,6 +585,31 @@ describe('plantService', () => {
       expect(counterUpdate.Update.UpdateExpression).toBe(
         'SET plantCount = if_not_exists(plantCount, :zero) + :one'
       );
+      // Reactivation is cap-checked exactly like createPlant.
+      expect(counterUpdate.Update.ConditionExpression).toBe(
+        'attribute_exists(PK) AND (attribute_not_exists(plantCount) OR plantCount < :max)'
+      );
+      expect(counterUpdate.Update.ExpressionAttributeValues[':max']).toBe(10);
+    });
+
+    it('rejects reactivation with PlanLimitError when the household is already at its plant cap', async () => {
+      const { dynamodb } = await import('../../../src/utils/dynamodb');
+      const { updatePlant, PlanLimitError } = await import('../../../src/services/plantService');
+      vi.mocked(dynamodb.send).mockResolvedValueOnce(plantRow('died')); // read current
+      vi.mocked(dynamodb.send).mockRejectedValueOnce(
+        Object.assign(new Error('cancelled'), {
+          name: 'TransactionCanceledException',
+          // reasons[0] (plant status write) succeeds; reasons[1] (the
+          // METADATA counter's cap condition) is the one that fails.
+          CancellationReasons: [{ Code: 'None' }, { Code: 'ConditionalCheckFailed' }],
+        })
+      );
+
+      await expect(updatePlant('hh', 'p1', { status: 'active' }, 10)).rejects.toThrow(
+        PlanLimitError
+      );
+      // Must NOT retry a genuine cap failure the way it retries a status race.
+      expect(vi.mocked(dynamodb.send).mock.calls).toHaveLength(2);
     });
 
     it('died → gave_away does not move the counter (never left the non-active population)', async () => {
@@ -593,7 +618,7 @@ describe('plantService', () => {
       vi.mocked(dynamodb.send).mockResolvedValueOnce(plantRow('died')); // read current
       vi.mocked(dynamodb.send).mockResolvedValueOnce({ Attributes: plantRow('gave_away').Item });
 
-      const result = await updatePlant('hh', 'p1', { status: 'gave_away' });
+      const result = await updatePlant('hh', 'p1', { status: 'gave_away' }, 10);
       expect(result?.status).toBe('gave_away');
       const calls = vi.mocked(dynamodb.send).mock.calls;
       expect(calls).toHaveLength(2);
@@ -617,7 +642,7 @@ describe('plantService', () => {
       vi.mocked(dynamodb.send).mockResolvedValueOnce(plantRow('died'));
       vi.mocked(dynamodb.send).mockResolvedValueOnce({ Attributes: plantRow('died').Item });
 
-      const result = await updatePlant('hh', 'p1', { status: 'died' });
+      const result = await updatePlant('hh', 'p1', { status: 'died' }, 10);
       expect(result?.status).toBe('died');
       expect(vi.mocked(dynamodb.send).mock.calls).toHaveLength(4);
     });
@@ -626,7 +651,7 @@ describe('plantService', () => {
       const { dynamodb } = await import('../../../src/utils/dynamodb');
       const { updatePlant } = await import('../../../src/services/plantService');
       vi.mocked(dynamodb.send).mockResolvedValueOnce({ Item: undefined });
-      expect(await updatePlant('hh', 'gone', { status: 'died' })).toBeNull();
+      expect(await updatePlant('hh', 'gone', { status: 'died' }, 10)).toBeNull();
     });
   });
 

--- a/docs/billing.md
+++ b/docs/billing.md
@@ -8,9 +8,18 @@ Source of truth: `backend/src/models/plans.ts`.
 
 | Plan       | Monthly | Plants cap | Members cap | Notes                           |
 | ---------- | ------- | ---------- | ----------- | ------------------------------- |
-| Seedling   | Free    | 10         | 1           | Default for every new household |
+| Seedling   | Free    | 10         | 6           | Default for every new household |
 | Garden     | $4.99   | 500        | 6           | 14-day free trial via Stripe    |
 | Greenhouse | $9.99   | 5000       | 50          | 14-day free trial               |
+
+Seedling's member cap is deliberately the same as Garden's, not 1 — household
+sharing is a free, unrestricted capability by design (competitors like
+Planta paywall it entirely; matching that would give up the product's main
+differentiator). Only plant count and paid-feature depth are monetization
+levers. This table previously listed 1 for Seedling, which was stale
+relative to `plans.ts` and the marketing pricing page (both already say 6) —
+if you're about to "fix" `plans.ts` to match a "1" you saw somewhere, don't;
+check here and the marketing copy first.
 
 Caps are enforced in:
 


### PR DESCRIPTION
## Summary
- **Bypass fix:** reactivating a plant (died/gave_away → active) incremented the household's active-plant counter with no plan-cap check. Exploit: mark a plant died (frees a counter slot) → create a new plant under the now-lower count → reactivate the died one → net +1 active plant above the cap, repeatable without limit. `createPlant` already cap-checks the same counter atomically; `updatePlant` now does too, via the identical conditional-increment pattern, surfacing the same 402 `PlanLimitError` response.
- **Doc correction, not a code change:** `docs/billing.md` claimed the free (Seedling) tier's member cap is 1. Both `plans.ts` (which the doc itself calls "source of truth") and the customer-facing pricing page already say 6 — free household sharing is a deliberate differentiator (competitors like Planta paywall it entirely), not a bug. Fixed the stale doc instead of "fixing" working, intentional code down to match it.

Found by an automated repo-wide audit.

## Test plan
- [x] Added regression test: reactivation is rejected with `PlanLimitError`/402 when the household is at its plant cap, and does NOT get treated as a retryable race
- [x] Updated existing reactivation test to assert the new cap `ConditionExpression`
- [x] Full backend suite: 1006/1006 passing
- [x] Full frontend suite: 344/344 passing
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)