### PR TITLE
fix(auth): don't lock out a removed member on every route, only on ones needing a household

### DIFF
--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -120,26 +120,41 @@ export const authMiddleware = (): middy.MiddlewareObj<
     // household to resolve — the membership row decides membership AND
     // role. A user who was removed from their household gets a 403 within
     // the 60s cache TTL instead of keeping access until token expiry.
+    //
+    // That 403 must only fire for an EXPLICIT header override — a caller
+    // that deliberately asked for a specific household and isn't a member of
+    // it. A stale/wrong CLAIM default (e.g. the user was just removed from
+    // their default household but still belongs to another one, or belongs
+    // to none) must degrade to householdId=null instead of hard-403ing,
+    // because that 403 previously fired on EVERY authenticated route —
+    // including GET /me/households and GET /auth/me — leaving the caller no
+    // way to even discover their other households or reach the onboarding
+    // flow without a full logout/login.
     const headerOverride = event.headers?.['x-household-id'] ?? event.headers?.['X-Household-Id'];
+    const isExplicitOverride = typeof headerOverride === 'string' && headerOverride.length > 0;
     const claimHouseholdId = claims['custom:household_id'] || null;
-    const requestedHouseholdId =
-      typeof headerOverride === 'string' && headerOverride.length > 0
-        ? headerOverride
-        : claimHouseholdId;
+    const requestedHouseholdId = isExplicitOverride ? headerOverride : claimHouseholdId;
 
     if (requestedHouseholdId) {
       let role = getCachedMembership(claims.sub, requestedHouseholdId);
       if (!role) {
         const member = await getMemberByUserId(requestedHouseholdId, claims.sub);
         if (!member) {
-          throw createHttpError(403, 'Not a member of the requested household');
+          if (isExplicitOverride) {
+            throw createHttpError(403, 'Not a member of the requested household');
+          }
+          // Stale claim hint, no explicit override — fall through with no
+          // active household rather than locking the caller out entirely.
+        } else {
+          role = member.role;
+          setCachedMembership(claims.sub, requestedHouseholdId, role);
         }
-        role = member.role;
-        setCachedMembership(claims.sub, requestedHouseholdId, role);
       }
-      user.householdId = requestedHouseholdId;
-      // Membership row is authoritative — never the claim's role.
-      user.householdRole = role;
+      if (role) {
+        user.householdId = requestedHouseholdId;
+        // Membership row is authoritative — never the claim's role.
+        user.householdRole = role;
+      }
     }
 
     (event as AuthenticatedEvent).user = user;

