### PR TITLE
feat(frontend): unify the whole app on the garden-journal design system

### DIFF
--- a/frontend/src/components/BrandMark.tsx
+++ b/frontend/src/components/BrandMark.tsx
@@ -73,7 +73,10 @@ export function BrandMark({
   }
 
   const s = SIZE_CLASSES[size];
-  const titleColor = tone === 'light' ? 'text-white' : 'text-gray-900';
+  // Dark tone renders the name in brand ink, not stock near-black — the
+  // lockup appears in every public header, so this is where the brand
+  // color is either everywhere or nowhere.
+  const titleColor = tone === 'light' ? 'text-white' : 'text-ink';
   const taglineColor = tone === 'light' ? 'text-primary-200' : 'text-primary-700';
 
   return (

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -29,7 +29,7 @@ const PADDING_CLASSES = {
 };
 
 const VARIANT_CLASSES: Record<NonNullable<CardProps['variant']>, string> = {
-  solid: 'bg-white rounded-lg shadow-card border border-gray-200',
+  solid: 'bg-white rounded-lg shadow-card border border-primary-100/70',
   paper:
     'bg-paper rounded-xl shadow-journal hover:shadow-journal-hover transition-shadow duration-200 border border-primary-100/60',
   journal: 'bg-paper border-b border-primary-100/80 last:border-b-0 rounded-none',
@@ -62,8 +62,8 @@ export function CardHeader({ title, description, action }: CardHeaderProps) {
   return (
     <div className="flex items-start justify-between mb-4">
       <div>
-        <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
-        {description && <p className="mt-1 text-sm text-gray-500">{description}</p>}
+        <h2 className="font-serif text-lg text-ink">{title}</h2>
+        {description && <p className="mt-1 text-sm text-gray-600">{description}</p>}
       </div>
       {action && <div>{action}</div>}
     </div>

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -107,7 +107,7 @@ export function CommandPalette() {
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
         >
-          <div className="fixed inset-0 bg-gray-500/75" />
+          <div className="fixed inset-0 bg-primary-950/70" />
         </Transition.Child>
 
         <div className="fixed inset-0 z-10 overflow-y-auto p-4 sm:p-6 md:p-20">
@@ -120,7 +120,7 @@ export function CommandPalette() {
             leaveFrom="opacity-100 scale-100"
             leaveTo="opacity-0 scale-95"
           >
-            <Dialog.Panel className="mx-auto max-w-xl transform overflow-hidden rounded-xl bg-white shadow-2xl ring-1 ring-black/5 transition-all">
+            <Dialog.Panel className="mx-auto max-w-xl transform overflow-hidden rounded-xl bg-paper shadow-2xl ring-1 ring-primary-100/80 transition-all">
               <Combobox onChange={onSelect}>
                 <div className="relative">
                   <MagnifyingGlassIcon
@@ -138,11 +138,11 @@ export function CommandPalette() {
                 {results.length > 0 && (
                   <Combobox.Options
                     static
-                    className="max-h-80 scroll-py-2 divide-y divide-gray-100 overflow-y-auto"
+                    className="max-h-80 scroll-py-2 divide-y divide-primary-100/60 overflow-y-auto"
                   >
                     {results.some((r) => r.kind === 'plant') && (
                       <li>
-                        <h2 className="bg-gray-50 px-4 py-2 text-xs font-semibold text-gray-700">
+                        <h2 className="bg-parchment/70 px-4 py-2 text-xs font-semibold text-gray-700">
                           Plants
                         </h2>
                         <ul className="text-sm text-gray-700">
@@ -154,7 +154,7 @@ export function CommandPalette() {
                                 value={r}
                                 className={({ active }) =>
                                   `flex items-center gap-3 cursor-pointer select-none px-4 py-2 ${
-                                    active ? 'bg-primary-600 text-white' : ''
+                                    active ? 'bg-primary-700 text-white' : ''
                                   }`
                                 }
                               >
@@ -172,7 +172,7 @@ export function CommandPalette() {
                     )}
                     {results.some((r) => r.kind === 'task') && (
                       <li>
-                        <h2 className="bg-gray-50 px-4 py-2 text-xs font-semibold text-gray-700">
+                        <h2 className="bg-parchment/70 px-4 py-2 text-xs font-semibold text-gray-700">
                           Tasks
                         </h2>
                         <ul className="text-sm text-gray-700">
@@ -184,7 +184,7 @@ export function CommandPalette() {
                                 value={r}
                                 className={({ active }) =>
                                   `flex items-center gap-3 cursor-pointer select-none px-4 py-2 ${
-                                    active ? 'bg-primary-600 text-white' : ''
+                                    active ? 'bg-primary-700 text-white' : ''
                                   }`
                                 }
                               >
@@ -214,7 +214,7 @@ export function CommandPalette() {
                 {query === '' && (
                   <p className="px-6 py-8 text-center text-sm text-gray-500">
                     Type to search plants and tasks. Press{' '}
-                    <kbd className="rounded border border-gray-200 bg-gray-50 px-1 font-sans text-xs">
+                    <kbd className="rounded border border-primary-200/70 bg-parchment/70 px-1 font-sans text-xs">
                       Esc
                     </kbd>{' '}
                     to close.

--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -38,7 +38,7 @@ export function ConfirmDialog({
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
         >
-          <div className="fixed inset-0 bg-gray-500/75 transition-opacity" />
+          <div className="fixed inset-0 bg-primary-950/70 transition-opacity" />
         </Transition.Child>
 
         <div className="fixed inset-0 z-10 overflow-y-auto">
@@ -52,7 +52,7 @@ export function ConfirmDialog({
               leaveFrom="opacity-100 translate-y-0 sm:scale-100"
               leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
             >
-              <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
+              <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-paper border border-primary-100/70 px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
                 <div className="sm:flex sm:items-start">
                   <div
                     className={`mx-auto flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full sm:mx-0 sm:h-10 sm:w-10 ${
@@ -69,7 +69,7 @@ export function ConfirmDialog({
                   <div className="mt-3 text-center sm:ml-4 sm:mt-0 sm:text-left">
                     <Dialog.Title
                       as="h3"
-                      className="font-serif text-xl font-semibold leading-tight tracking-tight text-gray-900"
+                      className="font-serif text-xl font-semibold leading-tight tracking-tight text-ink"
                     >
                       {title}
                     </Dialog.Title>

--- a/frontend/src/components/EmptyState.tsx
+++ b/frontend/src/components/EmptyState.tsx
@@ -28,7 +28,7 @@ export function EmptyState({ icon, title, description, action, hint }: EmptyStat
       <h3 className="font-serif text-xl text-ink">{title}</h3>
       {description && <p className="mt-1 text-sm text-gray-600 max-w-md">{description}</p>}
       {action && <div className="mt-6">{action}</div>}
-      {hint && <p className="mt-3 text-xs text-gray-500">{hint}</p>}
+      {hint && <p className="mt-3 text-xs text-gray-600">{hint}</p>}
     </div>
   );
 }

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,26 +1,50 @@
+import { Link } from 'react-router-dom';
+import { MemorialFrame } from './brand/MemorialFrame';
+
+const FOOTER_LINKS = [
+  { label: 'Care guides', to: '/care' },
+  { label: 'Blog', to: '/blog' },
+  { label: 'Pricing', to: '/pricing' },
+  { label: 'Changelog', to: '/changelog' },
+  { label: 'Status', to: '/status' },
+  { label: 'Privacy', to: '/legal/privacy' },
+  { label: 'Terms', to: '/legal/terms' },
+];
+
 /**
- * Footer rendered at the bottom of public marketing pages.
+ * Footer rendered at the bottom of public content pages (via PublicShell).
+ * Compact cousin of the landing page's full footer: same dark-green
+ * ground, same memorial treatment, plus one row of cross-links so
+ * readers arriving from search can find the rest of the site.
  *
  * The dedication line is intentional and quiet — please leave it.
  */
 export function Footer() {
   const year = new Date().getFullYear();
   return (
-    <footer className="border-t border-gray-200 bg-white">
+    <footer className="bg-primary-900">
       <div className="mx-auto max-w-7xl px-6 py-10 text-center">
-        <p className="text-sm text-gray-500">
-          &copy; {year} Family Greenhouse. Care for what grows.
-        </p>
-        <p className="mt-2 text-sm italic text-gray-500">
-          In loving memory of my mom, Joyce - who taught us to keep growing. 🌱
-        </p>
-        <p className="mt-2 text-xs text-gray-500">
-          Plant data powered by{' '}
+        <nav aria-label="Footer" className="flex flex-wrap justify-center gap-x-6 gap-y-2">
+          {FOOTER_LINKS.map((link) => (
+            <Link key={link.to} to={link.to} className="text-sm text-primary-200 hover:text-white">
+              {link.label}
+            </Link>
+          ))}
+        </nav>
+        <div className="mt-8 flex items-center justify-center gap-4">
+          <MemorialFrame className="hidden sm:block h-8 w-32 text-primary-300/50" />
+          <p className="text-sm italic text-primary-200">
+            In loving memory of my mom, Joyce — who taught us to keep growing.
+          </p>
+          <MemorialFrame className="hidden sm:block h-8 w-32 text-primary-300/50 -scale-x-100" />
+        </div>
+        <p className="mt-6 text-sm text-primary-200">
+          &copy; {year} Family Greenhouse. Plant data powered by{' '}
           <a
             href="https://perenual.com/"
             target="_blank"
             rel="noopener noreferrer"
-            className="underline hover:text-gray-600"
+            className="underline underline-offset-2 hover:text-white"
           >
             Perenual
           </a>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -80,7 +80,7 @@ export function Layout() {
             leaveFrom="opacity-100"
             leaveTo="opacity-0"
           >
-            <div className="fixed inset-0 bg-gray-900/80" />
+            <div className="fixed inset-0 bg-primary-950/80" />
           </Transition.Child>
 
           <div className="fixed inset-0 flex">

--- a/frontend/src/components/PublicShell.tsx
+++ b/frontend/src/components/PublicShell.tsx
@@ -1,0 +1,125 @@
+import { ReactNode } from 'react';
+import { Link } from 'react-router-dom';
+import clsx from 'clsx';
+import { BrandMark } from './BrandMark';
+import { Footer } from './Footer';
+import { TitleUnderline } from './brand/TitleUnderline';
+
+/**
+ * Shared chrome for the public content pages (care guides, blog, pricing,
+ * changelog, legal, status, pet-safe, sitter). These ten pages used to
+ * hand-roll the same white header/footer shell, which left them visually
+ * severed from the garden-journal system the landing/auth/app surfaces
+ * use — stark white where everything else is paper, gray rules where
+ * everything else is green-tinted. One component, one look.
+ *
+ * Width maps to the reading measure each page already used: `article`
+ * for single-column prose (blog post, care guide), `prose` for indexes,
+ * `wide` for the pricing grid.
+ */
+const WIDTHS = {
+  article: 'max-w-2xl',
+  prose: 'max-w-3xl',
+  wide: 'max-w-5xl',
+} as const;
+
+interface PublicShellProps {
+  width?: keyof typeof WIDTHS;
+  /** Drop the nav links + app CTA. The sitter page uses this: a guest
+   *  doing someone a favor shouldn't be marketed at from the header. */
+  plainHeader?: boolean;
+  children: ReactNode;
+}
+
+export function PublicShell({ width = 'prose', plainHeader = false, children }: PublicShellProps) {
+  return (
+    <div className="min-h-screen bg-paper flex flex-col">
+      <header className="border-b border-primary-100/80">
+        <nav
+          className={clsx('mx-auto flex items-center justify-between gap-4 p-6', WIDTHS[width])}
+          aria-label="Site"
+        >
+          <Link to="/" aria-label="Family Greenhouse home">
+            <BrandMark variant="wordmark" size="sm" />
+          </Link>
+          {!plainHeader && (
+            <div className="flex items-center gap-x-6">
+              <Link
+                to="/care"
+                className="hidden md:block text-sm font-medium text-ink hover:text-primary-700 transition-colors"
+              >
+                Care guides
+              </Link>
+              <Link
+                to="/blog"
+                className="hidden md:block text-sm font-medium text-ink hover:text-primary-700 transition-colors"
+              >
+                Blog
+              </Link>
+              <Link
+                to="/pricing"
+                className="hidden md:block text-sm font-medium text-ink hover:text-primary-700 transition-colors"
+              >
+                Pricing
+              </Link>
+              <Link
+                to="/"
+                className="text-sm font-semibold text-primary-700 hover:text-primary-800 whitespace-nowrap"
+              >
+                Try the app →
+              </Link>
+            </div>
+          )}
+        </nav>
+      </header>
+
+      <main className={clsx('flex-1 mx-auto w-full px-6 py-12 sm:py-16', WIDTHS[width])}>
+        {children}
+      </main>
+
+      <Footer />
+    </div>
+  );
+}
+
+interface PageIntroProps {
+  /** Small label above the title, e.g. "Health check". */
+  eyebrow?: string;
+  title: string;
+  /** Secondary line below the underline. */
+  lede?: ReactNode;
+  align?: 'left' | 'center';
+}
+
+/**
+ * Title treatment for public content pages: eyebrow, Gloock serif title
+ * in ink, hand-drawn underline. Mirrors the landing page's SectionHeading
+ * and the app's PageHeader so every surface opens the same way.
+ *
+ * No font-semibold on the title: Gloock ships a single 400 weight, and a
+ * bold utility only buys synthetic emboldening that muddies the serifs.
+ */
+export function PageIntro({ eyebrow, title, lede, align = 'left' }: PageIntroProps) {
+  const centered = align === 'center';
+  return (
+    <div className={clsx(centered && 'text-center max-w-2xl mx-auto')}>
+      {eyebrow && (
+        <p className="text-xs uppercase tracking-[0.22em] text-primary-700 font-semibold">
+          {eyebrow}
+        </p>
+      )}
+      <h1
+        className={clsx(
+          'font-serif text-4xl tracking-tight text-ink sm:text-5xl',
+          eyebrow && 'mt-3'
+        )}
+      >
+        {title}
+      </h1>
+      <div className={clsx('mt-2', centered && 'flex justify-center')}>
+        <TitleUnderline className="h-3 w-40 text-primary-600" />
+      </div>
+      {lede && <p className="mt-5 text-lg leading-8 text-gray-700">{lede}</p>}
+    </div>
+  );
+}

--- a/frontend/src/components/icons/MistLeafIcon.tsx
+++ b/frontend/src/components/icons/MistLeafIcon.tsx
@@ -1,0 +1,44 @@
+/**
+ * Botanical icon — humidity. A leaf with mist beads hanging above it,
+ * drawn in the house style (32-grid, 1.4 stroke, partial fills) for the
+ * care-guide seed-packet facts card.
+ *
+ * Stroke + fill are `currentColor`-able via the `className` prop's text-*
+ * utilities so callers can recolor without re-exporting the icon.
+ */
+interface IconProps {
+  className?: string;
+}
+
+export function MistLeafIcon({ className }: IconProps) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 32 32"
+      fill="none"
+      aria-hidden="true"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      {/* Mist — three drifting dashes and two beads */}
+      <path d="M 7 7.5 Q 11 6 15 7.5" opacity="0.55" />
+      <path d="M 17 5.5 Q 21 4.2 25 5.5" opacity="0.55" />
+      <path d="M 12 11 Q 16 9.7 20 11" opacity="0.55" />
+      <circle cx="24" cy="10.5" r="1.3" fill="currentColor" fillOpacity="0.8" stroke="none" />
+      <circle cx="8.5" cy="12" r="1" fill="currentColor" fillOpacity="0.8" stroke="none" />
+      {/* Leaf catching the moisture */}
+      <path
+        d="M 16 28 Q 8 24 8 18.5 Q 8 14.5 12.5 14 Q 20 13.5 23.5 17 Q 24.5 23 19 26.5 Q 17.5 27.5 16 28 Z"
+        fill="currentColor"
+        fillOpacity="0.18"
+      />
+      <path d="M 16 28 Q 8 24 8 18.5 Q 8 14.5 12.5 14 Q 20 13.5 23.5 17 Q 24.5 23 19 26.5 Q 17.5 27.5 16 28 Z" />
+      {/* Midrib */}
+      <path d="M 11 16.5 Q 16 20 19.5 25" opacity="0.7" />
+      {/* One bead resting on the leaf */}
+      <circle cx="14" cy="19" r="1.2" fill="currentColor" fillOpacity="0.9" stroke="none" />
+    </svg>
+  );
+}

--- a/frontend/src/components/icons/PawLeafIcon.tsx
+++ b/frontend/src/components/icons/PawLeafIcon.tsx
@@ -1,0 +1,89 @@
+/**
+ * Botanical icon — pet safety. A paw print beside a small leaf, drawn in
+ * the house style (32-grid, 1.4 stroke, partial fills) for the care-guide
+ * seed-packet facts card. Neutral on purpose: the fact text says whether
+ * the plant is safe; the icon only marks the topic.
+ *
+ * Stroke + fill are `currentColor`-able via the `className` prop's text-*
+ * utilities so callers can recolor without re-exporting the icon.
+ */
+interface IconProps {
+  className?: string;
+}
+
+export function PawLeafIcon({ className }: IconProps) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 32 32"
+      fill="none"
+      aria-hidden="true"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      {/* Main pad — a soft rounded triangle */}
+      <path
+        d="M 13 27 Q 8.5 26.5 8.5 23 Q 8.5 20.5 11 19.5 Q 13.5 18.7 15.5 20.5 Q 17.5 22.5 16.5 25 Q 15.5 27.3 13 27 Z"
+        fill="currentColor"
+        fillOpacity="0.18"
+      />
+      <path d="M 13 27 Q 8.5 26.5 8.5 23 Q 8.5 20.5 11 19.5 Q 13.5 18.7 15.5 20.5 Q 17.5 22.5 16.5 25 Q 15.5 27.3 13 27 Z" />
+      {/* Toes — four uneven beans */}
+      <ellipse
+        cx="6.5"
+        cy="17"
+        rx="1.7"
+        ry="2.2"
+        fill="currentColor"
+        fillOpacity="0.7"
+        stroke="none"
+        transform="rotate(-18 6.5 17)"
+      />
+      <ellipse
+        cx="11"
+        cy="13.5"
+        rx="1.8"
+        ry="2.3"
+        fill="currentColor"
+        fillOpacity="0.7"
+        stroke="none"
+        transform="rotate(-8 11 13.5)"
+      />
+      <ellipse
+        cx="16.5"
+        cy="13.5"
+        rx="1.8"
+        ry="2.3"
+        fill="currentColor"
+        fillOpacity="0.7"
+        stroke="none"
+        transform="rotate(10 16.5 13.5)"
+      />
+      <ellipse
+        cx="20.5"
+        cy="17"
+        rx="1.7"
+        ry="2.2"
+        fill="currentColor"
+        fillOpacity="0.7"
+        stroke="none"
+        transform="rotate(20 20.5 17)"
+      />
+      {/* Sprig leaning in from the right */}
+      <path d="M 26 27 Q 26.5 20 25 13 Q 24.6 10.5 25.5 8" />
+      <path
+        d="M 25.2 14 Q 28.5 12.5 30 14.5 Q 27.5 16 25.2 14 Z"
+        fill="currentColor"
+        fillOpacity="0.7"
+      />
+      <path
+        d="M 25.6 20 Q 22.5 19 21.5 21.5 Q 24.5 22.5 25.6 20 Z"
+        fill="currentColor"
+        fillOpacity="0.7"
+      />
+      <circle cx="25.5" cy="8" r="1.6" fill="currentColor" fillOpacity="0.9" stroke="none" />
+    </svg>
+  );
+}

--- a/frontend/src/components/icons/SunGlowIcon.tsx
+++ b/frontend/src/components/icons/SunGlowIcon.tsx
@@ -1,0 +1,42 @@
+/**
+ * Botanical icon — light. A low sun with hand-drawn rays and a small
+ * seedling leaning toward it. Drawn in the house style (32-grid, 1.4
+ * stroke, partial fills) for the care-guide seed-packet facts card.
+ *
+ * Stroke + fill are `currentColor`-able via the `className` prop's text-*
+ * utilities so callers can recolor without re-exporting the icon.
+ */
+interface IconProps {
+  className?: string;
+}
+
+export function SunGlowIcon({ className }: IconProps) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 32 32"
+      fill="none"
+      aria-hidden="true"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      {/* Sun disc, slightly off-center like a quick sketch */}
+      <circle cx="19" cy="13" r="5.5" fill="currentColor" fillOpacity="0.18" />
+      <circle cx="19" cy="13" r="5.5" />
+      {/* Rays — uneven lengths on purpose */}
+      <path d="M 19 3.5 L 19 5.8" />
+      <path d="M 26 6 L 24.4 7.6" />
+      <path d="M 28.5 13 L 26.2 13" />
+      <path d="M 26 20 L 24.4 18.4" />
+      <path d="M 12 6 L 13.6 7.6" />
+      {/* Seedling leaning toward the light */}
+      <path d="M 8 28 Q 8.5 23 10 19.5" />
+      <path d="M 9 23 Q 5.5 22 4.5 24.5 Q 7.5 25.5 9 23 Z" fill="currentColor" fillOpacity="0.7" />
+      <path d="M 10 20 Q 13 18.5 14.5 20 Q 12 21.8 10 20 Z" fill="currentColor" fillOpacity="0.7" />
+      {/* Soil line */}
+      <path d="M 4.5 28.5 Q 9 27.5 14 28.5" opacity="0.6" />
+    </svg>
+  );
+}

--- a/frontend/src/features/analytics/AnalyticsPage.tsx
+++ b/frontend/src/features/analytics/AnalyticsPage.tsx
@@ -31,12 +31,13 @@ const TASK_TYPE_LABELS: Record<string, string> = {
   custom: 'Custom',
 };
 
+// Bar hues mirror taskTypeConfig chips so charts match task chips app-wide.
 const TASK_TYPE_COLORS: Record<string, string> = {
-  water: 'bg-blue-500',
-  fertilize: 'bg-green-500',
-  prune: 'bg-orange-500',
-  repot: 'bg-purple-500',
-  custom: 'bg-gray-500',
+  water: 'bg-sky-500',
+  fertilize: 'bg-primary-500',
+  prune: 'bg-accent-500',
+  repot: 'bg-amber-500',
+  custom: 'bg-stone-400',
 };
 
 function isOverdue(nextDue: string, now = new Date()): boolean {
@@ -127,7 +128,7 @@ export function AnalyticsPage() {
 
       {/* 30-day trend */}
       <Card padding="none">
-        <div className="px-6 py-4 border-b border-gray-200">
+        <div className="px-6 py-4 border-b border-primary-100/70">
           <CardHeader title="Last 30 days" description="Completed tasks per day." />
         </div>
         <div className="p-6">
@@ -144,13 +145,13 @@ export function AnalyticsPage() {
       {/* By task type */}
       {review && review.byTaskType.length > 0 && (
         <Card padding="none">
-          <div className="px-6 py-4 border-b border-gray-200">
+          <div className="px-6 py-4 border-b border-primary-100/70">
             <CardHeader
               title={`By task type in ${yearNow}`}
               description="What kind of care your household has put in this year."
             />
           </div>
-          <ul className="divide-y divide-gray-200">
+          <ul className="divide-y divide-primary-100/60">
             {(() => {
               const total = review.byTaskType.reduce((s, b) => s + b.count, 0) || 1;
               return [...review.byTaskType]
@@ -165,7 +166,7 @@ export function AnalyticsPage() {
                       <span
                         className={clsx(
                           'h-3 rounded-full',
-                          TASK_TYPE_COLORS[b.type] ?? 'bg-gray-400'
+                          TASK_TYPE_COLORS[b.type] ?? 'bg-stone-400'
                         )}
                         style={{ width: `${pct}%`, minWidth: '4px' }}
                         aria-hidden="true"
@@ -184,18 +185,18 @@ export function AnalyticsPage() {
       {/* Plants at risk */}
       {atRisk.length > 0 && (
         <Card padding="none">
-          <div className="px-6 py-4 border-b border-gray-200">
+          <div className="px-6 py-4 border-b border-primary-100/70">
             <CardHeader
               title="Plants at risk"
               description="Tasks overdue — the most-overdue plant first."
             />
           </div>
-          <ul className="divide-y divide-gray-200">
+          <ul className="divide-y divide-primary-100/60">
             {atRisk.map(({ plant, overdueCount, worst }) => (
               <li key={plant.id} className="px-6 py-3 text-sm">
                 <Link
                   to={`/plants/${plant.id}`}
-                  className="flex items-center gap-3 hover:bg-gray-50 -mx-6 px-6 py-1 -my-1"
+                  className="flex items-center gap-3 hover:bg-parchment/60 -mx-6 px-6 py-1 -my-1"
                 >
                   <span className="flex-1 truncate font-medium text-gray-900">{plant.name}</span>
                   <span className="text-amber-700 tabular-nums">{overdueCount} overdue</span>
@@ -210,13 +211,13 @@ export function AnalyticsPage() {
       {/* Per-member */}
       {review && review.byMember.length > 0 && (
         <Card padding="none">
-          <div className="px-6 py-4 border-b border-gray-200">
+          <div className="px-6 py-4 border-b border-primary-100/70">
             <CardHeader
               title={`Top contributors in ${yearNow}`}
               description="Tasks each member has completed this year."
             />
           </div>
-          <ul className="divide-y divide-gray-200">
+          <ul className="divide-y divide-primary-100/60">
             {review.byMember.map((m) => {
               const max = review.byMember[0].count || 1;
               const pct = (m.count / max) * 100;
@@ -239,10 +240,10 @@ export function AnalyticsPage() {
       {/* Per-plant */}
       {plants && tasks && (
         <Card padding="none">
-          <div className="px-6 py-4 border-b border-gray-200">
+          <div className="px-6 py-4 border-b border-primary-100/70">
             <CardHeader title="Per plant" description="Recent task activity by plant." />
           </div>
-          <ul className="divide-y divide-gray-200">
+          <ul className="divide-y divide-primary-100/60">
             {plants
               .map((plant) => ({
                 plant,
@@ -348,15 +349,15 @@ function KpiTile({ label, value, tone }: { label: string; value: number; tone?: 
   return (
     <div
       className={clsx(
-        'rounded-lg border p-4',
-        tone === 'warning' ? 'border-amber-300 bg-amber-50' : 'border-gray-200 bg-white'
+        'rounded-lg border p-4 shadow-journal',
+        tone === 'warning' ? 'border-amber-300 bg-amber-50' : 'border-primary-100/70 bg-paper'
       )}
     >
-      <p className="text-xs font-medium text-gray-600">{label}</p>
+      <p className="text-xs uppercase tracking-[0.14em] text-gray-600">{label}</p>
       <p
         className={clsx(
-          'mt-1 text-2xl font-semibold tabular-nums',
-          tone === 'warning' ? 'text-amber-900' : 'text-gray-900'
+          'mt-1 font-serif text-2xl tabular-nums',
+          tone === 'warning' ? 'text-amber-900' : 'text-ink'
         )}
       >
         {value}

--- a/frontend/src/features/blog/BlogIndex.tsx
+++ b/frontend/src/features/blog/BlogIndex.tsx
@@ -1,6 +1,5 @@
 import { Link } from 'react-router-dom';
-import { BrandMark } from '@/components/BrandMark';
-import { Footer } from '@/components/Footer';
+import { PublicShell, PageIntro } from '@/components/PublicShell';
 import { POSTS } from './posts';
 import { useMetaTags } from '@/hooks/useMetaTags';
 import { siteUrl } from '@/config/site';
@@ -22,52 +21,36 @@ export function BlogIndex() {
   });
 
   return (
-    <div className="min-h-screen bg-white flex flex-col">
-      <header className="border-b border-gray-200">
-        <nav className="mx-auto max-w-3xl flex items-center justify-between p-6">
-          <Link to="/" aria-label="Family Greenhouse home">
-            <BrandMark variant="wordmark" size="sm" />
-          </Link>
-          <Link to="/" className="text-sm font-medium text-primary-700 hover:underline">
-            Try the app →
-          </Link>
-        </nav>
-      </header>
+    <PublicShell>
+      <PageIntro
+        eyebrow="The journal"
+        title="Notes on growing things"
+        lede="Plant care, shared chores, and the occasional unsolicited opinion."
+      />
 
-      <main className="flex-1 mx-auto max-w-3xl w-full px-6 py-16">
-        <h1 className="font-serif text-4xl font-semibold tracking-tight text-gray-900 sm:text-5xl">
-          Notes on growing things
-        </h1>
-        <p className="mt-3 text-lg text-gray-600">
-          Plant care, shared chores, and the occasional unsolicited opinion.
-        </p>
-
-        <ul className="mt-12 space-y-10">
-          {[...POSTS]
-            .sort((a, b) => (a.date < b.date ? 1 : -1))
-            .map((post) => (
-              <li key={post.slug}>
-                <Link to={`/blog/${post.slug}`} className="group block">
-                  <p className="text-xs font-medium uppercase tracking-[0.2em] text-primary-700">
-                    {new Date(post.date).toLocaleDateString(undefined, {
-                      year: 'numeric',
-                      month: 'long',
-                      day: 'numeric',
-                    })}{' '}
-                    · {post.readingMinutes} min read
-                  </p>
-                  <h2 className="mt-2 font-serif text-2xl font-semibold tracking-tight text-gray-900 group-hover:text-primary-700 transition-colors">
-                    {post.title}
-                  </h2>
-                  <p className="mt-2 text-base text-gray-600 leading-relaxed">{post.description}</p>
-                  <p className="mt-3 text-sm font-medium text-primary-700">Read more →</p>
-                </Link>
-              </li>
-            ))}
-        </ul>
-      </main>
-
-      <Footer />
-    </div>
+      <ul className="mt-12 divide-y divide-primary-100/70">
+        {[...POSTS]
+          .sort((a, b) => (a.date < b.date ? 1 : -1))
+          .map((post) => (
+            <li key={post.slug} className="py-8 first:pt-0 last:pb-0">
+              <Link to={`/blog/${post.slug}`} className="group block">
+                <p className="text-xs font-medium uppercase tracking-[0.2em] text-primary-700">
+                  {new Date(post.date).toLocaleDateString(undefined, {
+                    year: 'numeric',
+                    month: 'long',
+                    day: 'numeric',
+                  })}{' '}
+                  · {post.readingMinutes} min read
+                </p>
+                <h2 className="mt-2 font-serif text-2xl tracking-tight text-ink group-hover:text-primary-700 transition-colors">
+                  {post.title}
+                </h2>
+                <p className="mt-2 text-base text-gray-700 leading-relaxed">{post.description}</p>
+                <p className="mt-3 text-sm font-medium text-primary-700">Read more →</p>
+              </Link>
+            </li>
+          ))}
+      </ul>
+    </PublicShell>
   );
 }

--- a/frontend/src/features/blog/BlogPost.tsx
+++ b/frontend/src/features/blog/BlogPost.tsx
@@ -1,7 +1,6 @@
 import { Link, Navigate, useParams } from 'react-router-dom';
 import { ChevronLeftIcon } from '@heroicons/react/24/outline';
-import { BrandMark } from '@/components/BrandMark';
-import { Footer } from '@/components/Footer';
+import { PublicShell } from '@/components/PublicShell';
 import { Button } from '@/components/Button';
 import { findPost, POSTS } from './posts';
 import { useMetaTags } from '@/hooks/useMetaTags';
@@ -59,77 +58,60 @@ export function BlogPost() {
   const otherPosts = POSTS.filter((p) => p.slug !== post.slug).slice(0, 2);
 
   return (
-    <div className="min-h-screen bg-white flex flex-col">
-      <header className="border-b border-gray-200">
-        <nav className="mx-auto max-w-3xl flex items-center justify-between p-6">
-          <Link to="/" aria-label="Family Greenhouse home">
-            <BrandMark variant="wordmark" size="sm" />
-          </Link>
-          <Link to="/" className="text-sm font-medium text-primary-700 hover:underline">
-            Try the app →
-          </Link>
-        </nav>
+    <PublicShell width="article">
+      <Link
+        to="/blog"
+        className="inline-flex items-center gap-1 text-sm font-medium text-primary-700 hover:underline"
+      >
+        <ChevronLeftIcon className="h-4 w-4" aria-hidden="true" />
+        All posts
+      </Link>
+
+      <header className="mt-6 mb-10">
+        <p className="text-xs font-medium uppercase tracking-[0.2em] text-primary-700">
+          {new Date(post.date).toLocaleDateString(undefined, {
+            year: 'numeric',
+            month: 'long',
+            day: 'numeric',
+          })}{' '}
+          · {post.readingMinutes} min read
+        </p>
+        <h1 className="mt-3 font-serif text-4xl tracking-tight text-ink sm:text-5xl">
+          {post.title}
+        </h1>
       </header>
 
-      <main className="flex-1 mx-auto max-w-2xl w-full px-6 py-12 sm:py-16">
-        <Link
-          to="/blog"
-          className="inline-flex items-center gap-1 text-sm font-medium text-primary-700 hover:underline"
-        >
-          <ChevronLeftIcon className="h-4 w-4" aria-hidden="true" />
-          All posts
-        </Link>
+      <Body />
 
-        <header className="mt-6 mb-10">
-          <p className="text-xs font-medium uppercase tracking-[0.2em] text-primary-700">
-            {new Date(post.date).toLocaleDateString(undefined, {
-              year: 'numeric',
-              month: 'long',
-              day: 'numeric',
-            })}{' '}
-            · {post.readingMinutes} min read
-          </p>
-          <h1 className="mt-3 font-serif text-4xl font-semibold tracking-tight text-gray-900 sm:text-5xl">
-            {post.title}
-          </h1>
-        </header>
+      <aside className="mt-16 rounded-xl border border-primary-200 bg-primary-50 p-6 text-center">
+        <p className="font-serif text-xl text-ink">Try Family Greenhouse</p>
+        <p className="mt-2 text-sm text-gray-600">
+          Free for up to 10 plants. No credit card. Share with whoever you live with.
+        </p>
+        <div className="mt-4">
+          <Link to="/register">
+            <Button>Get started</Button>
+          </Link>
+        </div>
+      </aside>
 
-        <Body />
-
-        <aside className="mt-16 rounded-lg border border-primary-200 bg-primary-50 p-6 text-center">
-          <p className="font-serif text-xl font-semibold text-gray-900">Try Family Greenhouse</p>
-          <p className="mt-2 text-sm text-gray-600">
-            Free for up to 10 plants. No credit card. Share with whoever you live with.
-          </p>
-          <div className="mt-4">
-            <Link to="/register">
-              <Button>Get started</Button>
-            </Link>
-          </div>
-        </aside>
-
-        {otherPosts.length > 0 && (
-          <section className="mt-16">
-            <h2 className="font-serif text-2xl font-semibold tracking-tight text-gray-900">
-              More to read
-            </h2>
-            <ul className="mt-6 space-y-6">
-              {otherPosts.map((p) => (
-                <li key={p.slug}>
-                  <Link to={`/blog/${p.slug}`} className="group block">
-                    <h3 className="font-serif text-lg font-semibold text-gray-900 group-hover:text-primary-700 transition-colors">
-                      {p.title}
-                    </h3>
-                    <p className="mt-1 text-sm text-gray-600">{p.description}</p>
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          </section>
-        )}
-      </main>
-
-      <Footer />
-    </div>
+      {otherPosts.length > 0 && (
+        <section className="mt-16">
+          <h2 className="font-serif text-2xl tracking-tight text-ink">More to read</h2>
+          <ul className="mt-6 space-y-6">
+            {otherPosts.map((p) => (
+              <li key={p.slug}>
+                <Link to={`/blog/${p.slug}`} className="group block">
+                  <h3 className="font-serif text-lg text-ink group-hover:text-primary-700 transition-colors">
+                    {p.title}
+                  </h3>
+                  <p className="mt-1 text-sm text-gray-600">{p.description}</p>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </PublicShell>
   );
 }

--- a/frontend/src/features/care/CareGuidePage.tsx
+++ b/frontend/src/features/care/CareGuidePage.tsx
@@ -1,8 +1,12 @@
 import { Link, Navigate, useParams } from 'react-router-dom';
 import { ChevronLeftIcon } from '@heroicons/react/24/outline';
-import { BrandMark } from '@/components/BrandMark';
-import { Footer } from '@/components/Footer';
+import { PublicShell } from '@/components/PublicShell';
 import { Button } from '@/components/Button';
+import { WaterDropIcon } from '@/components/icons/WaterDropIcon';
+import { SunGlowIcon } from '@/components/icons/SunGlowIcon';
+import { GrowthRingsIcon } from '@/components/icons/GrowthRingsIcon';
+import { MistLeafIcon } from '@/components/icons/MistLeafIcon';
+import { PawLeafIcon } from '@/components/icons/PawLeafIcon';
 import { useMetaTags } from '@/hooks/useMetaTags';
 import { SITE_URL } from '@/config/site';
 import { CARE_GUIDES, findCareGuide, type CareGuide } from './careGuides';
@@ -86,134 +90,133 @@ export function CareGuidePage() {
   const related = CARE_GUIDES.filter((g) => g.slug !== guide.slug).slice(0, 3);
 
   return (
-    <div className="min-h-screen bg-white flex flex-col">
-      <header className="border-b border-gray-200">
-        <nav className="mx-auto max-w-3xl flex items-center justify-between p-6">
-          <Link to="/" aria-label="Family Greenhouse home">
-            <BrandMark variant="wordmark" size="sm" />
-          </Link>
-          <Link to="/" className="text-sm font-medium text-primary-700 hover:underline">
-            Try the app →
-          </Link>
-        </nav>
+    <PublicShell width="article">
+      <Link
+        to="/care"
+        className="inline-flex items-center gap-1 text-sm font-medium text-primary-700 hover:underline"
+      >
+        <ChevronLeftIcon className="h-4 w-4" aria-hidden="true" />
+        All care guides
+      </Link>
+
+      <header className="mt-6 mb-8">
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-primary-700">
+          Plant care guide
+        </p>
+        <h1 className="mt-3 font-serif text-4xl tracking-tight text-ink sm:text-5xl">
+          {guide.commonName} care
+        </h1>
+        <p className="mt-2 text-lg italic text-gray-600">
+          {guide.scientificName}
+          {guide.alsoKnownAs.length > 0 && (
+            <span className="not-italic text-base text-gray-600">
+              {' '}
+              · also called {guide.alsoKnownAs.join(', ')}
+            </span>
+          )}
+        </p>
       </header>
 
-      <main className="flex-1 mx-auto max-w-2xl w-full px-6 py-12 sm:py-16">
-        <Link
-          to="/care"
-          className="inline-flex items-center gap-1 text-sm font-medium text-primary-700 hover:underline"
-        >
-          <ChevronLeftIcon className="h-4 w-4" aria-hidden="true" />
-          All care guides
-        </Link>
+      <p className="prose-fg lead">{guide.summary}</p>
 
-        <header className="mt-6 mb-8">
-          <p className="text-xs font-medium uppercase tracking-[0.2em] text-primary-700">
-            Plant care guide
+      {/* At-a-glance facts, styled as the back of a seed packet:
+            parchment ground, a dashed inner frame like a cut line, and a
+            hand-drawn icon per fact. The icons mark topics only — the
+            fact text carries the actual answer. */}
+      <aside
+        aria-label={`${guide.commonName} at a glance`}
+        className="mt-8 rounded-xl border border-primary-200 bg-parchment/70 shadow-journal"
+      >
+        <div className="m-2 rounded-lg border border-dashed border-primary-300/70 px-5 py-4">
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-primary-800">
+            At a glance
           </p>
-          <h1 className="mt-3 font-serif text-4xl font-semibold tracking-tight text-gray-900 sm:text-5xl">
-            {guide.commonName} care
-          </h1>
-          <p className="mt-2 text-lg italic text-gray-500">
-            {guide.scientificName}
-            {guide.alsoKnownAs.length > 0 && (
-              <span className="not-italic text-base text-gray-400">
-                {' '}
-                · also called {guide.alsoKnownAs.join(', ')}
-              </span>
-            )}
-          </p>
-        </header>
-
-        <p className="prose-fg lead">{guide.summary}</p>
-
-        {/* At-a-glance grounded facts */}
-        <dl className="mt-8 grid grid-cols-1 gap-px overflow-hidden rounded-lg border border-primary-100 bg-primary-100 sm:grid-cols-2">
-          {[
-            ['Water', guide.quickFacts.water],
-            ['Light', guide.quickFacts.light],
-            ['Difficulty', guide.quickFacts.difficulty],
-            ['Humidity', guide.quickFacts.humidity],
-            ['Toxic to pets?', guide.quickFacts.toxicity],
-          ].map(([label, value]) => (
-            <div key={label} className="bg-white p-4">
-              <dt className="text-xs font-medium uppercase tracking-wide text-primary-700">
-                {label}
-              </dt>
-              <dd className="mt-1 text-sm text-gray-900">{value}</dd>
-            </div>
-          ))}
-        </dl>
-
-        <article className="prose-fg mt-12">
-          <h2>How often to water a {guide.commonName.toLowerCase()}</h2>
-          <Paragraphs items={guide.sections.watering} />
-
-          <h2>Light</h2>
-          <Paragraphs items={guide.sections.light} />
-
-          <h2>Why is my {guide.commonName.toLowerCase()} dying?</h2>
-          <Paragraphs items={guide.sections.problems} />
-
-          <h2>Keeping it alive when you share a home</h2>
-          <Paragraphs items={guide.sections.sharedCare} />
-
-          <h2>The honest bit</h2>
-          <Paragraphs items={guide.sections.honestBit} />
-
-          <h2>{guide.commonName} FAQ</h2>
-          <dl>
-            {guide.faqs.map((f) => (
-              <div key={f.q} className="mt-4">
-                <dt className="font-semibold text-gray-900">{f.q}</dt>
-                <dd className="mt-1 text-gray-700">{f.a}</dd>
+          <dl className="mt-1 divide-y divide-primary-200/50">
+            {(
+              [
+                ['Water', guide.quickFacts.water, WaterDropIcon],
+                ['Light', guide.quickFacts.light, SunGlowIcon],
+                ['Difficulty', guide.quickFacts.difficulty, GrowthRingsIcon],
+                ['Humidity', guide.quickFacts.humidity, MistLeafIcon],
+                ['Toxic to pets?', guide.quickFacts.toxicity, PawLeafIcon],
+              ] as Array<[string, string, React.ComponentType<{ className?: string }>]>
+            ).map(([label, value, Icon]) => (
+              <div key={label} className="flex gap-4 py-3">
+                <Icon className="mt-0.5 h-8 w-8 shrink-0 text-primary-700" />
+                <div>
+                  <dt className="text-xs font-medium uppercase tracking-wide text-primary-800">
+                    {label}
+                  </dt>
+                  <dd className="mt-0.5 text-sm text-gray-900">{value}</dd>
+                </div>
               </div>
             ))}
           </dl>
-        </article>
+        </div>
+      </aside>
 
-        <aside className="mt-16 rounded-lg border border-primary-200 bg-primary-50 p-6 text-center">
-          <p className="font-serif text-xl font-semibold text-gray-900">
-            Stop guessing when you watered it
-          </p>
-          <p className="mt-2 text-sm text-gray-600">
-            Family Greenhouse tracks your {guide.commonName.toLowerCase()}’s schedule and reminds
-            the right person — so “I thought you watered it” stops being a thing. Free for up to 10
-            plants, no card.
-          </p>
-          <div className="mt-4">
-            <Link to="/register">
-              <Button>Add your {guide.commonName.toLowerCase()}</Button>
-            </Link>
-          </div>
-        </aside>
+      <article className="prose-fg mt-12">
+        <h2>How often to water a {guide.commonName.toLowerCase()}</h2>
+        <Paragraphs items={guide.sections.watering} />
 
-        {related.length > 0 && (
-          <section className="mt-16">
-            <h2 className="font-serif text-2xl font-semibold tracking-tight text-gray-900">
-              More care guides
-            </h2>
-            <ul className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
-              {related.map((g) => (
-                <li key={g.slug}>
-                  <Link
-                    to={`/care/${g.slug}`}
-                    className="group block rounded-lg border border-primary-100 p-4 transition-colors hover:border-primary-300 hover:bg-primary-50/50"
-                  >
-                    <span className="font-serif text-lg font-semibold text-gray-900 group-hover:text-primary-700">
-                      {g.commonName}
-                    </span>
-                    <span className="mt-1 block text-xs text-gray-500">{g.quickFacts.water}</span>
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          </section>
-        )}
-      </main>
+        <h2>Light</h2>
+        <Paragraphs items={guide.sections.light} />
 
-      <Footer />
-    </div>
+        <h2>Why is my {guide.commonName.toLowerCase()} dying?</h2>
+        <Paragraphs items={guide.sections.problems} />
+
+        <h2>Keeping it alive when you share a home</h2>
+        <Paragraphs items={guide.sections.sharedCare} />
+
+        <h2>The honest bit</h2>
+        <Paragraphs items={guide.sections.honestBit} />
+
+        <h2>{guide.commonName} FAQ</h2>
+        <dl>
+          {guide.faqs.map((f) => (
+            <div key={f.q} className="mt-4">
+              <dt className="font-semibold text-gray-900">{f.q}</dt>
+              <dd className="mt-1 text-gray-700">{f.a}</dd>
+            </div>
+          ))}
+        </dl>
+      </article>
+
+      <aside className="mt-16 rounded-xl border border-primary-200 bg-primary-50 p-6 text-center">
+        <p className="font-serif text-xl text-ink">Stop guessing when you watered it</p>
+        <p className="mt-2 text-sm text-gray-600">
+          Family Greenhouse tracks your {guide.commonName.toLowerCase()}’s schedule and reminds the
+          right person — so “I thought you watered it” stops being a thing. Free for up to 10
+          plants, no card.
+        </p>
+        <div className="mt-4">
+          <Link to="/register">
+            <Button>Add your {guide.commonName.toLowerCase()}</Button>
+          </Link>
+        </div>
+      </aside>
+
+      {related.length > 0 && (
+        <section className="mt-16">
+          <h2 className="font-serif text-2xl tracking-tight text-ink">More care guides</h2>
+          <ul className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
+            {related.map((g) => (
+              <li key={g.slug}>
+                <Link
+                  to={`/care/${g.slug}`}
+                  className="group block h-full rounded-xl border border-primary-100/80 bg-white p-4 shadow-journal transition hover:border-primary-300 hover:shadow-journal-hover"
+                >
+                  <span className="font-serif text-lg text-ink group-hover:text-primary-700">
+                    {g.commonName}
+                  </span>
+                  <span className="mt-1 block text-xs text-gray-600">{g.quickFacts.water}</span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </PublicShell>
   );
 }
 

--- a/frontend/src/features/care/CareIndex.tsx
+++ b/frontend/src/features/care/CareIndex.tsx
@@ -1,6 +1,5 @@
 import { Link } from 'react-router-dom';
-import { BrandMark } from '@/components/BrandMark';
-import { Footer } from '@/components/Footer';
+import { PublicShell, PageIntro } from '@/components/PublicShell';
 import { useMetaTags } from '@/hooks/useMetaTags';
 import { siteUrl } from '@/config/site';
 import { CARE_GUIDES } from './careGuides';
@@ -19,64 +18,45 @@ export function CareIndex() {
   });
 
   return (
-    <div className="min-h-screen bg-white flex flex-col">
-      <header className="border-b border-gray-200">
-        <nav className="mx-auto max-w-3xl flex items-center justify-between p-6">
-          <Link to="/" aria-label="Family Greenhouse home">
-            <BrandMark variant="wordmark" size="sm" />
-          </Link>
-          <Link to="/" className="text-sm font-medium text-primary-700 hover:underline">
-            Try the app →
-          </Link>
-        </nav>
-      </header>
+    <PublicShell>
+      <PageIntro
+        eyebrow="Before the plant comes home"
+        title="Plant care guides"
+        lede="How often to water it, how much light it wants, and why yours is doing that. Honest, specific, no “lush green companion” filler."
+      />
 
-      <main className="flex-1 mx-auto max-w-3xl w-full px-6 py-16">
-        <h1 className="font-serif text-4xl font-semibold tracking-tight text-gray-900 sm:text-5xl">
-          Plant care guides
-        </h1>
-        <p className="mt-3 text-lg text-gray-600">
-          How often to water it, how much light it wants, and why yours is doing that. Honest,
-          specific, no “lush green companion” filler.
-        </p>
-
-        <ul className="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2">
-          {CARE_GUIDES.map((g) => (
-            <li key={g.slug}>
-              <Link
-                to={`/care/${g.slug}`}
-                className="group block h-full rounded-lg border border-primary-100 p-5 transition-colors hover:border-primary-300 hover:bg-primary-50/50"
-              >
-                <h2 className="font-serif text-xl font-semibold text-gray-900 group-hover:text-primary-700">
-                  {g.commonName}
-                </h2>
-                <p className="mt-1 text-sm italic text-gray-500">{g.scientificName}</p>
-                <p className="mt-3 text-sm text-gray-600">{g.quickFacts.water}</p>
-              </Link>
-            </li>
-          ))}
-        </ul>
-
-        <aside className="mt-16 rounded-lg border border-primary-200 bg-primary-50 p-6 text-center">
-          <p className="font-serif text-xl font-semibold text-gray-900">
-            Knowing the schedule is the easy part
-          </p>
-          <p className="mt-2 text-sm text-gray-600">
-            The hard part is remembering — and not assuming someone else did it. Family Greenhouse
-            handles both. Free for up to 10 plants.
-          </p>
-          <div className="mt-4">
+      <ul className="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2">
+        {CARE_GUIDES.map((g) => (
+          <li key={g.slug}>
             <Link
-              to="/register"
-              className="inline-flex items-center rounded-md bg-primary-700 px-4 py-2 text-sm font-medium text-white hover:bg-primary-800 min-h-touch"
+              to={`/care/${g.slug}`}
+              className="group block h-full rounded-xl border border-primary-100/80 bg-white p-5 shadow-journal transition hover:border-primary-300 hover:shadow-journal-hover"
             >
-              Get started
+              <h2 className="font-serif text-xl text-ink group-hover:text-primary-700">
+                {g.commonName}
+              </h2>
+              <p className="mt-1 text-sm italic text-gray-600">{g.scientificName}</p>
+              <p className="mt-3 text-sm text-gray-600">{g.quickFacts.water}</p>
             </Link>
-          </div>
-        </aside>
-      </main>
+          </li>
+        ))}
+      </ul>
 
-      <Footer />
-    </div>
+      <aside className="mt-16 rounded-xl border border-primary-200 bg-primary-50 p-6 text-center">
+        <p className="font-serif text-xl text-ink">Knowing the schedule is the easy part</p>
+        <p className="mt-2 text-sm text-gray-600">
+          The hard part is remembering — and not assuming someone else did it. Family Greenhouse
+          handles both. Free for up to 10 plants.
+        </p>
+        <div className="mt-4">
+          <Link
+            to="/register"
+            className="inline-flex items-center rounded-md bg-primary-700 px-4 py-2 text-sm font-medium text-white hover:bg-primary-800 min-h-touch"
+          >
+            Get started
+          </Link>
+        </div>
+      </aside>
+    </PublicShell>
   );
 }

--- a/frontend/src/features/changelog/ChangelogPage.tsx
+++ b/frontend/src/features/changelog/ChangelogPage.tsx
@@ -1,6 +1,5 @@
 import { Link } from 'react-router-dom';
-import { BrandMark } from '@/components/BrandMark';
-import { Footer } from '@/components/Footer';
+import { PublicShell, PageIntro } from '@/components/PublicShell';
 import { useMetaTags } from '@/hooks/useMetaTags';
 
 /**
@@ -22,15 +21,30 @@ interface Entry {
   body: React.ReactNode;
 }
 
+// Category tags stay inside the garden palette (greens, terracotta,
+// amber, warm stone) — stock blue/purple read as another product's UI.
 const CATEGORY_STYLES: Record<Category, string> = {
   Feature: 'bg-primary-100 text-primary-900',
-  Improvement: 'bg-blue-100 text-blue-900',
+  Improvement: 'bg-accent-100 text-accent-900',
   Reliability: 'bg-amber-100 text-amber-900',
-  Design: 'bg-purple-100 text-purple-900',
-  Fix: 'bg-gray-100 text-gray-700',
+  Design: 'bg-secondary-100 text-secondary-800',
+  Fix: 'bg-stone-100 text-stone-700',
 };
 
 const ENTRIES: Entry[] = [
+  {
+    date: '2026-07-04',
+    category: 'Design',
+    title: 'The reading room joins the greenhouse',
+    body: (
+      <>
+        The care guides, blog, pricing, changelog, legal pages, and this status page&rsquo;s
+        siblings now share the same paper-and-ink look as the rest of the site — one header, one
+        footer, and a seed-packet facts card on every care guide. Inside the app, dialogs, chat, and
+        analytics picked up the same palette, and a batch of low-contrast small text got darker.
+      </>
+    ),
+  },
   {
     date: '2026-06-12',
     category: 'Design',
@@ -51,8 +65,8 @@ const ENTRIES: Entry[] = [
     title: 'Spider plant care guide',
     body: (
       <>
-        Fourth entry in the <Link to="/care">care guides</Link>: the spider plant — why brown tips
-        are usually your tap water, and what to do with all those plantlets.
+        New in the <Link to="/care">care guides</Link>: the spider plant — why brown tips are
+        usually your tap water, and what to do with all those plantlets.
       </>
     ),
   },
@@ -186,7 +200,9 @@ const ENTRIES: Entry[] = [
     body: (
       <>
         Press{' '}
-        <kbd className="rounded border border-gray-200 bg-gray-50 px-1 font-sans text-xs">⌘K</kbd>{' '}
+        <kbd className="rounded border border-primary-200/70 bg-parchment px-1 font-sans text-xs">
+          ⌘K
+        </kbd>{' '}
         anywhere to search across plants and tasks. Results split by type; press Enter to jump.
       </>
     ),
@@ -216,59 +232,41 @@ export function ChangelogPage() {
   const grouped = groupByMonth(ENTRIES);
 
   return (
-    <div className="min-h-screen bg-white flex flex-col">
-      <header className="border-b border-gray-200">
-        <nav className="mx-auto max-w-3xl flex items-center justify-between p-6">
-          <Link to="/" aria-label="Family Greenhouse home">
-            <BrandMark variant="wordmark" size="sm" />
-          </Link>
-          <Link to="/" className="text-sm font-medium text-primary-700 hover:underline">
-            Try the app →
-          </Link>
-        </nav>
-      </header>
+    <PublicShell>
+      <PageIntro
+        eyebrow="Changelog"
+        title={'What’s new'}
+        lede={'Things we’ve shipped, in plain language. Most recent first.'}
+      />
 
-      <main className="flex-1 mx-auto max-w-3xl w-full px-6 py-16">
-        <h1 className="font-serif text-4xl font-semibold tracking-tight text-gray-900 sm:text-5xl">
-          What&rsquo;s new
-        </h1>
-        <p className="mt-3 text-lg text-gray-600">
-          Things we&rsquo;ve shipped, in plain language. Most recent first.
-        </p>
-
-        <div className="mt-12 space-y-12">
-          {[...grouped.entries()].map(([month, entries]) => (
-            <section key={month}>
-              <h2 className="font-serif text-2xl font-semibold tracking-tight text-gray-900 border-b border-gray-200 pb-2">
-                {month}
-              </h2>
-              <ul className="mt-6 space-y-8">
-                {entries.map((e, i) => (
-                  <li key={`${e.date}-${i}`}>
-                    <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.15em]">
-                      <span className={`rounded-full px-2 py-0.5 ${CATEGORY_STYLES[e.category]}`}>
-                        {e.category}
-                      </span>
-                      <span className="text-gray-500 normal-case tracking-normal">
-                        {new Date(e.date).toLocaleDateString(undefined, {
-                          month: 'short',
-                          day: 'numeric',
-                        })}
-                      </span>
-                    </div>
-                    <h3 className="mt-2 font-serif text-xl font-semibold tracking-tight text-gray-900">
-                      {e.title}
-                    </h3>
-                    <p className="mt-2 text-base text-gray-700 leading-relaxed">{e.body}</p>
-                  </li>
-                ))}
-              </ul>
-            </section>
-          ))}
-        </div>
-      </main>
-
-      <Footer />
-    </div>
+      <div className="mt-12 space-y-12">
+        {[...grouped.entries()].map(([month, entries]) => (
+          <section key={month}>
+            <h2 className="font-serif text-2xl tracking-tight text-ink border-b border-primary-100/80 pb-2">
+              {month}
+            </h2>
+            <ul className="mt-6 space-y-8">
+              {entries.map((e, i) => (
+                <li key={`${e.date}-${i}`}>
+                  <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.15em]">
+                    <span className={`rounded-full px-2 py-0.5 ${CATEGORY_STYLES[e.category]}`}>
+                      {e.category}
+                    </span>
+                    <span className="text-gray-600 normal-case tracking-normal">
+                      {new Date(e.date).toLocaleDateString(undefined, {
+                        month: 'short',
+                        day: 'numeric',
+                      })}
+                    </span>
+                  </div>
+                  <h3 className="mt-2 font-serif text-xl tracking-tight text-ink">{e.title}</h3>
+                  <p className="mt-2 text-base text-gray-700 leading-relaxed">{e.body}</p>
+                </li>
+              ))}
+            </ul>
+          </section>
+        ))}
+      </div>
+    </PublicShell>
   );
 }

--- a/frontend/src/features/chat/ChatPage.tsx
+++ b/frontend/src/features/chat/ChatPage.tsx
@@ -189,14 +189,14 @@ export function ChatPage() {
 
   return (
     <div className="flex flex-col h-[calc(100vh-4rem)] [height:calc(100dvh-4rem)]">
-      <div className="px-4 sm:px-6 lg:px-8 pt-4 pb-2 border-b border-gray-200">
+      <div className="px-4 sm:px-6 lg:px-8 pt-4 pb-2 border-b border-primary-100/80">
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-2xl font-semibold text-gray-900 flex items-center gap-2">
+            <h1 className="font-serif text-2xl text-ink flex items-center gap-2">
               <SparklesIcon className="h-6 w-6 text-primary-600" />
               Plant care chat
             </h1>
-            <p className="text-sm text-gray-500 mt-1">
+            <p className="text-sm text-gray-600 mt-1">
               Ask about your plants, tasks, or local climate. Answers are based on your household's
               actual data and a curated plant-care knowledge base.
             </p>
@@ -235,7 +235,7 @@ export function ChatPage() {
               <div className={`flex ${m.role === 'user' ? 'justify-end' : 'justify-start'}`}>
                 <div
                   className={`max-w-xl rounded-2xl px-4 py-2 text-sm whitespace-pre-wrap ${
-                    m.role === 'user' ? 'bg-primary-600 text-white' : 'bg-gray-100 text-gray-900'
+                    m.role === 'user' ? 'bg-primary-700 text-white' : 'bg-parchment text-gray-900'
                   }`}
                 >
                   {m.text}
@@ -253,22 +253,22 @@ export function ChatPage() {
         ))}
         {isSending && streamingText && (
           <div className="flex justify-start">
-            <div className="max-w-xl rounded-2xl px-4 py-2 text-sm whitespace-pre-wrap bg-gray-100 text-gray-900">
+            <div className="max-w-xl rounded-2xl px-4 py-2 text-sm whitespace-pre-wrap bg-parchment text-gray-900">
               {streamingText}
             </div>
           </div>
         )}
         {isSending && !streamingText && (
           <div className="flex justify-start">
-            <div className="bg-gray-100 text-gray-900 rounded-2xl px-4 py-3 text-sm">
+            <div className="bg-parchment text-gray-900 rounded-2xl px-4 py-3 text-sm">
               <span className="inline-flex gap-1">
-                <span className="w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce" />
+                <span className="w-1.5 h-1.5 bg-primary-300 rounded-full animate-bounce" />
                 <span
-                  className="w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce"
+                  className="w-1.5 h-1.5 bg-primary-300 rounded-full animate-bounce"
                   style={{ animationDelay: '120ms' }}
                 />
                 <span
-                  className="w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce"
+                  className="w-1.5 h-1.5 bg-primary-300 rounded-full animate-bounce"
                   style={{ animationDelay: '240ms' }}
                 />
               </span>
@@ -285,7 +285,7 @@ export function ChatPage() {
         )}
       </div>
 
-      <div className="border-t border-gray-200 px-4 sm:px-6 lg:px-8 py-3">
+      <div className="border-t border-primary-100/80 px-4 sm:px-6 lg:px-8 py-3">
         <div className="flex gap-2 items-end">
           <textarea
             ref={inputRef}
@@ -295,20 +295,20 @@ export function ChatPage() {
             placeholder="Ask about your plants..."
             disabled={isSending}
             rows={1}
-            className="flex-1 resize-none border border-gray-300 rounded-lg px-3 py-3 text-base sm:text-sm min-h-[44px] focus:ring-2 focus:ring-primary-500 focus:border-primary-500 disabled:bg-gray-50"
+            className="flex-1 resize-none border border-primary-200 rounded-lg px-3 py-3 text-base sm:text-sm min-h-[44px] focus:ring-2 focus:ring-primary-500 focus:border-primary-500 disabled:bg-parchment/60"
             aria-label="Chat message"
           />
           <button
             type="button"
             onClick={handleSend}
             disabled={!input.trim() || isSending}
-            className="rounded-lg bg-primary-600 text-white px-3 py-2 hover:bg-primary-700 disabled:bg-gray-300 disabled:cursor-not-allowed"
+            className="rounded-lg bg-primary-700 text-white px-3 py-2 hover:bg-primary-800 disabled:bg-primary-200 disabled:cursor-not-allowed"
             aria-label="Send"
           >
             <PaperAirplaneIcon className="h-5 w-5" />
           </button>
         </div>
-        <p className="text-xs text-gray-500 mt-1">
+        <p className="text-xs text-gray-600 mt-1">
           AI-generated — verify before acting. Refuses pesticide / dosage advice. Reminder
           suggestions wait for your confirm before being created.
         </p>

--- a/frontend/src/features/chat/ProposalCard.tsx
+++ b/frontend/src/features/chat/ProposalCard.tsx
@@ -81,7 +81,7 @@ export function ProposalCard({ proposal }: ProposalCardProps) {
             type="button"
             onClick={() => createMutation.mutate()}
             disabled={createMutation.isPending}
-            className="rounded bg-primary-600 text-white px-3 py-1 text-xs font-medium hover:bg-primary-700 disabled:bg-gray-300 flex items-center gap-1"
+            className="rounded bg-primary-700 text-white px-3 py-1 text-xs font-medium hover:bg-primary-800 disabled:bg-primary-200 flex items-center gap-1"
           >
             <CheckCircleIcon className="h-4 w-4" />
             {t('chat.proposal.createTask')}

--- a/frontend/src/features/dashboard/ClimateCard.tsx
+++ b/frontend/src/features/dashboard/ClimateCard.tsx
@@ -94,7 +94,7 @@ export function ClimateCard() {
               className={
                 tip.level === 'warning'
                   ? 'flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 p-2 text-sm text-amber-900'
-                  : 'flex items-start gap-2 rounded-md border border-gray-200 bg-gray-50 p-2 text-sm text-gray-700'
+                  : 'flex items-start gap-2 rounded-md border border-primary-100/70 bg-primary-50/60 p-2 text-sm text-gray-700'
               }
             >
               {tip.level === 'warning' ? (

--- a/frontend/src/features/dashboard/YearInReviewCard.tsx
+++ b/frontend/src/features/dashboard/YearInReviewCard.tsx
@@ -38,7 +38,7 @@ export function YearInReviewCard() {
 
   return (
     <Card padding="none">
-      <div className="px-6 py-4 border-b border-gray-200">
+      <div className="px-6 py-4 border-b border-primary-100/70">
         <CardHeader
           title={`Your ${year}`}
           description="Care work this household has done so far this year."
@@ -93,7 +93,7 @@ function Stat({ label, value, sub }: StatProps) {
   return (
     <div>
       <p className="text-sm text-gray-600">{label}</p>
-      <p className="mt-1 text-2xl font-semibold text-gray-900">{value}</p>
+      <p className="mt-1 font-serif text-2xl text-ink tabular-nums">{value}</p>
       {sub && <p className="text-xs text-gray-600">{sub}</p>}
     </div>
   );

--- a/frontend/src/features/help/HelpPage.tsx
+++ b/frontend/src/features/help/HelpPage.tsx
@@ -486,7 +486,7 @@ export function HelpPage() {
         filtered.map((section) => (
           <Card key={section.id} padding="none">
             <CardHeader title={section.title} description={section.description} />
-            <ul className="divide-y divide-gray-200">
+            <ul className="divide-y divide-primary-100/60">
               {section.articles.map((article) => {
                 const id = `${section.id}::${article.q}`;
                 const isOpen = open === id;
@@ -494,7 +494,7 @@ export function HelpPage() {
                   <li key={article.q}>
                     <button
                       type="button"
-                      className="flex w-full items-center justify-between gap-4 px-6 py-4 text-left hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
+                      className="flex w-full items-center justify-between gap-4 px-6 py-4 text-left hover:bg-parchment/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
                       aria-expanded={isOpen}
                       aria-controls={`faq-${id}`}
                       onClick={() => setOpen(isOpen ? null : id)}

--- a/frontend/src/features/household/HouseholdOnboarding.tsx
+++ b/frontend/src/features/household/HouseholdOnboarding.tsx
@@ -105,7 +105,7 @@ export function HouseholdOnboarding() {
     <div className="min-h-screen flex flex-col justify-center py-12 sm:px-6 lg:px-8 bg-gradient-to-b from-primary-50 to-white">
       <div className="sm:mx-auto sm:w-full sm:max-w-md flex flex-col items-center">
         <BrandMark variant="wordmark" />
-        <h2 className="mt-8 text-center font-serif text-3xl font-semibold tracking-tight text-gray-900">
+        <h2 className="mt-8 text-center font-serif text-3xl font-semibold tracking-tight text-ink">
           {step === 'choice' &&
             (isAddingAnother ? 'Add another household' : 'Set up your household')}
           {step === 'create' &&
@@ -130,9 +130,7 @@ export function HouseholdOnboarding() {
                     <HomeIcon className="h-6 w-6 text-primary-700" aria-hidden="true" />
                   </div>
                   <div className="text-left">
-                    <h3 className="text-base font-semibold text-gray-900">
-                      Create a new household
-                    </h3>
+                    <h3 className="text-base font-semibold text-ink">Create a new household</h3>
                     <p className="mt-1 text-sm text-gray-500">
                       Start fresh on your own — invite family any time you like
                     </p>
@@ -144,13 +142,11 @@ export function HouseholdOnboarding() {
             <button type="button" onClick={() => setStep('join')} className="w-full">
               <Card className="hover:border-primary-500 hover:shadow-md transition-all cursor-pointer">
                 <div className="flex items-start gap-4">
-                  <div className="flex-shrink-0 rounded-lg bg-secondary-100 p-3">
-                    <UserGroupIcon className="h-6 w-6 text-secondary-600" aria-hidden="true" />
+                  <div className="flex-shrink-0 rounded-lg bg-accent-100 p-3">
+                    <UserGroupIcon className="h-6 w-6 text-accent-700" aria-hidden="true" />
                   </div>
                   <div className="text-left">
-                    <h3 className="text-base font-semibold text-gray-900">
-                      Join an existing household
-                    </h3>
+                    <h3 className="text-base font-semibold text-ink">Join an existing household</h3>
                     <p className="mt-1 text-sm text-gray-500">
                       Use an invite link from a family member
                     </p>

--- a/frontend/src/features/household/HouseholdPage.tsx
+++ b/frontend/src/features/household/HouseholdPage.tsx
@@ -234,16 +234,16 @@ export function HouseholdPage() {
 
       {/* Members list */}
       <Card padding="none">
-        <div className="px-6 py-4 border-b border-gray-200">
-          <h2 className="text-lg font-semibold text-gray-900">
+        <div className="px-6 py-4 border-b border-primary-100/70">
+          <h2 className="font-serif text-lg text-ink">
             Members
-            <span className="ml-2 text-sm font-normal text-gray-500">
+            <span className="ml-2 text-sm font-normal text-gray-600">
               ({household.members.length})
             </span>
           </h2>
         </div>
 
-        <ul className="divide-y divide-gray-200">
+        <ul className="divide-y divide-primary-100/60">
           {household.members.map((member) => (
             <li key={member.userId} className="flex items-center justify-between gap-4 px-6 py-4">
               <div className="flex items-center gap-4">
@@ -279,7 +279,7 @@ export function HouseholdPage() {
                     'inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium',
                     member.role === 'admin'
                       ? 'bg-primary-100 text-primary-900'
-                      : 'bg-gray-100 text-gray-900'
+                      : 'bg-parchment text-gray-700 ring-1 ring-primary-200/50'
                   )}
                 >
                   {member.role === 'admin' ? 'Admin' : 'Member'}

--- a/frontend/src/features/household/JoinHouseholdPage.tsx
+++ b/frontend/src/features/household/JoinHouseholdPage.tsx
@@ -5,6 +5,7 @@ import { useAuthStore } from '@/store/authStore';
 import { householdService } from '@/services/householdService';
 import { authService } from '@/services/authService';
 import { getErrorMessage } from '@/services/api';
+import { BrandMark } from '@/components/BrandMark';
 import { Button } from '@/components/Button';
 import { Card } from '@/components/Card';
 import { LoadingSpinner } from '@/components/LoadingSpinner';
@@ -68,7 +69,7 @@ export function JoinHouseholdPage() {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="min-h-screen flex items-center justify-center bg-paper">
         <LoadingSpinner size="lg" />
       </div>
     );
@@ -77,10 +78,12 @@ export function JoinHouseholdPage() {
   const isInvalid = validateError || !inviteData?.valid;
 
   return (
-    <div className="min-h-screen flex flex-col justify-center py-12 sm:px-6 lg:px-8 bg-gray-50">
+    <div className="min-h-screen flex flex-col justify-center py-12 sm:px-6 lg:px-8 bg-paper">
       <div className="sm:mx-auto sm:w-full sm:max-w-md">
-        <h1 className="text-center text-3xl font-bold text-primary-700">Family Greenhouse</h1>
-        <h2 className="mt-6 text-center text-2xl font-semibold text-gray-900">Join Household</h2>
+        <div className="flex justify-center">
+          <BrandMark variant="wordmark" />
+        </div>
+        <h2 className="mt-6 text-center font-serif text-2xl text-ink">Join Household</h2>
       </div>
 
       <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">

--- a/frontend/src/features/household/MemberVacation.tsx
+++ b/frontend/src/features/household/MemberVacation.tsx
@@ -88,7 +88,7 @@ export function MemberVacation({
     const startLabel = new Date(vacationWindow.startDate).toLocaleDateString();
     return (
       <div className="mt-1 flex flex-wrap items-center gap-2">
-        <span className="inline-flex items-center rounded-full bg-sky-50 px-2 py-0.5 text-xs font-medium text-sky-800 ring-1 ring-sky-300/70">
+        <span className="inline-flex items-center rounded-full bg-accent-50 px-2 py-0.5 text-xs font-medium text-accent-800 ring-1 ring-accent-300/70">
           {upcoming
             ? t('household.vacation.startsOn', { date: startLabel })
             : t('household.vacation.onVacationUntil', { date: endLabel })}

--- a/frontend/src/features/household/SitterLinksCard.tsx
+++ b/frontend/src/features/household/SitterLinksCard.tsx
@@ -144,14 +144,14 @@ export function SitterLinksCard({ householdId }: { householdId: string }) {
       {activeLinks.length > 0 && (
         <div className="mt-6">
           <h3 className="text-sm font-medium text-gray-900">Active links</h3>
-          <ul className="mt-2 divide-y divide-gray-100 rounded-lg border border-gray-200">
+          <ul className="mt-2 divide-y divide-primary-100/60 rounded-lg border border-primary-100/70">
             {activeLinks.map((link) => (
               <li key={link.id} className="flex items-center justify-between gap-4 px-4 py-3">
                 <div className="min-w-0">
                   <p className="truncate text-sm font-medium text-gray-900">
                     {link.label || 'Sitter link'}
                   </p>
-                  <p className="text-xs text-gray-500">
+                  <p className="text-xs text-gray-600">
                     Expires {new Date(link.expiresAt).toLocaleDateString()}
                   </p>
                 </div>

--- a/frontend/src/features/legal/LegalShell.tsx
+++ b/frontend/src/features/legal/LegalShell.tsx
@@ -1,6 +1,4 @@
-import { Link } from 'react-router-dom';
-import { BrandMark } from '@/components/BrandMark';
-import { Footer } from '@/components/Footer';
+import { PublicShell, PageIntro } from '@/components/PublicShell';
 
 interface LegalShellProps {
   title: string;
@@ -9,34 +7,17 @@ interface LegalShellProps {
 }
 
 /**
- * Shared chrome for /legal/privacy and /legal/terms. Same header + footer
- * pattern as the blog and changelog so the marketing site reads as a
- * consistent surface, not a grab bag of differently-styled pages.
+ * Shared chrome for /legal/privacy and /legal/terms. Rides on PublicShell
+ * so the legal pages read as part of the same site as the blog, care
+ * guides, and changelog rather than a differently-styled annex.
  */
 export function LegalShell({ title, effectiveDate, children }: LegalShellProps) {
   return (
-    <div className="min-h-screen bg-white flex flex-col">
-      <header className="border-b border-gray-200">
-        <nav className="mx-auto max-w-3xl flex items-center justify-between p-6">
-          <Link to="/" aria-label="Family Greenhouse home">
-            <BrandMark variant="wordmark" size="sm" />
-          </Link>
-          <Link to="/" className="text-sm font-medium text-primary-700 hover:underline">
-            Try the app →
-          </Link>
-        </nav>
-      </header>
+    <PublicShell>
+      <PageIntro eyebrow="The fine print" title={title} />
+      <p className="mt-4 text-sm text-gray-600">Effective {effectiveDate}.</p>
 
-      <main className="flex-1 mx-auto max-w-3xl w-full px-6 py-16">
-        <h1 className="font-serif text-4xl font-semibold tracking-tight text-gray-900 sm:text-5xl">
-          {title}
-        </h1>
-        <p className="mt-2 text-sm text-gray-500">Effective {effectiveDate}.</p>
-
-        <div className="prose-fg mt-10">{children}</div>
-      </main>
-
-      <Footer />
-    </div>
+      <div className="prose-fg mt-10">{children}</div>
+    </PublicShell>
   );
 }

--- a/frontend/src/features/onboarding/WelcomeFlow.tsx
+++ b/frontend/src/features/onboarding/WelcomeFlow.tsx
@@ -70,7 +70,7 @@ export function WelcomeFlow() {
 
   return (
     <div
-      className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-b from-primary-50 to-white p-6"
+      className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-b from-primary-50 to-paper p-6"
       role="dialog"
       aria-labelledby="welcome-title"
     >
@@ -81,7 +81,7 @@ export function WelcomeFlow() {
           <Illustration className="mx-auto h-32 w-auto" />
           <h1
             id="welcome-title"
-            className="mt-4 font-serif text-3xl font-semibold tracking-tight text-gray-900"
+            className="mt-4 font-serif text-3xl font-semibold tracking-tight text-ink"
           >
             {isFirst && firstName ? `Welcome, ${firstName}` : current.title}
           </h1>
@@ -101,7 +101,7 @@ export function WelcomeFlow() {
               aria-current={i === step ? 'step' : undefined}
               className={clsx(
                 'h-1.5 w-8 rounded-full transition-colors',
-                i === step ? 'bg-primary-700' : 'bg-gray-300 hover:bg-gray-400'
+                i === step ? 'bg-primary-700' : 'bg-primary-200 hover:bg-primary-300'
               )}
             />
           ))}

--- a/frontend/src/features/petsafe/PetSafePage.tsx
+++ b/frontend/src/features/petsafe/PetSafePage.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { BrandMark } from '@/components/BrandMark';
-import { Footer } from '@/components/Footer';
+import { PublicShell, PageIntro } from '@/components/PublicShell';
 import { Alert } from '@/components/Alert';
 import { Input } from '@/components/Input';
 import { useMetaTags } from '@/hooks/useMetaTags';
@@ -61,125 +60,111 @@ export function PetSafePage() {
   const showEmpty = status === 'done' && results.length === 0 && resolvedQuery.length >= 2;
 
   return (
-    <div className="min-h-screen bg-white flex flex-col">
-      <header className="border-b border-gray-200">
-        <nav className="mx-auto max-w-3xl flex items-center justify-between p-6">
-          <Link to="/" aria-label="Family Greenhouse home">
-            <BrandMark variant="wordmark" size="sm" />
-          </Link>
-          <Link to="/" className="text-sm font-medium text-primary-700 hover:underline">
-            Try the app →
-          </Link>
-        </nav>
-      </header>
-
-      <main className="flex-1 mx-auto max-w-3xl w-full px-6 py-16">
-        <h1 className="font-serif text-4xl font-semibold tracking-tight text-gray-900 sm:text-5xl">
-          Is this plant safe for pets?
-        </h1>
-        <p className="mt-3 text-lg text-gray-600">
-          Type a houseplant name and we’ll tell you, plainly, whether it’s toxic to cats and dogs.
-          No sign-up, no fuss. Based on the{' '}
-          <a
-            href="https://www.aspca.org/pet-care/animal-poison-control/toxic-and-non-toxic-plants"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-primary-700 underline hover:text-primary-800"
-          >
-            ASPCA’s plant safety data
-          </a>
-          .
-        </p>
-
-        <form
-          className="mt-10"
-          role="search"
-          aria-label="Search plant pet-toxicity"
-          onSubmit={(e) => e.preventDefault()}
-        >
-          <Input
-            type="search"
-            label="Plant or species name"
-            placeholder="e.g. snake plant, pothos, lily…"
-            autoComplete="off"
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            helperText="Try a common name or a scientific name."
-          />
-        </form>
-
-        {/* Live region so screen readers hear the result as it loads. */}
-        <div className="mt-8 space-y-4" aria-live="polite" aria-busy={status === 'loading'}>
-          {status === 'error' && (
-            <Alert variant="error" title="Something went wrong">
-              We couldn’t check that just now. Give it another moment and try again.
-            </Alert>
-          )}
-
-          {results.map((match) => (
-            <ToxicityCard key={match.slug} match={match} />
-          ))}
-
-          {showEmpty && (
-            <Alert variant="info" title="No match yet">
-              We don’t have that one in our checker yet. Double-check the spelling, or try the
-              plant’s common name. When in doubt, assume it’s unsafe and keep it out of reach until
-              you can confirm with your vet or the ASPCA.
-            </Alert>
-          )}
-        </div>
-
-        {/* General, always-visible caveat for kids and pets. */}
-        <aside className="mt-12 rounded-lg border border-primary-200 bg-primary-50/60 p-5">
-          <h2 className="font-serif text-lg font-semibold text-gray-900">
-            A note on kids and pets
-          </h2>
-          <p className="mt-2 text-sm text-gray-700">
-            Even “non-toxic” plants can cause a mild upset stomach if a curious pet or toddler eats
-            a big mouthful — non-toxic means not poisonous, not that it’s food. With anything truly
-            toxic, the safest move is height: put it where paws and little hands can’t reach. If you
-            think a pet has eaten something harmful, call your vet or the{' '}
+    <PublicShell>
+      <PageIntro
+        eyebrow="Pet safety"
+        title="Is this plant safe for pets?"
+        lede={
+          <>
+            Type a houseplant name and we’ll tell you, plainly, whether it’s toxic to cats and dogs.
+            No sign-up, no fuss. Based on the{' '}
             <a
-              href="https://www.aspca.org/pet-care/animal-poison-control"
+              href="https://www.aspca.org/pet-care/animal-poison-control/toxic-and-non-toxic-plants"
               target="_blank"
               rel="noopener noreferrer"
               className="text-primary-700 underline hover:text-primary-800"
             >
-              ASPCA Animal Poison Control
-            </a>{' '}
-            line right away.
-          </p>
-        </aside>
+              ASPCA’s plant safety data
+            </a>
+            .
+          </>
+        }
+      />
 
-        <section className="mt-16 rounded-lg border border-primary-200 bg-primary-50 p-6 text-center">
-          <h2 className="font-serif text-xl font-semibold text-gray-900">
-            Keeping a pet-safe home is easier when everyone’s on the same page
-          </h2>
-          <p className="mt-2 text-sm text-gray-600">
-            Family Greenhouse keeps your plants, their care, and who’s looking after what in one
-            shared place — so the whole household knows which plants to keep out of reach. Free to
-            start, no card needed.
-          </p>
-          <div className="mt-4">
-            <Link
-              to="/register"
-              className="inline-flex items-center rounded-md bg-primary-700 px-4 py-2 text-sm font-medium text-white hover:bg-primary-800 min-h-touch"
-            >
-              Get started
+      <form
+        className="mt-10"
+        role="search"
+        aria-label="Search plant pet-toxicity"
+        onSubmit={(e) => e.preventDefault()}
+      >
+        <Input
+          type="search"
+          label="Plant or species name"
+          placeholder="e.g. snake plant, pothos, lily…"
+          autoComplete="off"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          helperText="Try a common name or a scientific name."
+        />
+      </form>
+
+      {/* Live region so screen readers hear the result as it loads. */}
+      <div className="mt-8 space-y-4" aria-live="polite" aria-busy={status === 'loading'}>
+        {status === 'error' && (
+          <Alert variant="error" title="Something went wrong">
+            We couldn’t check that just now. Give it another moment and try again.
+          </Alert>
+        )}
+
+        {results.map((match) => (
+          <ToxicityCard key={match.slug} match={match} />
+        ))}
+
+        {showEmpty && (
+          <Alert variant="info" title="No match yet">
+            We don’t have that one in our checker yet. Double-check the spelling, or try the plant’s
+            common name. When in doubt, assume it’s unsafe and keep it out of reach until you can
+            confirm with your vet or the ASPCA.
+          </Alert>
+        )}
+      </div>
+
+      {/* General, always-visible caveat for kids and pets. */}
+      <aside className="mt-12 rounded-xl border border-primary-200 bg-primary-50/60 p-5">
+        <h2 className="font-serif text-lg text-ink">A note on kids and pets</h2>
+        <p className="mt-2 text-sm text-gray-700">
+          Even “non-toxic” plants can cause a mild upset stomach if a curious pet or toddler eats a
+          big mouthful — non-toxic means not poisonous, not that it’s food. With anything truly
+          toxic, the safest move is height: put it where paws and little hands can’t reach. If you
+          think a pet has eaten something harmful, call your vet or the{' '}
+          <a
+            href="https://www.aspca.org/pet-care/animal-poison-control"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary-700 underline hover:text-primary-800"
+          >
+            ASPCA Animal Poison Control
+          </a>{' '}
+          line right away.
+        </p>
+      </aside>
+
+      <section className="mt-16 rounded-xl border border-primary-200 bg-primary-50 p-6 text-center">
+        <h2 className="font-serif text-xl text-ink">
+          Keeping a pet-safe home is easier when everyone’s on the same page
+        </h2>
+        <p className="mt-2 text-sm text-gray-600">
+          Family Greenhouse keeps your plants, their care, and who’s looking after what in one
+          shared place — so the whole household knows which plants to keep out of reach. Free to
+          start, no card needed.
+        </p>
+        <div className="mt-4">
+          <Link
+            to="/register"
+            className="inline-flex items-center rounded-md bg-primary-700 px-4 py-2 text-sm font-medium text-white hover:bg-primary-800 min-h-touch"
+          >
+            Get started
+          </Link>
+          <p className="mt-3 text-xs text-gray-600">
+            Just browsing? Read our{' '}
+            <Link to="/care" className="text-primary-700 underline hover:text-primary-800">
+              plant care guides
             </Link>
-            <p className="mt-3 text-xs text-gray-500">
-              Just browsing? Read our{' '}
-              <Link to="/care" className="text-primary-700 underline hover:text-primary-800">
-                plant care guides
-              </Link>
-              .
-            </p>
-          </div>
-        </section>
-      </main>
-
-      <Footer />
-    </div>
+            .
+          </p>
+        </div>
+      </section>
+    </PublicShell>
   );
 }
 

--- a/frontend/src/features/plants/AddPlantPage.tsx
+++ b/frontend/src/features/plants/AddPlantPage.tsx
@@ -16,6 +16,7 @@ import { Button } from '@/components/Button';
 import { Input } from '@/components/Input';
 import { Card } from '@/components/Card';
 import { Alert } from '@/components/Alert';
+import { TitleUnderline } from '@/components/brand/TitleUnderline';
 import { SpeciesCombobox } from '@/components/SpeciesCombobox';
 import { SuggestedCareCard } from './SuggestedCareCard';
 import { PetToxicityNote } from './PetToxicityNote';
@@ -261,8 +262,11 @@ export function AddPlantPage() {
       </Link>
 
       <div>
-        <h1 className="text-2xl font-bold text-gray-900">Add a new plant</h1>
-        <p className="mt-1 text-sm text-gray-500">
+        <h1 className="font-serif text-3xl text-ink leading-tight tracking-tight">
+          Add a new plant
+        </h1>
+        <TitleUnderline className="mt-1 h-3 w-28 text-primary-600" />
+        <p className="mt-1 text-sm text-gray-600">
           Enter the details of your plant to start tracking its care.
         </p>
       </div>
@@ -293,7 +297,7 @@ export function AddPlantPage() {
           <div className="space-y-3">
             <span className="label">Photo (optional)</span>
             <div className="flex items-start gap-4">
-              <div className="h-32 w-32 flex-shrink-0 overflow-hidden rounded-lg bg-gray-100">
+              <div className="h-32 w-32 flex-shrink-0 overflow-hidden rounded-lg bg-parchment">
                 {pickedPreview ? (
                   <img
                     src={pickedPreview}
@@ -304,7 +308,7 @@ export function AddPlantPage() {
                     className="h-full w-full object-cover"
                   />
                 ) : (
-                  <div className="flex h-full w-full items-center justify-center text-gray-300">
+                  <div className="flex h-full w-full items-center justify-center text-primary-300">
                     <CameraIcon className="h-10 w-10" aria-hidden="true" />
                   </div>
                 )}
@@ -351,7 +355,7 @@ export function AddPlantPage() {
               </div>
             </div>
             {suggestions && suggestions.length > 0 && (
-              <ul className="rounded-md border border-gray-200 divide-y divide-gray-200">
+              <ul className="rounded-md border border-primary-100/70 divide-y divide-primary-100/60">
                 {suggestions.map((s) => (
                   <li
                     key={s.scientificName}

--- a/frontend/src/features/plants/AddTaskModal.tsx
+++ b/frontend/src/features/plants/AddTaskModal.tsx
@@ -85,7 +85,7 @@ export function AddTaskModal({ plantId, isOpen, onClose }: AddTaskModalProps) {
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
         >
-          <div className="fixed inset-0 bg-gray-500/75 transition-opacity" />
+          <div className="fixed inset-0 bg-primary-950/70 transition-opacity" />
         </Transition.Child>
 
         <div className="fixed inset-0 z-10 overflow-y-auto">
@@ -99,11 +99,11 @@ export function AddTaskModal({ plantId, isOpen, onClose }: AddTaskModalProps) {
               leaveFrom="opacity-100 translate-y-0 sm:scale-100"
               leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
             >
-              <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
+              <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-paper border border-primary-100/70 px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
                 <div className="absolute right-0 top-0 pr-4 pt-4">
                   <button
                     type="button"
-                    className="rounded-md bg-white text-gray-600 hover:text-gray-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
+                    className="rounded-md bg-paper text-gray-600 hover:text-gray-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
                     onClick={handleClose}
                   >
                     <span className="sr-only">Close</span>
@@ -113,7 +113,7 @@ export function AddTaskModal({ plantId, isOpen, onClose }: AddTaskModalProps) {
 
                 <Dialog.Title
                   as="h3"
-                  className="font-serif text-2xl font-semibold tracking-tight text-gray-900 mb-4"
+                  className="font-serif text-2xl font-semibold tracking-tight text-ink mb-4"
                 >
                   Add care task
                 </Dialog.Title>

--- a/frontend/src/features/plants/BulkApplyTemplateDialog.tsx
+++ b/frontend/src/features/plants/BulkApplyTemplateDialog.tsx
@@ -79,7 +79,7 @@ export function BulkApplyTemplateDialog({ isOpen, onClose }: BulkApplyTemplateDi
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
         >
-          <div className="fixed inset-0 bg-gray-500/75" />
+          <div className="fixed inset-0 bg-primary-950/70 transition-opacity" />
         </Transition.Child>
 
         <div className="fixed inset-0 z-10 overflow-y-auto">
@@ -93,12 +93,12 @@ export function BulkApplyTemplateDialog({ isOpen, onClose }: BulkApplyTemplateDi
               leaveFrom="opacity-100 translate-y-0 sm:scale-100"
               leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
             >
-              <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
+              <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-paper border border-primary-100/70 px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
                 <div className="absolute right-0 top-0 pr-4 pt-4">
                   <button
                     type="button"
                     onClick={handleClose}
-                    className="rounded-md bg-white text-gray-500 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
+                    className="rounded-md bg-paper text-gray-500 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
                   >
                     <span className="sr-only">Close</span>
                     <XMarkIcon className="h-6 w-6" aria-hidden="true" />
@@ -107,7 +107,7 @@ export function BulkApplyTemplateDialog({ isOpen, onClose }: BulkApplyTemplateDi
 
                 <Dialog.Title
                   as="h3"
-                  className="font-serif text-2xl font-semibold tracking-tight text-gray-900 mb-4"
+                  className="font-serif text-2xl font-semibold tracking-tight text-ink mb-4"
                 >
                   Apply care template
                 </Dialog.Title>
@@ -150,10 +150,10 @@ export function BulkApplyTemplateDialog({ isOpen, onClose }: BulkApplyTemplateDi
                     ) : plants.length === 0 ? (
                       <p className="text-sm text-gray-600">No plants yet.</p>
                     ) : (
-                      <ul className="max-h-64 overflow-y-auto rounded-md border border-gray-200 divide-y divide-gray-200">
+                      <ul className="max-h-64 overflow-y-auto rounded-md border border-primary-100/70 divide-y divide-primary-100/60">
                         {plants.map((p) => (
                           <li key={p.id}>
-                            <label className="flex items-center gap-3 px-3 py-2 hover:bg-gray-50 cursor-pointer">
+                            <label className="flex items-center gap-3 px-3 py-2 hover:bg-parchment/60 cursor-pointer">
                               <input
                                 type="checkbox"
                                 className="h-4 w-4"

--- a/frontend/src/features/plants/CareGuidanceCard.tsx
+++ b/frontend/src/features/plants/CareGuidanceCard.tsx
@@ -15,7 +15,7 @@ export function CareGuidanceCard({ species }: CareGuidanceCardProps) {
   if (!guide) return null;
   return (
     <Card padding="none">
-      <div className="px-6 py-4 border-b border-gray-200">
+      <div className="px-6 py-4 border-b border-primary-100/70">
         <CardHeader
           title={`Caring for ${guide.common}`}
           description={`Curated tips for ${guide.scientific}.`}

--- a/frontend/src/features/plants/CareGuideCard.tsx
+++ b/frontend/src/features/plants/CareGuideCard.tsx
@@ -80,7 +80,7 @@ export function CareGuideCard({ perenualSpeciesId }: CareGuideCardProps) {
 function Stat({ label, value }: { label: string; value: string }) {
   return (
     <div>
-      <dt className="text-xs font-medium text-gray-500">{label}</dt>
+      <dt className="text-xs font-medium text-gray-600">{label}</dt>
       <dd className="mt-1 text-sm font-medium text-gray-900">{value}</dd>
     </div>
   );

--- a/frontend/src/features/plants/CareReportCard.tsx
+++ b/frontend/src/features/plants/CareReportCard.tsx
@@ -50,7 +50,7 @@ export function CareReportCard({ plant }: CareReportCardProps) {
           <h4 className="text-xs font-semibold uppercase tracking-wide text-gray-600 mb-2">
             By task
           </h4>
-          <ul className="divide-y divide-gray-200 text-sm">
+          <ul className="divide-y divide-primary-100/60 text-sm">
             {plant.upcomingTasks.map((t) => (
               <TaskRow key={t.id} task={t} completions={completions} />
             ))}

--- a/frontend/src/features/plants/EditPlantModal.tsx
+++ b/frontend/src/features/plants/EditPlantModal.tsx
@@ -93,7 +93,7 @@ export function EditPlantModal({ plant, isOpen, onClose }: EditPlantModalProps) 
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
         >
-          <div className="fixed inset-0 bg-gray-500/75 transition-opacity" />
+          <div className="fixed inset-0 bg-primary-950/70 transition-opacity" />
         </Transition.Child>
 
         <div className="fixed inset-0 z-10 overflow-y-auto">
@@ -107,11 +107,11 @@ export function EditPlantModal({ plant, isOpen, onClose }: EditPlantModalProps) 
               leaveFrom="opacity-100 translate-y-0 sm:scale-100"
               leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
             >
-              <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
+              <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-paper border border-primary-100/70 px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
                 <div className="absolute right-0 top-0 pr-4 pt-4">
                   <button
                     type="button"
-                    className="rounded-md bg-white text-gray-600 hover:text-gray-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
+                    className="rounded-md bg-paper text-gray-600 hover:text-gray-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
                     onClick={handleClose}
                   >
                     <span className="sr-only">Close</span>
@@ -121,7 +121,7 @@ export function EditPlantModal({ plant, isOpen, onClose }: EditPlantModalProps) 
 
                 <Dialog.Title
                   as="h3"
-                  className="font-serif text-2xl font-semibold tracking-tight text-gray-900 mb-4"
+                  className="font-serif text-2xl font-semibold tracking-tight text-ink mb-4"
                 >
                   Edit plant
                 </Dialog.Title>

--- a/frontend/src/features/plants/EditTaskModal.tsx
+++ b/frontend/src/features/plants/EditTaskModal.tsx
@@ -98,7 +98,7 @@ export function EditTaskModal({ task, isOpen, onClose }: EditTaskModalProps) {
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
         >
-          <div className="fixed inset-0 bg-gray-500/75 transition-opacity" />
+          <div className="fixed inset-0 bg-primary-950/70 transition-opacity" />
         </Transition.Child>
 
         <div className="fixed inset-0 z-10 overflow-y-auto">
@@ -112,11 +112,11 @@ export function EditTaskModal({ task, isOpen, onClose }: EditTaskModalProps) {
               leaveFrom="opacity-100 translate-y-0 sm:scale-100"
               leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
             >
-              <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
+              <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-paper border border-primary-100/70 px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
                 <div className="absolute right-0 top-0 pr-4 pt-4">
                   <button
                     type="button"
-                    className="rounded-md bg-white text-gray-600 hover:text-gray-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
+                    className="rounded-md bg-paper text-gray-600 hover:text-gray-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
                     onClick={handleClose}
                   >
                     <span className="sr-only">Close</span>
@@ -126,7 +126,7 @@ export function EditTaskModal({ task, isOpen, onClose }: EditTaskModalProps) {
 
                 <Dialog.Title
                   as="h3"
-                  className="font-serif text-2xl font-semibold tracking-tight text-gray-900 mb-4"
+                  className="font-serif text-2xl font-semibold tracking-tight text-ink mb-4"
                 >
                   Edit task
                 </Dialog.Title>

--- a/frontend/src/features/plants/ImportPlantsPage.tsx
+++ b/frontend/src/features/plants/ImportPlantsPage.tsx
@@ -170,10 +170,10 @@ export function ImportPlantsPage() {
           onDragLeave={() => setIsDragOver(false)}
           onDrop={onDrop}
           className={`flex flex-col items-center justify-center gap-3 rounded-lg border-2 border-dashed p-8 text-center transition-colors ${
-            isDragOver ? 'border-primary-500 bg-primary-50' : 'border-gray-300'
+            isDragOver ? 'border-primary-500 bg-primary-50' : 'border-primary-200'
           }`}
         >
-          <DocumentArrowUpIcon className="h-10 w-10 text-gray-400" aria-hidden="true" />
+          <DocumentArrowUpIcon className="h-10 w-10 text-primary-300" aria-hidden="true" />
           <p className="text-sm text-gray-600">{t('importPlants.dropHint')}</p>
           <Button
             variant="secondary"
@@ -213,7 +213,7 @@ export function ImportPlantsPage() {
             </Alert>
           )}
           <div className="max-h-96 overflow-auto">
-            <table className="min-w-full divide-y divide-gray-200 text-sm">
+            <table className="min-w-full divide-y divide-primary-100/60 text-sm">
               <thead>
                 <tr className="text-left text-xs font-medium uppercase tracking-wide text-gray-600">
                   <th className="px-3 py-2">{t('importPlants.preview.colRow')}</th>
@@ -225,13 +225,13 @@ export function ImportPlantsPage() {
                   <th className="px-3 py-2">{t('importPlants.preview.colTasks')}</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-gray-100">
+              <tbody className="divide-y divide-primary-100/50">
                 {rows.map((row) => (
                   <tr key={row.index} className={row.data ? '' : 'bg-red-50'}>
                     <td className="px-3 py-2 text-gray-500">{row.index + 1}</td>
                     <td className="px-3 py-2">
                       {row.data ? (
-                        <span className="inline-flex rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800">
+                        <span className="inline-flex rounded-full bg-primary-100 px-2 py-0.5 text-xs font-medium text-primary-800">
                           {t('importPlants.preview.ready')}
                         </span>
                       ) : (

--- a/frontend/src/features/plants/LeafHealthCard.tsx
+++ b/frontend/src/features/plants/LeafHealthCard.tsx
@@ -41,7 +41,7 @@ const OVERALL_STYLES: Record<LeafHealthResult['overall'], string> = {
 };
 
 const CONFIDENCE_STYLES: Record<LeafHealthObservation['confidence'], string> = {
-  low: 'bg-gray-100 text-gray-600',
+  low: 'bg-parchment text-gray-700',
   medium: 'bg-amber-50 text-amber-700',
   high: 'bg-amber-100 text-amber-900',
 };
@@ -77,7 +77,7 @@ export function LeafHealthResults({ result }: { result: LeafHealthResult }) {
         ) : (
           <ul className="mt-2 space-y-2">
             {result.observations.map((obs, i) => (
-              <li key={`${obs.sign}-${i}`} className="rounded-md bg-gray-50 px-3 py-2">
+              <li key={`${obs.sign}-${i}`} className="rounded-md bg-parchment/70 px-3 py-2">
                 <div className="flex items-center justify-between gap-2">
                   <span className="text-sm font-medium text-gray-900">{obs.sign}</span>
                   <span
@@ -105,7 +105,7 @@ export function LeafHealthResults({ result }: { result: LeafHealthResult }) {
 
       {result.demo && <p className="text-xs text-amber-700">{t('plants.leafHealth.demoNotice')}</p>}
 
-      <p className="text-xs text-gray-500">{result.disclaimer}</p>
+      <p className="text-xs text-gray-600">{result.disclaimer}</p>
     </div>
   );
 }
@@ -171,7 +171,7 @@ export function LeafHealthCard({ plantId, isOpen, onClose }: LeafHealthCardProps
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
         >
-          <div className="fixed inset-0 bg-gray-500/75 transition-opacity" />
+          <div className="fixed inset-0 bg-primary-950/70 transition-opacity" />
         </Transition.Child>
 
         <div className="fixed inset-0 z-10 overflow-y-auto">
@@ -185,7 +185,7 @@ export function LeafHealthCard({ plantId, isOpen, onClose }: LeafHealthCardProps
               leaveFrom="opacity-100 translate-y-0 sm:scale-100"
               leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
             >
-              <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
+              <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-paper border border-primary-100/70 px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
                 <div className="sm:flex sm:items-start">
                   <div className="mx-auto flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-primary-100 sm:mx-0 sm:h-10 sm:w-10">
                     <SparklesIcon className="h-6 w-6 text-primary-700" aria-hidden="true" />
@@ -193,7 +193,7 @@ export function LeafHealthCard({ plantId, isOpen, onClose }: LeafHealthCardProps
                   <div className="mt-3 w-full text-center sm:ml-4 sm:mt-0 sm:text-left">
                     <Dialog.Title
                       as="h3"
-                      className="font-serif text-xl font-semibold leading-tight tracking-tight text-gray-900"
+                      className="font-serif text-xl font-semibold leading-tight tracking-tight text-ink"
                     >
                       {t('plants.leafHealth.title')}
                     </Dialog.Title>

--- a/frontend/src/features/plants/PhotoTimeline.tsx
+++ b/frontend/src/features/plants/PhotoTimeline.tsx
@@ -31,7 +31,7 @@ export function PhotoTimeline({ plantId }: PhotoTimelineProps) {
 
   return (
     <section aria-label="Photo timeline">
-      <h2 className="text-sm font-semibold text-gray-900 mb-2">Photo timeline</h2>
+      <h2 className="text-sm font-semibold text-ink mb-2">Photo timeline</h2>
       <ul className="flex gap-3 overflow-x-auto pb-2">
         {photos.map((photo) => (
           <li key={photo.id} className="flex-shrink-0">
@@ -45,7 +45,7 @@ export function PhotoTimeline({ plantId }: PhotoTimelineProps) {
                 height={128}
                 loading="lazy"
                 decoding="async"
-                className="h-32 w-32 rounded-md object-cover bg-gray-100"
+                className="h-32 w-32 rounded-md object-cover bg-parchment"
               />
               <figcaption className="mt-1 text-xs text-gray-600">
                 {new Date(photo.uploadedAt).toLocaleDateString()}

--- a/frontend/src/features/plants/PlantDetailPage.tsx
+++ b/frontend/src/features/plants/PlantDetailPage.tsx
@@ -40,6 +40,7 @@ import { PlantLineageCard } from './PlantLineageCard';
 import { ShareCuttingDialog } from './ShareCuttingDialog';
 import { LeafHealthCard } from './LeafHealthCard';
 import clsx from 'clsx';
+import { TitleUnderline } from '@/components/brand/TitleUnderline';
 import { taskTypeLabels, taskTypeStyle } from '@/utils/taskTypeConfig';
 import { toast } from '@/store/toastStore';
 
@@ -166,7 +167,7 @@ export function PlantDetailPage() {
       {/* Plant header */}
       <div className="flex flex-col sm:flex-row gap-6">
         <div className="w-full sm:w-48 flex-shrink-0 space-y-3">
-          <div className="h-48 rounded-lg bg-gray-100 overflow-hidden">
+          <div className="h-48 rounded-lg bg-parchment overflow-hidden">
             {plant.imageUrl ? (
               <img
                 src={plant.imageUrl}
@@ -181,7 +182,7 @@ export function PlantDetailPage() {
             ) : (
               <div className="w-full h-full flex items-center justify-center">
                 <svg
-                  className="h-20 w-20 text-gray-300"
+                  className="h-20 w-20 text-primary-300"
                   fill="none"
                   viewBox="0 0 24 24"
                   strokeWidth={1}
@@ -214,7 +215,9 @@ export function PlantDetailPage() {
           <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
             <div>
               <div className="flex items-center gap-2">
-                <h1 className="text-2xl font-bold text-gray-900">{plant.name}</h1>
+                <h1 className="font-serif text-3xl text-ink leading-tight tracking-tight">
+                  {plant.name}
+                </h1>
                 {plant.status === 'died' && (
                   <span className="inline-flex items-center rounded-full bg-stone-100 px-2.5 py-0.5 text-xs font-medium text-stone-700">
                     Died
@@ -226,6 +229,7 @@ export function PlantDetailPage() {
                   </span>
                 )}
               </div>
+              <TitleUnderline className="mt-1 h-3 w-28 text-primary-600" />
               {plant.species && <p className="text-lg text-gray-500 italic">{plant.species}</p>}
             </div>
             <div className="flex flex-wrap justify-end gap-2">
@@ -346,7 +350,7 @@ export function PlantDetailPage() {
             action={<Button onClick={() => setShowAddTask(true)}>Add first task</Button>}
           />
         ) : (
-          <ul className="divide-y divide-gray-200 -mx-6 -mb-6">
+          <ul className="divide-y divide-primary-100/60 -mx-6 -mb-6">
             {plant.upcomingTasks.map((task) => (
               <TaskRow
                 key={task.id}
@@ -474,21 +478,26 @@ function TaskRow({
   const isOverdue = new Date(task.nextDue) < new Date();
   const streak = computeStreak(task, completions);
   const streakText = streakLabel(task, streak);
+  const style = taskTypeStyle(task.type);
+  const { Icon } = style;
 
   return (
-    <li className="flex items-center justify-between gap-4 px-6 py-4 hover:bg-gray-50">
+    <li className="flex items-center justify-between gap-4 px-6 py-4 hover:bg-parchment/60">
       <div className="flex items-center gap-4 min-w-0">
         <span
           className={clsx(
-            'inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium',
-            taskTypeStyle(task.type).chip
+            'inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium ring-1',
+            style.chip
           )}
         >
+          <Icon className={clsx('h-4 w-4', style.iconColor)} aria-hidden="true" />
           {task.customType || taskTypeLabels[task.type]}
         </span>
         <div>
           <p className="text-sm text-gray-900">Every {task.frequency} days</p>
-          <p className={clsx('text-xs', isOverdue ? 'text-red-600 font-medium' : 'text-gray-600')}>
+          <p
+            className={clsx('text-xs', isOverdue ? 'text-accent-700 font-medium' : 'text-gray-600')}
+          >
             Due: {formatDate(task.nextDue)}
             {task.lastCompleted && ` • Last: ${formatDate(task.lastCompleted)}`}
           </p>
@@ -543,7 +552,7 @@ function SnoozeMenu({ isSnoozing, onPick }: SnoozeMenuProps) {
       <summary
         className={clsx(
           'list-none inline-flex items-center justify-center gap-1 px-3 py-2 text-sm font-medium rounded-md min-h-touch min-w-touch cursor-pointer',
-          'bg-white text-gray-700 border border-gray-300 hover:bg-gray-50',
+          'bg-paper text-gray-700 border border-primary-200/70 hover:bg-primary-50',
           'focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2',
           isSnoozing && 'opacity-50 cursor-wait'
         )}
@@ -552,12 +561,12 @@ function SnoozeMenu({ isSnoozing, onPick }: SnoozeMenuProps) {
         <ClockIcon className="h-4 w-4" aria-hidden="true" />
         Snooze
       </summary>
-      <ul className="absolute right-0 z-10 mt-1 w-44 max-w-[calc(100vw-2rem)] rounded-md bg-white shadow-lg ring-1 ring-black/5 py-1">
+      <ul className="absolute right-0 z-10 mt-1 w-44 max-w-[calc(100vw-2rem)] rounded-md bg-paper shadow-lg ring-1 ring-primary-100/80 py-1">
         {SNOOZE_OPTIONS.map((opt) => (
           <li key={opt.label}>
             <button
               type="button"
-              className="flex min-h-touch w-full items-center px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary-500"
+              className="flex min-h-touch w-full items-center px-3 py-2 text-sm text-gray-700 hover:bg-parchment/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary-500"
               onClick={(e) => {
                 onPick(opt.days);
                 // Close the details popover after clicking.

--- a/frontend/src/features/plants/PlantsPage.tsx
+++ b/frontend/src/features/plants/PlantsPage.tsx
@@ -140,7 +140,7 @@ export function PlantsPage() {
               'relative inline-flex items-center rounded-l-md min-h-touch min-w-touch justify-center px-3 py-2 text-sm font-medium border focus:z-10 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500',
               viewMode === 'grid'
                 ? 'bg-primary-50 text-primary-700 border-primary-500'
-                : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50'
+                : 'bg-paper text-gray-700 border-primary-200/70 hover:bg-primary-50'
             )}
             onClick={() => setViewMode('grid')}
             aria-pressed={viewMode === 'grid'}
@@ -154,7 +154,7 @@ export function PlantsPage() {
               'relative -ml-px inline-flex items-center rounded-r-md min-h-touch min-w-touch justify-center px-3 py-2 text-sm font-medium border focus:z-10 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500',
               viewMode === 'list'
                 ? 'bg-primary-50 text-primary-700 border-primary-500'
-                : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50'
+                : 'bg-paper text-gray-700 border-primary-200/70 hover:bg-primary-50'
             )}
             onClick={() => setViewMode('list')}
             aria-pressed={viewMode === 'list'}

--- a/frontend/src/features/plants/RemovePlantDialog.tsx
+++ b/frontend/src/features/plants/RemovePlantDialog.tsx
@@ -41,7 +41,7 @@ export function RemovePlantDialog({
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
         >
-          <div className="fixed inset-0 bg-gray-500/75 transition-opacity" />
+          <div className="fixed inset-0 bg-primary-950/70 transition-opacity" />
         </Transition.Child>
 
         <div className="fixed inset-0 z-10 overflow-y-auto">
@@ -55,10 +55,10 @@ export function RemovePlantDialog({
               leaveFrom="opacity-100 translate-y-0 sm:scale-100"
               leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
             >
-              <Dialog.Panel className="relative w-full transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:max-w-lg sm:p-6">
+              <Dialog.Panel className="relative w-full transform overflow-hidden rounded-lg bg-paper border border-primary-100/70 px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:max-w-lg sm:p-6">
                 <Dialog.Title
                   as="h3"
-                  className="font-serif text-xl font-semibold leading-tight tracking-tight text-gray-900"
+                  className="font-serif text-xl font-semibold leading-tight tracking-tight text-ink"
                 >
                   Remove {plantName}?
                 </Dialog.Title>

--- a/frontend/src/features/plants/ShareCuttingDialog.tsx
+++ b/frontend/src/features/plants/ShareCuttingDialog.tsx
@@ -67,7 +67,7 @@ export function ShareCuttingDialog({ plantId, isOpen, onClose }: ShareCuttingDia
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
         >
-          <div className="fixed inset-0 bg-gray-500/75 transition-opacity" />
+          <div className="fixed inset-0 bg-primary-950/70 transition-opacity" />
         </Transition.Child>
 
         <div className="fixed inset-0 z-10 overflow-y-auto">
@@ -81,7 +81,7 @@ export function ShareCuttingDialog({ plantId, isOpen, onClose }: ShareCuttingDia
               leaveFrom="opacity-100 translate-y-0 sm:scale-100"
               leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
             >
-              <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
+              <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-paper border border-primary-100/70 px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
                 <div className="sm:flex sm:items-start">
                   <div className="mx-auto flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-primary-100 sm:mx-0 sm:h-10 sm:w-10">
                     <ShareIcon className="h-6 w-6 text-primary-700" aria-hidden="true" />
@@ -89,7 +89,7 @@ export function ShareCuttingDialog({ plantId, isOpen, onClose }: ShareCuttingDia
                   <div className="mt-3 w-full text-center sm:ml-4 sm:mt-0 sm:text-left">
                     <Dialog.Title
                       as="h3"
-                      className="font-serif text-xl font-semibold leading-tight tracking-tight text-gray-900"
+                      className="font-serif text-xl font-semibold leading-tight tracking-tight text-ink"
                     >
                       {t('plants.share.title')}
                     </Dialog.Title>

--- a/frontend/src/features/plants/SharedPlantPage.tsx
+++ b/frontend/src/features/plants/SharedPlantPage.tsx
@@ -197,7 +197,7 @@ export function SharedPlantPage() {
 
             {plant.notes && (
               <div className="rounded-lg border border-primary-100/70 bg-white/60 p-3">
-                <p className="text-xs font-medium uppercase tracking-wide text-gray-500">
+                <p className="text-xs font-medium uppercase tracking-wide text-gray-600">
                   {t('plants.shared.notesLabel')}
                 </p>
                 <p className="mt-1 whitespace-pre-wrap text-sm text-gray-800">{plant.notes}</p>
@@ -218,7 +218,7 @@ export function SharedPlantPage() {
                   <Button className="w-full" onClick={startGraft}>
                     🌱 {t('plants.shared.graftCta')}
                   </Button>
-                  <p className="text-center text-xs text-gray-500">
+                  <p className="text-center text-xs text-gray-600">
                     {t('plants.shared.signInPrompt')}{' '}
                     <Link
                       to={`/login?redirect=/shared/${code}`}

--- a/frontend/src/features/pricing/PricingGrid.tsx
+++ b/frontend/src/features/pricing/PricingGrid.tsx
@@ -33,7 +33,7 @@ export function PricingGrid() {
         <div
           role="radiogroup"
           aria-label="Billing interval"
-          className="inline-flex rounded-full bg-gray-100 p-1"
+          className="inline-flex rounded-full bg-parchment ring-1 ring-primary-200/60 p-1"
         >
           {(['monthly', 'annual', 'lifetime'] as Interval[]).map((opt) => (
             <button
@@ -63,21 +63,18 @@ export function PricingGrid() {
               'flex flex-col rounded-2xl p-8',
               plan.highlighted
                 ? 'bg-primary-700 text-white ring-2 ring-primary-700 lg:scale-105 shadow-xl'
-                : 'bg-white ring-1 ring-gray-200'
+                : 'bg-white ring-1 ring-primary-200/60 shadow-journal'
             )}
           >
             <h3
-              className={clsx(
-                'text-lg font-semibold',
-                plan.highlighted ? 'text-white' : 'text-gray-900'
-              )}
+              className={clsx('font-serif text-xl', plan.highlighted ? 'text-white' : 'text-ink')}
             >
               {plan.name}
             </h3>
             <p
               className={clsx(
                 'mt-2 text-sm',
-                plan.highlighted ? 'text-primary-100' : 'text-gray-500'
+                plan.highlighted ? 'text-primary-100' : 'text-gray-600'
               )}
             >
               {plan.description}
@@ -103,8 +100,8 @@ export function PricingGrid() {
                   <div className="flex items-baseline gap-1">
                     <span
                       className={clsx(
-                        'text-4xl font-bold',
-                        plan.highlighted ? 'text-white' : 'text-gray-900'
+                        'font-serif text-4xl tabular-nums',
+                        plan.highlighted ? 'text-white' : 'text-ink'
                       )}
                     >
                       {plan.freeLabel ?? point?.price}
@@ -113,7 +110,7 @@ export function PricingGrid() {
                       <span
                         className={clsx(
                           'text-sm',
-                          plan.highlighted ? 'text-primary-100' : 'text-gray-500'
+                          plan.highlighted ? 'text-primary-100' : 'text-gray-600'
                         )}
                       >
                         {point.period}
@@ -124,7 +121,7 @@ export function PricingGrid() {
                     <p
                       className={clsx(
                         'mt-1 text-xs',
-                        plan.highlighted ? 'text-primary-100' : 'text-gray-500'
+                        plan.highlighted ? 'text-primary-100' : 'text-gray-600'
                       )}
                     >
                       No lifetime option — annual price shown

--- a/frontend/src/features/pricing/PricingPage.tsx
+++ b/frontend/src/features/pricing/PricingPage.tsx
@@ -1,6 +1,4 @@
-import { Link } from 'react-router-dom';
-import { BrandMark } from '@/components/BrandMark';
-import { Footer } from '@/components/Footer';
+import { PublicShell, PageIntro } from '@/components/PublicShell';
 import { useMetaTags } from '@/hooks/useMetaTags';
 import { siteUrl } from '@/config/site';
 import { PricingGrid } from './PricingGrid';
@@ -21,88 +19,67 @@ export function PricingPage() {
   });
 
   return (
-    <div className="min-h-screen bg-white flex flex-col">
-      <header className="border-b border-gray-200">
-        <nav className="mx-auto max-w-5xl flex items-center justify-between p-6">
-          <Link to="/" aria-label="Family Greenhouse home">
-            <BrandMark variant="wordmark" size="sm" />
-          </Link>
-          <Link to="/" className="text-sm font-medium text-primary-700 hover:underline">
-            Try the app →
-          </Link>
-        </nav>
-      </header>
+    <PublicShell width="wide">
+      <PageIntro
+        align="center"
+        eyebrow="Pricing"
+        title="Plans for every greenhouse"
+        lede="Start free. Upgrade when your household outgrows it. Cancel any time from inside the app."
+      />
 
-      <main className="flex-1 mx-auto max-w-5xl w-full px-6 py-16">
-        <div className="text-center max-w-2xl mx-auto">
-          <h1 className="font-serif text-4xl font-semibold tracking-tight text-gray-900 sm:text-5xl">
-            Pricing
-          </h1>
-          <p className="mt-4 text-lg text-gray-600">
-            Start free. Upgrade when your household outgrows it. Cancel any time from inside the
-            app.
-          </p>
-        </div>
+      <PricingGrid />
 
-        <PricingGrid />
-
-        <section className="mt-16 max-w-2xl mx-auto">
-          <h2 className="font-serif text-2xl font-semibold tracking-tight text-gray-900">
-            Common questions
-          </h2>
-          <dl className="mt-6 space-y-6">
-            <div>
-              <dt className="font-medium text-gray-900">
-                Do I need a credit card to try the free plan?
-              </dt>
-              <dd className="mt-1 text-sm text-gray-600">
-                No. The Seedling plan is fully free, no card required. Add up to 10 plants and bring
-                in up to 6 household members.
-              </dd>
-            </div>
-            <div>
-              <dt className="font-medium text-gray-900">
-                What happens if I downgrade past my plant or member limit?
-              </dt>
-              <dd className="mt-1 text-sm text-gray-600">
-                Existing plants and members stay — we never auto-delete data. You won&rsquo;t be
-                able to add new ones until you&rsquo;re back under the cap. Active tasks keep
-                running.
-              </dd>
-            </div>
-            <div>
-              <dt className="font-medium text-gray-900">
-                Can I share a single subscription across multiple households?
-              </dt>
-              <dd className="mt-1 text-sm text-gray-600">
-                A subscription pays for one household. If you create a second household (a vacation
-                place, a parent&rsquo;s plants), the new household starts on the free Seedling plan
-                and can be upgraded independently.
-              </dd>
-            </div>
-            <div>
-              <dt className="font-medium text-gray-900">
-                What does &ldquo;API access&rdquo; mean on the Greenhouse plan?
-              </dt>
-              <dd className="mt-1 text-sm text-gray-600">
-                Read-only access to your household data over a versioned REST API, authenticated
-                with personal access keys you can mint and revoke from Settings. Useful for Home
-                Assistant integrations, personal scripts, and exporting to other tools.
-              </dd>
-            </div>
-            <div>
-              <dt className="font-medium text-gray-900">How do refunds work?</dt>
-              <dd className="mt-1 text-sm text-gray-600">
-                Monthly subscriptions aren&rsquo;t pro-rated on cancel. If you&rsquo;ve been billed
-                by mistake or the service was seriously broken for you, email us — we&rsquo;ll make
-                it right.
-              </dd>
-            </div>
-          </dl>
-        </section>
-      </main>
-
-      <Footer />
-    </div>
+      <section className="mt-16 max-w-2xl mx-auto">
+        <h2 className="font-serif text-2xl tracking-tight text-ink">Common questions</h2>
+        <dl className="mt-6 space-y-6">
+          <div>
+            <dt className="font-medium text-gray-900">
+              Do I need a credit card to try the free plan?
+            </dt>
+            <dd className="mt-1 text-sm text-gray-600">
+              No. The Seedling plan is fully free, no card required. Add up to 10 plants and bring
+              in up to 6 household members.
+            </dd>
+          </div>
+          <div>
+            <dt className="font-medium text-gray-900">
+              What happens if I downgrade past my plant or member limit?
+            </dt>
+            <dd className="mt-1 text-sm text-gray-600">
+              Existing plants and members stay — we never auto-delete data. You won&rsquo;t be able
+              to add new ones until you&rsquo;re back under the cap. Active tasks keep running.
+            </dd>
+          </div>
+          <div>
+            <dt className="font-medium text-gray-900">
+              Can I share a single subscription across multiple households?
+            </dt>
+            <dd className="mt-1 text-sm text-gray-600">
+              A subscription pays for one household. If you create a second household (a vacation
+              place, a parent&rsquo;s plants), the new household starts on the free Seedling plan
+              and can be upgraded independently.
+            </dd>
+          </div>
+          <div>
+            <dt className="font-medium text-gray-900">
+              What does &ldquo;API access&rdquo; mean on the Greenhouse plan?
+            </dt>
+            <dd className="mt-1 text-sm text-gray-600">
+              Read-only access to your household data over a versioned REST API, authenticated with
+              personal access keys you can mint and revoke from Settings. Useful for Home Assistant
+              integrations, personal scripts, and exporting to other tools.
+            </dd>
+          </div>
+          <div>
+            <dt className="font-medium text-gray-900">How do refunds work?</dt>
+            <dd className="mt-1 text-sm text-gray-600">
+              Monthly subscriptions aren&rsquo;t pro-rated on cancel. If you&rsquo;ve been billed by
+              mistake or the service was seriously broken for you, email us — we&rsquo;ll make it
+              right.
+            </dd>
+          </div>
+        </dl>
+      </section>
+    </PublicShell>
   );
 }

--- a/frontend/src/features/settings/ApiKeysSettings.tsx
+++ b/frontend/src/features/settings/ApiKeysSettings.tsx
@@ -164,7 +164,7 @@ export function ApiKeysSettings() {
                   <label key={scope} className="flex items-center gap-2 text-sm text-gray-700">
                     <input
                       type="checkbox"
-                      className="rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+                      className="rounded border-gray-300 accent-primary-700 text-primary-600 focus:ring-primary-500"
                       checked={scopes.includes(scope)}
                       onChange={() => toggleScope(scope)}
                     />
@@ -218,7 +218,7 @@ export function ApiKeysSettings() {
                     {(key.scopes ?? []).map((scope) => (
                       <span
                         key={scope}
-                        className="inline-flex rounded bg-gray-100 px-1.5 py-0.5 text-[11px] font-medium text-gray-600"
+                        className="inline-flex rounded bg-primary-50 px-1.5 py-0.5 text-[11px] font-medium text-primary-800"
                       >
                         {SCOPE_LABELS[scope] ?? scope}
                       </span>

--- a/frontend/src/features/settings/BillingSettings.tsx
+++ b/frontend/src/features/settings/BillingSettings.tsx
@@ -187,7 +187,7 @@ function BillingIntervalToggle({
       <div
         role="radiogroup"
         aria-label="Billing interval"
-        className="inline-flex rounded-full bg-gray-100 p-1"
+        className="inline-flex rounded-full bg-parchment p-1"
       >
         {options.map((opt) => (
           <button
@@ -242,7 +242,7 @@ function UsageMeters({ usage }: { usage: PlanUsage }) {
               {m.label}
             </p>
             <div
-              className="mt-1 h-1.5 w-full max-w-xs rounded-full bg-gray-100"
+              className="mt-1 h-1.5 w-full max-w-xs rounded-full bg-primary-100/60"
               role="presentation"
             >
               <div

--- a/frontend/src/features/settings/NotificationSettings.tsx
+++ b/frontend/src/features/settings/NotificationSettings.tsx
@@ -236,10 +236,10 @@ export function NotificationSettings() {
         {info && <Alert variant="success">{info}</Alert>}
 
         {/* Browser */}
-        <div className="flex items-center justify-between gap-4 border-b border-gray-200 pb-4">
+        <div className="flex items-center justify-between gap-4 border-b border-primary-100/70 pb-4">
           <div>
             <p className="text-sm font-medium text-gray-900">Browser</p>
-            <p className="text-sm text-gray-500">
+            <p className="text-sm text-gray-600">
               {browserActive
                 ? 'Pop-ups appear while a tab is open or the app is installed.'
                 : permission === 'denied'
@@ -267,10 +267,10 @@ export function NotificationSettings() {
         </div>
 
         {/* Email */}
-        <div className="flex items-center justify-between gap-4 border-b border-gray-200 pb-4">
+        <div className="flex items-center justify-between gap-4 border-b border-primary-100/70 pb-4">
           <div>
             <p className="text-sm font-medium text-gray-900">Email</p>
-            <p className="text-sm text-gray-500">
+            <p className="text-sm text-gray-600">
               Daily roll-up to your account email when tasks are due in the next 24 hours.
             </p>
           </div>
@@ -278,7 +278,7 @@ export function NotificationSettings() {
             <span className="sr-only">Email notifications</span>
             <input
               type="checkbox"
-              className="h-5 w-5"
+              className="h-5 w-5 accent-primary-700"
               checked={prefs.email}
               onChange={(e) => save({ email: e.target.checked })}
             />
@@ -286,12 +286,12 @@ export function NotificationSettings() {
         </div>
 
         {/* Weekly digest */}
-        <div className="flex items-center justify-between gap-4 border-b border-gray-200 pb-4">
+        <div className="flex items-center justify-between gap-4 border-b border-primary-100/70 pb-4">
           <div>
             <p className="text-sm font-medium text-gray-900">
               {t('notifications.weeklyDigestTitle')}
             </p>
-            <p className="text-sm text-gray-500">
+            <p className="text-sm text-gray-600">
               {prefs.email
                 ? t('notifications.weeklyDigestDescription')
                 : t('notifications.weeklyDigestRequiresEmail')}
@@ -301,7 +301,7 @@ export function NotificationSettings() {
             <span className="sr-only">{t('notifications.weeklyDigestTitle')}</span>
             <input
               type="checkbox"
-              className="h-5 w-5"
+              className="h-5 w-5 accent-primary-700"
               checked={(prefs.weeklyDigest ?? true) && prefs.email}
               disabled={!prefs.email}
               onChange={(e) => save({ weeklyDigest: e.target.checked })}
@@ -314,7 +314,7 @@ export function NotificationSettings() {
           <div className="flex items-center justify-between gap-4">
             <div>
               <p className="text-sm font-medium text-gray-900">Text message</p>
-              <p className="text-sm text-gray-500">
+              <p className="text-sm text-gray-600">
                 {phoneIsVerified || prefs.sms
                   ? 'Short SMS reminders when tasks slip past due. Standard message rates may apply.'
                   : t('notifications.phoneUnverifiedHint')}
@@ -324,7 +324,7 @@ export function NotificationSettings() {
               <span className="sr-only">SMS notifications</span>
               <input
                 type="checkbox"
-                className="h-5 w-5"
+                className="h-5 w-5 accent-primary-700"
                 checked={prefs.sms}
                 // Allow turning OFF anytime; turning ON requires a verified number.
                 disabled={prefs.sms ? false : !phoneIsVerified}
@@ -395,7 +395,7 @@ export function NotificationSettings() {
         <div className="flex items-center justify-between gap-4 pt-2">
           <div>
             <p className="text-sm font-medium text-gray-900">Seasonal pest heads-ups</p>
-            <p className="text-sm text-gray-500">
+            <p className="text-sm text-gray-600">
               When a plant in your household enters a typical pest season (spider mites, aphids,
               etc.) we&rsquo;ll send one nudge per quarter to check it. Only fires for plants with a
               recognized species.
@@ -405,7 +405,7 @@ export function NotificationSettings() {
             <span className="sr-only">Pest alerts</span>
             <input
               type="checkbox"
-              className="h-5 w-5"
+              className="h-5 w-5 accent-primary-700"
               checked={prefs.pestAlerts ?? false}
               onChange={(e) => save({ pestAlerts: e.target.checked })}
             />
@@ -416,7 +416,7 @@ export function NotificationSettings() {
         <div className="space-y-3 pt-2">
           <div>
             <p className="text-sm font-medium text-gray-900">Quiet hours</p>
-            <p className="text-sm text-gray-500">
+            <p className="text-sm text-gray-600">
               Email + SMS reminders pause during this window. Browser pop-ups follow your OS Do Not
               Disturb settings instead.
             </p>

--- a/frontend/src/features/settings/PreferencesSettings.tsx
+++ b/frontend/src/features/settings/PreferencesSettings.tsx
@@ -56,7 +56,7 @@ export function PreferencesSettings() {
                   'rounded-md border px-4 py-2 text-sm font-medium min-h-touch',
                   density === value
                     ? 'border-primary-700 bg-primary-50 text-primary-800'
-                    : 'border-gray-300 bg-white text-gray-700 hover:bg-gray-50'
+                    : 'border-primary-200/70 bg-paper text-gray-700 hover:bg-primary-50'
                 )}
               >
                 {t(`settings.preferences.density${value[0].toUpperCase() + value.slice(1)}`)}

--- a/frontend/src/features/settings/SettingsPage.tsx
+++ b/frontend/src/features/settings/SettingsPage.tsx
@@ -36,7 +36,7 @@ export function SettingsPage() {
         description={t('settings.description')}
       />
 
-      <div className="border-b border-gray-200">
+      <div className="border-b border-primary-100/80">
         <nav className="-mb-px flex gap-3 sm:gap-6 overflow-x-auto" aria-label="Settings sections">
           {TABS.map((id) => (
             <button
@@ -47,7 +47,7 @@ export function SettingsPage() {
                 'border-b-2 px-1 py-4 text-sm font-medium',
                 tab === id
                   ? 'border-primary-500 text-primary-700'
-                  : 'border-transparent text-gray-600 hover:border-gray-300 hover:text-gray-800'
+                  : 'border-transparent text-gray-600 hover:border-primary-200 hover:text-ink'
               )}
               aria-current={tab === id ? 'page' : undefined}
             >

--- a/frontend/src/features/sitter/SitPage.tsx
+++ b/frontend/src/features/sitter/SitPage.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState, useCallback } from 'react';
 import { Link, useParams } from 'react-router-dom';
-import { BrandMark } from '@/components/BrandMark';
-import { Footer } from '@/components/Footer';
+import { PublicShell } from '@/components/PublicShell';
 import { Alert } from '@/components/Alert';
 import { Button } from '@/components/Button';
 import { LoadingSpinner } from '@/components/LoadingSpinner';
@@ -111,105 +110,92 @@ export function SitPage() {
   const allDone = status === 'ready' && remaining.length === 0;
 
   return (
-    <div className="min-h-screen bg-white flex flex-col">
-      <header className="border-b border-gray-200">
-        <nav className="mx-auto max-w-2xl flex items-center justify-between p-6">
-          <Link to="/" aria-label="Family Greenhouse home">
-            <BrandMark variant="wordmark" size="sm" />
-          </Link>
-        </nav>
-      </header>
+    <PublicShell width="article" plainHeader>
+      {status === 'loading' && (
+        <div className="flex min-h-[40vh] items-center justify-center" role="status">
+          <LoadingSpinner size="lg" />
+          <span className="sr-only">Loading plant-sitting tasks…</span>
+        </div>
+      )}
 
-      <main className="flex-1 mx-auto max-w-2xl w-full px-6 py-12">
-        {status === 'loading' && (
-          <div className="flex min-h-[40vh] items-center justify-center" role="status">
-            <LoadingSpinner size="lg" />
-            <span className="sr-only">Loading plant-sitting tasks…</span>
-          </div>
-        )}
+      {status === 'inactive' && (
+        <div className="mt-8">
+          <Alert variant="info" title="This plant-sitting link is no longer active">
+            The link may have expired or been turned off by the person who shared it. If you’re
+            still helping out, ask them for a fresh link.
+          </Alert>
+        </div>
+      )}
 
-        {status === 'inactive' && (
-          <div className="mt-8">
-            <Alert variant="info" title="This plant-sitting link is no longer active">
-              The link may have expired or been turned off by the person who shared it. If you’re
-              still helping out, ask them for a fresh link.
-            </Alert>
-          </div>
-        )}
+      {status === 'error' && (
+        <div className="mt-8">
+          <Alert variant="error" title="Something went wrong">
+            We couldn’t load the plant-sitting list just now. Please refresh and try again in a
+            moment.
+          </Alert>
+        </div>
+      )}
 
-        {status === 'error' && (
-          <div className="mt-8">
-            <Alert variant="error" title="Something went wrong">
-              We couldn’t load the plant-sitting list just now. Please refresh and try again in a
-              moment.
-            </Alert>
-          </div>
-        )}
+      {status === 'ready' && (
+        <>
+          <h1 className="font-serif text-3xl tracking-tight text-ink sm:text-4xl">
+            {label ? `${label}: what needs doing` : 'Thanks for plant-sitting!'}
+          </h1>
+          <p className="mt-3 text-base text-gray-600">
+            Here’s what needs a little care while they’re away. Tap <strong>Done</strong> once
+            you’ve looked after each one — no account needed.
+          </p>
 
-        {status === 'ready' && (
-          <>
-            <h1 className="font-serif text-3xl font-semibold tracking-tight text-gray-900 sm:text-4xl">
-              {label ? `${label}: what needs doing` : 'Thanks for plant-sitting!'}
-            </h1>
-            <p className="mt-3 text-base text-gray-600">
-              Here’s what needs a little care while they’re away. Tap <strong>Done</strong> once
-              you’ve looked after each one — no account needed.
-            </p>
-
-            {/* Live region announces completions to screen readers. */}
-            <div className="mt-10 space-y-3" aria-live="polite">
-              {allDone ? (
-                <Alert variant="success" title="All caught up — you’re a star 🌿">
-                  Every plant has been looked after. Thank you so much for helping out!
-                </Alert>
-              ) : (
-                <ul className="space-y-3">
-                  {remaining.map((task) => {
-                    const isPending = pending.has(task.taskId);
-                    return (
-                      <li
-                        key={task.taskId}
-                        className="flex items-center justify-between gap-4 rounded-lg border border-gray-200 bg-white p-4 shadow-sm"
-                      >
-                        <div className="min-w-0">
-                          <p className="font-medium text-gray-900">{instructionFor(task)}</p>
-                          <p
-                            className={
-                              'mt-0.5 text-sm ' +
-                              (task.overdue ? 'text-amber-700' : 'text-gray-500')
-                            }
-                          >
-                            {dueLabel(task, now)}
-                          </p>
-                        </div>
-                        <Button
-                          variant="primary"
-                          size="sm"
-                          isLoading={isPending}
-                          onClick={() => handleComplete(task.taskId)}
-                          aria-label={`Mark "${instructionFor(task)}" as done`}
+          {/* Live region announces completions to screen readers. */}
+          <div className="mt-10 space-y-3" aria-live="polite">
+            {allDone ? (
+              <Alert variant="success" title="All caught up — you’re a star 🌿">
+                Every plant has been looked after. Thank you so much for helping out!
+              </Alert>
+            ) : (
+              <ul className="space-y-3">
+                {remaining.map((task) => {
+                  const isPending = pending.has(task.taskId);
+                  return (
+                    <li
+                      key={task.taskId}
+                      className="flex items-center justify-between gap-4 rounded-xl border border-primary-100/80 bg-white p-4 shadow-journal"
+                    >
+                      <div className="min-w-0">
+                        <p className="font-medium text-gray-900">{instructionFor(task)}</p>
+                        <p
+                          className={
+                            'mt-0.5 text-sm ' + (task.overdue ? 'text-amber-700' : 'text-gray-600')
+                          }
                         >
-                          Done
-                        </Button>
-                      </li>
-                    );
-                  })}
-                </ul>
-              )}
-            </div>
+                          {dueLabel(task, now)}
+                        </p>
+                      </div>
+                      <Button
+                        variant="primary"
+                        size="sm"
+                        isLoading={isPending}
+                        onClick={() => handleComplete(task.taskId)}
+                        aria-label={`Mark "${instructionFor(task)}" as done`}
+                      >
+                        Done
+                      </Button>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
 
-            <p className="mt-10 text-sm text-gray-500">
-              Looking after plants regularly?{' '}
-              <Link to="/" className="text-primary-700 underline hover:text-primary-800">
-                Family Greenhouse
-              </Link>{' '}
-              keeps a whole household’s plant care in one shared place.
-            </p>
-          </>
-        )}
-      </main>
-
-      <Footer />
-    </div>
+          <p className="mt-10 text-sm text-gray-600">
+            Looking after plants regularly?{' '}
+            <Link to="/" className="text-primary-700 underline hover:text-primary-800">
+              Family Greenhouse
+            </Link>{' '}
+            keeps a whole household’s plant care in one shared place.
+          </p>
+        </>
+      )}
+    </PublicShell>
   );
 }

--- a/frontend/src/features/status/StatusPage.tsx
+++ b/frontend/src/features/status/StatusPage.tsx
@@ -1,4 +1,3 @@
-import { Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
 import {
@@ -7,8 +6,7 @@ import {
   QuestionMarkCircleIcon,
   XCircleIcon,
 } from '@heroicons/react/24/outline';
-import { BrandMark } from '@/components/BrandMark';
-import { Footer } from '@/components/Footer';
+import { PublicShell, PageIntro } from '@/components/PublicShell';
 import { useMetaTags } from '@/hooks/useMetaTags';
 import { healthService, type ComponentStatus } from '@/services/healthService';
 
@@ -41,8 +39,10 @@ const COMPONENT_LABELS: Record<string, string> = {
 
 function StatusPill({ status }: { status: ComponentStatus }) {
   if (status === 'ok') {
+    // Healthy state renders in the brand green, not stock Tailwind green —
+    // "operational" is the page's default mood and should look like us.
     return (
-      <span className="inline-flex items-center gap-1.5 rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-800">
+      <span className="inline-flex items-center gap-1.5 rounded-full bg-primary-100 px-2.5 py-0.5 text-xs font-medium text-primary-800">
         <CheckCircleIcon className="h-3.5 w-3.5" aria-hidden="true" />
         Operational
       </span>
@@ -87,174 +87,157 @@ export function StatusPage() {
   const overallStatus: ComponentStatus = serverErrored ? 'down' : (data?.status ?? 'ok');
 
   return (
-    <div className="min-h-screen bg-white flex flex-col">
-      <header className="border-b border-gray-200">
-        <nav className="mx-auto max-w-3xl flex items-center justify-between p-6">
-          <Link to="/" aria-label="Family Greenhouse home">
-            <BrandMark variant="wordmark" size="sm" />
-          </Link>
-          <Link to="/" className="text-sm font-medium text-primary-700 hover:underline">
-            Try the app →
-          </Link>
-        </nav>
-      </header>
+    <PublicShell>
+      <PageIntro
+        eyebrow="Health check"
+        title="System status"
+        lede="Live state of the services that keep Family Greenhouse running."
+      />
 
-      <main className="flex-1 mx-auto max-w-3xl w-full px-6 py-16">
-        <h1 className="font-serif text-4xl font-semibold tracking-tight text-gray-900 sm:text-5xl">
-          System status
-        </h1>
-        <p className="mt-3 text-lg text-gray-600">
-          Live state of the services that keep Family Greenhouse running.
-        </p>
-
-        {/* Overall banner */}
-        {unreachable ? (
-          <div className="mt-8 rounded-lg border border-amber-200 bg-amber-50 p-5">
-            <div className="flex items-center gap-3">
-              <QuestionMarkCircleIcon className="h-6 w-6 text-amber-600" aria-hidden="true" />
-              <p className="font-display text-xl font-semibold text-amber-900">
-                Can&rsquo;t reach the status API from your network
-              </p>
-            </div>
-            <p className="mt-2 text-sm text-amber-900">
-              This page checks <code>GET /health</code> from your browser, and that request got no
-              response. That can mean our API is down, but it can also be your connection, a VPN, or
-              an ad blocker. Try reloading, or check from another network.
+      {/* Overall banner */}
+      {unreachable ? (
+        <div className="mt-8 rounded-lg border border-amber-200 bg-amber-50 p-5">
+          <div className="flex items-center gap-3">
+            <QuestionMarkCircleIcon className="h-6 w-6 text-amber-600" aria-hidden="true" />
+            <p className="font-serif text-xl text-amber-900">
+              Can&rsquo;t reach the status API from your network
             </p>
-            {data?.checkedAt && (
-              <p className="mt-2 text-xs text-gray-600">
-                Last successful check {new Date(data.checkedAt).toLocaleString()}.
-              </p>
-            )}
           </div>
-        ) : (
-          <div
-            className={`mt-8 rounded-lg border p-5 ${
-              overallStatus === 'ok'
-                ? 'border-green-200 bg-green-50'
-                : overallStatus === 'degraded'
-                  ? 'border-amber-200 bg-amber-50'
-                  : 'border-red-200 bg-red-50'
-            }`}
-          >
-            <div className="flex items-center gap-3">
-              {overallStatus === 'ok' && (
-                <CheckCircleIcon className="h-6 w-6 text-green-600" aria-hidden="true" />
-              )}
-              {overallStatus === 'degraded' && (
-                <ExclamationTriangleIcon className="h-6 w-6 text-amber-600" aria-hidden="true" />
-              )}
-              {overallStatus === 'down' && (
-                <XCircleIcon className="h-6 w-6 text-red-600" aria-hidden="true" />
-              )}
-              <p
-                className={`font-display text-xl font-semibold ${
-                  overallStatus === 'ok'
-                    ? 'text-green-900'
-                    : overallStatus === 'degraded'
-                      ? 'text-amber-900'
-                      : 'text-red-900'
-                }`}
-              >
-                {overallStatus === 'ok' && 'All systems operational'}
-                {overallStatus === 'degraded' && 'Some systems degraded'}
-                {overallStatus === 'down' && 'We are investigating an issue'}
-              </p>
-            </div>
-            {data?.checkedAt && (
-              <p className="mt-2 text-xs text-gray-600">
-                Last checked {new Date(data.checkedAt).toLocaleString()}.
-              </p>
-            )}
-          </div>
-        )}
-
-        {/* Component breakdown */}
-        <section className="mt-10">
-          <h2 className="font-serif text-2xl font-semibold tracking-tight text-gray-900">
-            Components
-          </h2>
-          {isLoading ? (
-            <p className="mt-4 text-sm text-gray-500">Checking…</p>
-          ) : (
-            <ul className="mt-4 divide-y divide-gray-200 rounded-lg border border-gray-200 bg-white">
-              {data &&
-                Object.entries(data.components).map(([key, info]) => (
-                  <li key={key} className="flex items-center justify-between gap-4 px-5 py-4">
-                    <span className="text-sm font-medium text-gray-900">
-                      {COMPONENT_LABELS[key] ?? key}
-                    </span>
-                    <StatusPill status={info.status} />
-                  </li>
-                ))}
-              {!data && (
-                <li className="flex items-center justify-between gap-4 px-5 py-4">
-                  <span className="text-sm font-medium text-gray-900">API</span>
-                  {unreachable ? (
-                    <span className="inline-flex items-center gap-1.5 rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-700">
-                      <QuestionMarkCircleIcon className="h-3.5 w-3.5" aria-hidden="true" />
-                      No response
-                    </span>
-                  ) : (
-                    <StatusPill status="down" />
-                  )}
-                </li>
-              )}
-            </ul>
+          <p className="mt-2 text-sm text-amber-900">
+            This page checks <code>GET /health</code> from your browser, and that request got no
+            response. That can mean our API is down, but it can also be your connection, a VPN, or
+            an ad blocker. Try reloading, or check from another network.
+          </p>
+          {data?.checkedAt && (
+            <p className="mt-2 text-xs text-gray-600">
+              Last successful check {new Date(data.checkedAt).toLocaleString()}.
+            </p>
           )}
-        </section>
-
-        {/* Incidents */}
-        <section className="mt-12">
-          <h2 className="font-serif text-2xl font-semibold tracking-tight text-gray-900">
-            Recent incidents
-          </h2>
-          {INCIDENTS.length === 0 ? (
-            <p className="mt-4 text-sm text-gray-600">
-              {unreachable
-                ? 'Incident history unavailable right now.'
-                : 'No incidents in the last 90 days.'}
+        </div>
+      ) : (
+        <div
+          className={`mt-8 rounded-lg border p-5 ${
+            overallStatus === 'ok'
+              ? 'border-primary-200 bg-primary-50'
+              : overallStatus === 'degraded'
+                ? 'border-amber-200 bg-amber-50'
+                : 'border-red-200 bg-red-50'
+          }`}
+        >
+          <div className="flex items-center gap-3">
+            {overallStatus === 'ok' && (
+              <CheckCircleIcon className="h-6 w-6 text-primary-700" aria-hidden="true" />
+            )}
+            {overallStatus === 'degraded' && (
+              <ExclamationTriangleIcon className="h-6 w-6 text-amber-600" aria-hidden="true" />
+            )}
+            {overallStatus === 'down' && (
+              <XCircleIcon className="h-6 w-6 text-red-600" aria-hidden="true" />
+            )}
+            <p
+              className={`font-serif text-xl ${
+                overallStatus === 'ok'
+                  ? 'text-primary-900'
+                  : overallStatus === 'degraded'
+                    ? 'text-amber-900'
+                    : 'text-red-900'
+              }`}
+            >
+              {overallStatus === 'ok' && 'All systems operational'}
+              {overallStatus === 'degraded' && 'Some systems degraded'}
+              {overallStatus === 'down' && 'We are investigating an issue'}
             </p>
-          ) : (
-            <ul className="mt-4 space-y-6">
-              {INCIDENTS.map((inc, i) => (
-                <li
-                  key={`${inc.date}-${i}`}
-                  className="rounded-lg border border-gray-200 bg-white p-5"
-                >
-                  <div className="flex items-center gap-2 text-xs">
-                    <span
-                      className={`rounded-full px-2 py-0.5 font-medium ${
-                        inc.resolved ? 'bg-green-100 text-green-900' : 'bg-amber-100 text-amber-900'
-                      }`}
-                    >
-                      {inc.resolved ? 'Resolved' : 'Investigating'}
-                    </span>
-                    <span className="text-gray-500">
-                      {new Date(inc.date).toLocaleDateString(undefined, {
-                        year: 'numeric',
-                        month: 'short',
-                        day: 'numeric',
-                      })}
-                    </span>
-                  </div>
-                  <h3 className="mt-2 font-display text-lg font-semibold text-gray-900">
-                    {inc.title}
-                  </h3>
-                  <p className="mt-1 text-sm text-gray-700">{inc.body}</p>
+          </div>
+          {data?.checkedAt && (
+            <p className="mt-2 text-xs text-gray-600">
+              Last checked {new Date(data.checkedAt).toLocaleString()}.
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Component breakdown */}
+      <section className="mt-10">
+        <h2 className="font-serif text-2xl tracking-tight text-ink">Components</h2>
+        {isLoading ? (
+          <p className="mt-4 text-sm text-gray-600">Checking…</p>
+        ) : (
+          <ul className="mt-4 divide-y divide-primary-100/60 rounded-xl border border-primary-100/80 bg-white shadow-journal">
+            {data &&
+              Object.entries(data.components).map(([key, info]) => (
+                <li key={key} className="flex items-center justify-between gap-4 px-5 py-4">
+                  <span className="text-sm font-medium text-gray-900">
+                    {COMPONENT_LABELS[key] ?? key}
+                  </span>
+                  <StatusPill status={info.status} />
                 </li>
               ))}
-            </ul>
-          )}
-        </section>
+            {!data && (
+              <li className="flex items-center justify-between gap-4 px-5 py-4">
+                <span className="text-sm font-medium text-gray-900">API</span>
+                {unreachable ? (
+                  <span className="inline-flex items-center gap-1.5 rounded-full bg-parchment px-2.5 py-0.5 text-xs font-medium text-gray-700">
+                    <QuestionMarkCircleIcon className="h-3.5 w-3.5" aria-hidden="true" />
+                    No response
+                  </span>
+                ) : (
+                  <StatusPill status="down" />
+                )}
+              </li>
+            )}
+          </ul>
+        )}
+      </section>
 
-        <p className="mt-12 text-xs text-gray-500">
-          Status is checked live against <code>GET /health</code> every 60 seconds. For real-time
-          reach we recommend bookmarking this page.
-        </p>
-      </main>
+      {/* Incidents */}
+      <section className="mt-12">
+        <h2 className="font-serif text-2xl tracking-tight text-ink">Recent incidents</h2>
+        {INCIDENTS.length === 0 ? (
+          <p className="mt-4 text-sm text-gray-600">
+            {/* During a live outage, "No incidents in the last 90 days"
+                  would sit under a red banner and read as a contradiction —
+                  the hand-curated list just hasn't caught up yet. */}
+            {unreachable
+              ? 'Incident history unavailable right now.'
+              : serverErrored
+                ? 'Details for the current issue will be posted here as we learn more.'
+                : 'No incidents in the last 90 days.'}
+          </p>
+        ) : (
+          <ul className="mt-4 space-y-6">
+            {INCIDENTS.map((inc, i) => (
+              <li
+                key={`${inc.date}-${i}`}
+                className="rounded-xl border border-primary-100/80 bg-white p-5 shadow-journal"
+              >
+                <div className="flex items-center gap-2 text-xs">
+                  <span
+                    className={`rounded-full px-2 py-0.5 font-medium ${
+                      inc.resolved ? 'bg-green-100 text-green-900' : 'bg-amber-100 text-amber-900'
+                    }`}
+                  >
+                    {inc.resolved ? 'Resolved' : 'Investigating'}
+                  </span>
+                  <span className="text-gray-600">
+                    {new Date(inc.date).toLocaleDateString(undefined, {
+                      year: 'numeric',
+                      month: 'short',
+                      day: 'numeric',
+                    })}
+                  </span>
+                </div>
+                <h3 className="mt-2 font-serif text-lg text-ink">{inc.title}</h3>
+                <p className="mt-1 text-sm text-gray-700">{inc.body}</p>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
 
-      <Footer />
-    </div>
+      <p className="mt-12 text-xs text-gray-600">
+        Status is checked live against <code>GET /health</code> every 60 seconds. For real-time
+        reach we recommend bookmarking this page.
+      </p>
+    </PublicShell>
   );
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -105,11 +105,14 @@
   .prose-fg p {
     @apply mt-4;
   }
+  /* Prose headings sit in brand ink, not near-black, and skip the bold
+     utility: Gloock ships a single 400 weight, so font-semibold only
+     buys synthetic emboldening that muddies the serifs. */
   .prose-fg h2 {
-    @apply mt-10 font-serif text-2xl font-semibold tracking-tight text-gray-900;
+    @apply mt-10 font-serif text-2xl tracking-tight text-ink;
   }
   .prose-fg h3 {
-    @apply mt-8 font-serif text-xl font-semibold tracking-tight text-gray-900;
+    @apply mt-8 font-serif text-xl tracking-tight text-ink;
   }
   .prose-fg ul,
   .prose-fg ol {


### PR DESCRIPTION
## What

A whole-repo design pass. The garden-journal identity (paper, ink Gloock serif, hand-drawn underlines, botanical icons) was fully realized on landing/auth/404 and the app shell — and broke everywhere else. This closes the gap. 56 files, no behavior changes outside the fixes listed below.

### The reading room joins the greenhouse
- New **`PublicShell` + `PageIntro`**: one shared chrome (paper bg, branded header with cross-links, compact primary-900 footer with the memorial line) replacing ten hand-rolled white shells: care index/guides, blog index/posts, pricing, changelog, legal, status, pet-safe, sitter.
- **Seed-packet facts card** on every care guide: parchment, dashed cut-line frame, three new hand-drawn icons (`SunGlowIcon`, `MistLeafIcon`, `PawLeafIcon`).
- Footer tagline unified (the reading room previously carried a second tagline on a gray footer).

### App primitives on-brand
- `Card` default border + serif `CardHeader`; all 8 dialogs on a `primary-950/70` scrim with paper panels; CommandPalette, ConfirmDialog, settings controls, chat surface, JoinHousehold, WelcomeFlow, HouseholdOnboarding.
- Analytics chart hues now mirror `taskTypeConfig` (charts match the task chips used app-wide); KPI tiles use the journal card + serif ink numerals.

### Bugs fixed along the way
- **StatusPage used `font-display`, a class that doesn't exist in this config** — its headings silently rendered in the sans body font. Now `font-serif`.
- A live outage no longer renders "No incidents in the last 90 days" under a red outage banner.
- Changelog no longer calls the spider-plant guide the "fourth" (there are ten).
- Gloock is never faux-bolded (it ships one weight; `font-semibold` only bought synthetic emboldening).
- Contrast sweep: `text-xs text-gray-500` → `gray-600` across flagged spots; interactive `primary-600` fills → `primary-700` (600-on-white is 3.76:1, below AA).

## Verification
- `tsc --noEmit` clean, `eslint --max-warnings 0` clean, **344/344** vitest, size-limit budgets pass (CSS 13.81/15 kB).
- Before/after full-page screenshot pass at 1440 + 390 px across landing, pricing, care index/guide, blog, login, status, legal, 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)