### PR TITLE
fix(species): don't claim "no watering needed" when Perenual data is missing

### DIFF
--- a/backend/src/services/careRecommendations.ts
+++ b/backend/src/services/careRecommendations.ts
@@ -28,12 +28,21 @@ export function deriveCareSuggestion(detail: PerenualSpeciesDetail): CareSuggest
   const sunlight = detail.sunlight.slice(0, 3);
 
   const parts: string[] = [];
-  if (wateringDays === null) {
+  if (detail.watering === 'none') {
+    // Perenual explicitly flags this species as not needing regular
+    // watering (e.g. some epiphytes). Distinct from the case below, where
+    // Perenual simply has no watering data for the species at all — that's
+    // the common case for less-mainstream entries, and asserting "no
+    // watering needed" there would be a guess dressed up as a fact.
     parts.push('No regular watering needed.');
-  } else if (wateringDays <= 4) {
-    parts.push(`Water roughly every ${wateringDays} days.`);
+  } else if (wateringDays !== null) {
+    if (wateringDays <= 4) {
+      parts.push(`Water roughly every ${wateringDays} days.`);
+    } else {
+      parts.push(`Water about every ${wateringDays} days.`);
+    }
   } else {
-    parts.push(`Water about every ${wateringDays} days.`);
+    parts.push("Watering data isn't available for this species.");
   }
   if (sunlight.length > 0) {
     parts.push(`Light: ${sunlight.join(', ')}.`);

--- a/backend/tests/unit/services/careRecommendations.test.ts
+++ b/backend/tests/unit/services/careRecommendations.test.ts
@@ -27,6 +27,19 @@ describe('deriveCareSuggestion', () => {
     expect(deriveCareSuggestion({ ...base, watering: null }).wateringDays).toBeNull();
   });
 
+  it('distinguishes an explicit "no watering needed" from missing watering data', () => {
+    // Perenual explicitly says this species needs no regular watering.
+    const explicitNone = deriveCareSuggestion({ ...base, watering: 'none' });
+    expect(explicitNone.summary).toMatch(/no regular watering needed/i);
+
+    // Perenual has no watering data at all (e.g. a less-mainstream species
+    // like Cinnamomum cassia) — must not claim "no watering needed"; that's
+    // a guess, not a fact from the data source.
+    const unknown = deriveCareSuggestion({ ...base, watering: null });
+    expect(unknown.summary).not.toMatch(/no regular watering needed/i);
+    expect(unknown.summary).toMatch(/watering data isn't available/i);
+  });
+
   it('summarizes light requirements when present', () => {
     const out = deriveCareSuggestion({ ...base, sunlight: ['full sun', 'part shade'] });
     expect(out.summary).toContain('full sun');


### PR DESCRIPTION
## Bug

Adding a plant with species **Cinnamomum cassia** (cinnamon tree) shows "Suggested care: No regular watering needed." — wrong; it's a real tree that needs regular watering.

## Root cause

`deriveCareSuggestion` (`backend/src/services/careRecommendations.ts`) mapped Perenual's `watering` field through a `null`-collapsing ternary:

```ts
const wateringDays = detail.watering ? WATERING_DAYS[detail.watering] : null;
...
if (wateringDays === null) {
  parts.push('No regular watering needed.');
}
```

This is `null` for two very different cases:
1. Perenual **explicitly** says `watering: 'none'` (rare — a handful of genuine no-regular-watering species).
2. Perenual **has no watering data at all** for the species — the common case for a less-mainstream entry like cinnamon tree.

Both produced the same "No regular watering needed." sentence, asserting a fact from data source (2) that was never actually stated. This directly contradicts the principle the codebase already states elsewhere in the same flow — `NoCareDataNotice.tsx`: *"we'd rather show nothing than guess."*

## Fix

Only an explicit `watering === 'none'` produces "No regular watering needed." Missing/unrecognized data now says so plainly: "Watering data isn't available for this species." `wateringDays` stays `null` in both cases either way, so no bogus auto-scheduled task was ever the issue — this is purely a false-claim-in-copy bug.

## Verification
- Added a test asserting the two cases produce different summary text.
- `tsc --noEmit` clean, `eslint src --max-warnings 0` clean, full backend suite: **1012/1012** passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)