--- a/backend/tests/integration/real-handler.test.ts
+++ b/backend/tests/integration/real-handler.test.ts
@@ -68,16 +68,21 @@ describe('real-handler: auth / household-membership boundary', () => {
     expect(ok.statusCode).toBe(200);
     expect(Array.isArray(ok.body)).toBe(true);
 
-    // A non-member presenting the SAME household claim. The clone trusts the
-    // claim; the real authMiddleware re-validates it against the membership
-    // table and rejects with 403 — the bug class the clone can't catch.
+    // A non-member presenting the SAME household as their CLAIM default (no
+    // explicit X-Household-Id header). The clone trusts the claim; the real
+    // authMiddleware re-validates it against the membership table — but
+    // since this is a claim hint, not an explicit override, it degrades to
+    // householdId=null rather than 403ing at authMiddleware itself (a stale
+    // claim must not lock the caller out of every route, incl. GET
+    // /me/households). requireHousehold is what denies this resource route,
+    // with its own generic message — the access is still blocked either way.
     const denied = await invokeHandler(tasksHandler.listTasks, {
       method: 'GET',
       routeKey: 'GET /tasks',
       identity: { ...OUTSIDER, householdId },
     });
     expect(denied.statusCode).toBe(403);
-    expect(denied.body).toMatchObject({ message: 'Not a member of the requested household' });
+    expect(denied.body).toMatchObject({ message: 'User must belong to a household' });
   });
 
   it('401s a request with no Cognito claims at all', async () => {

--- a/backend/tests/unit/middleware/auth.test.ts
+++ b/backend/tests/unit/middleware/auth.test.ts
@@ -91,16 +91,46 @@ describe('authMiddleware', () => {
     expect(householdService.getMemberByUserId).toHaveBeenCalledWith('hh-1', 'user-1');
   });
 
-  it('403s the default claim path when the user is no longer a member (removed member)', async () => {
+  it('degrades to householdId=null (not a 403) when the claim default is stale (removed member, no explicit override)', async () => {
+    // Regression: this used to hard-403 here, at authMiddleware itself, for
+    // EVERY authenticated route including GET /me/households and GET
+    // /auth/me — leaving a just-removed user with no way to even discover
+    // their other households without a full logout/login. The claim is only
+    // a hint; a stale hint should fall through to "no active household",
+    // not lock the caller out entirely. requireHousehold() is what should
+    // 403 resource routes that actually need a household (see below).
     vi.mocked(householdService.getMemberByUserId).mockResolvedValueOnce(null);
-    const { invoke } = makeHandler([authMiddleware()]);
+    const { invoke, inner } = makeHandler([authMiddleware()]);
     const event = buildEvent({
       sub: 'user-1',
       email: 'a@b.com',
       'custom:household_id': 'hh-1',
       'custom:household_role': 'admin',
     });
-    await expect(invoke(event)).rejects.toMatchObject({ statusCode: 403 });
+    const res = await invoke(event);
+    expect(res.statusCode).toBe(200);
+    const calledEvent = inner.mock.calls[0][0] as { user: Record<string, unknown> };
+    expect(calledEvent.user).toEqual({
+      userId: 'user-1',
+      email: 'a@b.com',
+      householdId: null,
+      householdRole: null,
+    });
+  });
+
+  it('requireHousehold still 403s a stale-claim caller on a route that needs a household', async () => {
+    vi.mocked(householdService.getMemberByUserId).mockResolvedValueOnce(null);
+    const { invoke } = makeHandler([authMiddleware(), requireHousehold()]);
+    const event = buildEvent({
+      sub: 'user-1',
+      email: 'a@b.com',
+      'custom:household_id': 'hh-1',
+      'custom:household_role': 'admin',
+    });
+    await expect(invoke(event)).rejects.toMatchObject({
+      statusCode: 403,
+      message: 'User must belong to a household',
+    });
   });
 
   it('takes the role from the membership row, not the claim', async () => {


### PR DESCRIPTION
## Summary
- A stale/invalid claim-derived default household (`custom:household_id`) caused a hard 403 on **every** authenticated route, including `GET /me/households` and `GET /auth/me` — the exact routes a locked-out user would need to recover.
- Scenario: an admin removes a member who still belongs to a second household. Their currently-issued ID token keeps the stale claim for up to ~1h (Cognito claim propagation lag), and since a 403 (unlike a 401) never triggers the frontend's token-refresh interceptor, every subsequent request 403s — the user can't even list or switch to the household they still belong to without a full logout/login.
- Fix: the claim is documented as "only a hint" for which household to resolve — it now degrades to `householdId=null` when stale instead of hard-failing at `authMiddleware`. An **explicit** `X-Household-Id` header override is a different, intentional case (the caller deliberately asked for a household they must actually belong to) and still 403s exactly as before — unaffected by this change. `requireHousehold()` still 403s resource routes that genuinely need an active household, just with a clearer "User must belong to a household" message instead of "Not a member of the requested household".

Found by an automated repo-wide audit.

## Test plan
- [x] Added regression test: a stale claim with no explicit override now degrades to `householdId: null`, 200, instead of 403
- [x] Added test confirming `requireHousehold()` still correctly 403s that same caller on a route that needs a household
- [x] Updated integration test (`real-handler.test.ts`) that encoded the old 403-at-authMiddleware behavior for a claim-based non-member — now asserts the new message, with the underlying access-denial behavior unchanged
- [x] Confirmed the explicit-header-override 403 tests are unaffected (different code path)
- [x] Full backend suite: 1006/1006 passing
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)