### PR TITLE
fix(species): sweep the Perenual integration for the missing-data-as-false-answer bug

### DIFF
--- a/backend/src/handlers/species/handler.ts
+++ b/backend/src/handlers/species/handler.ts
@@ -17,13 +17,28 @@ import * as enrichment from '../../services/enrichment.js';
 import { isConfigured } from '../../services/perenual.js';
 import { deriveCareSuggestion } from '../../services/careRecommendations.js';
 import { lookupToxicity } from '../../models/petToxicity.js';
+import createHttpError from 'http-errors';
+
+// `Number.parseInt` truncates trailing garbage ("7abc" → 7, "7e2" → 7), so a
+// malformed id would silently resolve to a real species instead of being
+// rejected. Require the whole path segment to be digits.
+function parseSpeciesId(idStr: string): number | null {
+  if (!/^[0-9]+$/.test(idStr)) return null;
+  const id = Number.parseInt(idStr, 10);
+  return id > 0 ? id : null;
+}
+
+// Max length for a free-text search query, mirroring the cap already applied
+// to /species/toxicity — bounds the string forwarded to Perenual and used as
+// a DynamoDB cache sort key (which has its own ~1KB limit).
+const MAX_QUERY_LENGTH = 80;
 
 // GET /species/search?q=...
 // Public catalog: same query → same answer for every user. 5-minute
 // CloudFront cache mirrors the server-side TTL on `SEARCH#…` rows.
 export const search = createHandler(
   async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
-    const q = (event.queryStringParameters?.q ?? '').trim();
+    const q = (event.queryStringParameters?.q ?? '').trim().slice(0, MAX_QUERY_LENGTH);
     if (!q || q.length < 2) {
       return successResponse({
         source: (await isConfigured()) ? 'perenual' : 'disabled',
@@ -31,11 +46,12 @@ export const search = createHandler(
       });
     }
     const hits = await enrichment.searchSpeciesCached(q);
+    // `source: 'disabled'` should mean exactly that — not "budget exhausted"
+    // or "Perenual errored," which look identical to a real outage if this
+    // says "disabled." isConfigured() only reports the no-API-key case.
+    const source = hits !== null ? 'perenual' : (await isConfigured()) ? 'unavailable' : 'disabled';
     return cacheableResponse(
-      {
-        source: hits === null ? 'disabled' : 'perenual',
-        results: hits ?? [],
-      },
+      { source, results: hits ?? [] },
       { maxAgeSeconds: 300, visibility: 'public' }
     );
   }
@@ -49,11 +65,12 @@ export const search = createHandler(
 // Botanical detail rarely changes; cache for an hour at the edge.
 export const detail = createHandler(
   async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
-    const idStr = event.pathParameters?.id ?? '';
-    const id = Number.parseInt(idStr, 10);
-    if (!Number.isFinite(id) || id <= 0) {
-      return successResponse({ result: null });
-    }
+    const id = parseSpeciesId(event.pathParameters?.id ?? '');
+    // A malformed id and "no data for this (valid) id" must not look the
+    // same: the former is a client bug, the latter is a normal, cacheable
+    // 200. Collapsing them into the same response (as this used to do) makes
+    // a real Perenual outage indistinguishable from a typo'd URL.
+    if (id === null) throw createHttpError(400, 'Invalid species id');
     const detail = await enrichment.getSpeciesCached(id);
     // Surface `thumbnailUrl` directly (allowlist-sanitized, same policy as
     // the /thumbnail redirect) so clients can render the image without the
@@ -83,9 +100,8 @@ export const detail = createHandler(
 // on.
 export const thumbnail = createHandler(
   async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
-    const idStr = event.pathParameters?.id ?? '';
-    const id = Number.parseInt(idStr, 10);
-    if (!Number.isFinite(id) || id <= 0) {
+    const id = parseSpeciesId(event.pathParameters?.id ?? '');
+    if (id === null) {
       return { statusCode: 404, body: '' };
     }
     const detail = await enrichment.getSpeciesCached(id);
@@ -153,11 +169,8 @@ function pickAllowedThumbnailUrl(...candidates: Array<string | null>): string | 
 // just see localized strings.
 export const guide = createHandler(
   async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
-    const idStr = event.pathParameters?.id ?? '';
-    const id = Number.parseInt(idStr, 10);
-    if (!Number.isFinite(id) || id <= 0) {
-      return successResponse({ result: null });
-    }
+    const id = parseSpeciesId(event.pathParameters?.id ?? '');
+    if (id === null) throw createHttpError(400, 'Invalid species id');
     const locale = (event.queryStringParameters?.locale ?? 'en').toLowerCase();
     const [detail, careGuide] = await Promise.all([
       enrichment.getSpeciesCached(id),
@@ -190,11 +203,8 @@ export const guide = createHandler(
 // the frontend doesn't have to know about Perenual's enum vocabulary.
 export const careSuggestions = createHandler(
   async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
-    const idStr = event.pathParameters?.id ?? '';
-    const id = Number.parseInt(idStr, 10);
-    if (!Number.isFinite(id) || id <= 0) {
-      return successResponse({ result: null });
-    }
+    const id = parseSpeciesId(event.pathParameters?.id ?? '');
+    if (id === null) throw createHttpError(400, 'Invalid species id');
     const detail = await enrichment.getSpeciesCached(id);
     if (!detail) return successResponse({ result: null });
     return successResponse({ result: deriveCareSuggestion(detail) });

--- a/backend/src/middleware/rateLimit.ts
+++ b/backend/src/middleware/rateLimit.ts
@@ -94,7 +94,28 @@ function sourceIp(event: APIGatewayProxyEvent): string {
   return rc?.http?.sourceIp ?? rc?.identity?.sourceIp ?? 'unknown';
 }
 
+interface MaybeRoutedEvent {
+  routeKey?: string;
+  resource?: string;
+  httpMethod?: string;
+}
+
+// Bucket on the route TEMPLATE API Gateway resolved (e.g.
+// "GET /species/{id}/guide"), not the literal request path — otherwise every
+// distinct numeric id on an `{id}`-shaped route gets its own bucket, and
+// varying the id trivially defeats a documented "N per minute" cap. Mirrors
+// the same resolution `router.ts`'s `routeKeyFor` uses for dispatch.
+//
+// Falls back to the literal path when neither `routeKey` (HTTP API v2) nor a
+// real `resource` (REST API v1) is present — routes with no `{param}` segment
+// (e.g. /auth/login vs /auth/refresh) are already distinct paths with nothing
+// to conflate, so the fallback stays correct for them.
 function routePath(event: APIGatewayProxyEvent): string {
+  const routed = event as MaybeRoutedEvent;
+  if (typeof routed.routeKey === 'string') return routed.routeKey;
+  if (typeof routed.resource === 'string' && routed.resource !== '/') {
+    return `${routed.httpMethod ?? 'GET'} ${routed.resource}`;
+  }
   return (event as MaybeV2Event).rawPath ?? event.path ?? '/';
 }
 

--- a/backend/src/services/enrichment.ts
+++ b/backend/src/services/enrichment.ts
@@ -12,9 +12,13 @@
  *    until the next UTC day. The ceiling is generous; the goal is to stop
  *    runaway usage, not to ration aggressively.
  *
- * If Perenual is unconfigured (no API key) every method returns null so
- * callers transparently fall back to whatever degraded behavior they
- * implement (usually the static species catalog).
+ * Every method returns null for three DIFFERENT reasons: Perenual is
+ * unconfigured (no API key), the daily budget is exhausted, or the upstream
+ * call itself failed (network/non-2xx/timeout). Callers that need to tell
+ * these apart (anything user-facing, or anything deciding whether to retry)
+ * must not assume null always means "the integration is off" — check
+ * `perenual.isConfigured()` separately, and watch the `perenual.*` warn logs
+ * this module emits on every null-causing branch.
  */
 import { GetCommand, PutCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
 import { dynamodb, TABLE_NAME } from '../utils/dynamodb.js';
@@ -31,6 +35,15 @@ import type {
 const SPECIES_TTL_DAYS = 90;
 const SEARCH_TTL_SECONDS = 5 * 60;
 const DEFAULT_DAILY_BUDGET = 80; // free tier is 100; leave headroom for retries
+// Smears a bulk cache-warm's expiry across up to 6h instead of one instant —
+// without jitter, everything written on the same day expires on the same
+// day 90 days later, and the resulting burst of cache misses can exceed the
+// daily budget and trip the circuit breaker for every caller at once.
+const TTL_JITTER_SECONDS = 6 * 60 * 60;
+
+function jitteredTtlSeconds(baseSeconds: number): number {
+  return baseSeconds + Math.floor(Math.random() * TTL_JITTER_SECONDS);
+}
 
 function dailyBudget(): number {
   const raw = optionalEnv('PERENUAL_DAILY_BUDGET');
@@ -154,10 +167,14 @@ export async function getSpeciesCached(id: number): Promise<PerenualSpeciesDetai
   if (cached) return cached;
 
   const budget = await checkAndIncrementBudget();
-  if (budget.blocked) return null;
+  if (budget.blocked) {
+    logger.warn({ used: budget.used, limit: budget.limit }, 'perenual.budget_exhausted');
+    return null;
+  }
 
   const fresh = await perenual.getSpecies(id);
-  if (fresh) await writeCache('PERENUAL#CACHE', sk, fresh, SPECIES_TTL_DAYS * 86400);
+  if (fresh)
+    await writeCache('PERENUAL#CACHE', sk, fresh, jitteredTtlSeconds(SPECIES_TTL_DAYS * 86400));
   return fresh;
 }
 
@@ -169,27 +186,46 @@ export async function getCareGuideCached(speciesId: number): Promise<PerenualCar
   if (cached) return cached;
 
   const budget = await checkAndIncrementBudget();
-  if (budget.blocked) return null;
+  if (budget.blocked) {
+    logger.warn({ used: budget.used, limit: budget.limit }, 'perenual.budget_exhausted');
+    return null;
+  }
 
   const fresh = await perenual.getCareGuide(speciesId);
-  if (fresh) await writeCache('PERENUAL#CACHE', sk, fresh, SPECIES_TTL_DAYS * 86400);
+  if (fresh)
+    await writeCache('PERENUAL#CACHE', sk, fresh, jitteredTtlSeconds(SPECIES_TTL_DAYS * 86400));
   return fresh;
 }
 
-export async function listPestsForSpeciesCached(
-  scientificName: string
-): Promise<PerenualPestSummary[] | null> {
-  if (!(await perenual.isConfigured())) return null;
-  const sk = `PESTS#${scientificName.toLowerCase()}`;
+/**
+ * Unlike the other cached lookups (which only need to answer "what's the
+ * data, or null"), pest-alert evaluation needs to tell "confirmed no pests"
+ * apart from "we don't actually know" — a caller that silently treats budget
+ * exhaustion or an upstream error as "no pests" ends up permanently skipping
+ * alerts for that plant with no trace of why (see `pestAlerts.ts`). Hence the
+ * discriminated result instead of a bare nullable array.
+ */
+export type PestLookupResult =
+  | { ok: true; pests: PerenualPestSummary[] }
+  | { ok: false; reason: 'unconfigured' | 'budget_exhausted' | 'upstream_error' };
+
+export async function listPestsForSpeciesCached(scientificName: string): Promise<PestLookupResult> {
+  if (!(await perenual.isConfigured())) return { ok: false, reason: 'unconfigured' };
+  const trimmed = scientificName.trim().toLowerCase();
+  const sk = `PESTS#${trimmed}`;
   const cached = await readCache<PerenualPestSummary[]>('PERENUAL#CACHE', sk);
-  if (cached) return cached;
+  if (cached) return { ok: true, pests: cached };
 
   const budget = await checkAndIncrementBudget();
-  if (budget.blocked) return null;
+  if (budget.blocked) {
+    logger.warn({ used: budget.used, limit: budget.limit }, 'perenual.budget_exhausted');
+    return { ok: false, reason: 'budget_exhausted' };
+  }
 
-  const fresh = await perenual.listPestsForSpecies(scientificName);
-  if (fresh) await writeCache('PERENUAL#CACHE', sk, fresh, SPECIES_TTL_DAYS * 86400);
-  return fresh;
+  const fresh = await perenual.listPestsForSpecies(trimmed);
+  if (fresh === null) return { ok: false, reason: 'upstream_error' };
+  await writeCache('PERENUAL#CACHE', sk, fresh, jitteredTtlSeconds(SPECIES_TTL_DAYS * 86400));
+  return { ok: true, pests: fresh };
 }
 
 export const __testing = { checkAndIncrementBudget, readCache, writeCache };

--- a/backend/src/services/perenual.ts
+++ b/backend/src/services/perenual.ts
@@ -38,7 +38,10 @@ export interface PerenualSpeciesDetail extends PerenualSpeciesSummary {
   hardinessZone: string | null;
   indoor: boolean;
   edible: boolean;
-  poisonousToPets: boolean;
+  // `null` means Perenual has no data for this species — distinct from a
+  // confirmed `false`. Collapsing "unknown" into "not toxic" would make the
+  // app assert plants are pet-safe when it actually never checked.
+  poisonousToPets: boolean | null;
   defaultImageUrl: string | null;
 }
 
@@ -189,7 +192,10 @@ function summarize(item: RawSpeciesListItem): PerenualSpeciesSummary {
     : item.scientific_name;
   return {
     id: item.id,
-    commonName: item.common_name,
+    // Thin-data species can have a null common_name despite the raw type
+    // asserting `string` (untrusted upstream JSON — see fetchJson). Fall back
+    // to the scientific name so callers never see/crash on a null.
+    commonName: item.common_name ?? scientific ?? '',
     scientificName: scientific ?? '',
     thumbnailUrl: item.default_image?.thumbnail ?? null,
   };
@@ -197,8 +203,17 @@ function summarize(item: RawSpeciesListItem): PerenualSpeciesSummary {
 
 function watering(raw: string | null): PerenualSpeciesDetail['watering'] {
   if (!raw) return null;
-  const v = raw.toLowerCase();
+  const v = raw.trim().toLowerCase();
   if (v === 'frequent' || v === 'average' || v === 'minimum' || v === 'none') return v;
+  return null;
+}
+
+// Distinguishes "confirmed toxic" / "confirmed not toxic" from "Perenual has
+// no data" (null/undefined/any shape we don't recognize) — see the doc
+// comment on `PerenualSpeciesDetail.poisonousToPets`.
+function poisonousToPets(raw: boolean | number | null | undefined): boolean | null {
+  if (raw === true || raw === 1) return true;
+  if (raw === false || raw === 0) return false;
   return null;
 }
 
@@ -226,7 +241,7 @@ export async function getSpecies(id: number): Promise<PerenualSpeciesDetail | nu
         : null,
     indoor: raw.indoor === true,
     edible: raw.edible_fruit === true,
-    poisonousToPets: raw.poisonous_to_pets === true || raw.poisonous_to_pets === 1,
+    poisonousToPets: poisonousToPets(raw.poisonous_to_pets),
     defaultImageUrl: raw.default_image?.original_url ?? null,
   };
 }
@@ -235,8 +250,20 @@ export async function getCareGuide(speciesId: number): Promise<PerenualCareGuide
   const raw = await fetchJson<RawCareGuide>('/species-care-guide-list', {
     species_id: String(speciesId),
   });
-  const guide = raw?.data?.[0];
-  if (!guide) return null;
+  // `null` here means the request itself failed (network/non-2xx/timeout) —
+  // not cacheable, the caller should retry. Distinct from the request
+  // succeeding with genuinely no guide for this species (below), which IS a
+  // real, cacheable answer — same distinction `searchSpecies` already makes
+  // for an empty result set. Conflating the two meant a species with no
+  // guide was never cached and re-spent budget on every single request.
+  if (!raw) return null;
+  const guide = raw.data?.[0];
+  if (!guide) return { speciesId, sections: [] };
+  // `section` is typed as a required array, but that's a compile-time
+  // assertion, not a runtime guarantee (see fetchJson) — a thin-data guide
+  // entry can genuinely omit it. The module promises "never throws"; honor
+  // that here instead of letting a malformed response 500 the endpoint.
+  if (!Array.isArray(guide.section)) return { speciesId: guide.species_id, sections: [] };
   const sections: PerenualCareGuideSection[] = guide.section
     .filter((s) => s.type === 'watering' || s.type === 'sunlight' || s.type === 'pruning')
     .map((s) => ({ type: s.type as PerenualCareGuideSection['type'], description: s.description }));

--- a/backend/src/services/pestAlerts.ts
+++ b/backend/src/services/pestAlerts.ts
@@ -16,6 +16,7 @@
  */
 import { GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb';
 import { dynamodb, TABLE_NAME } from '../utils/dynamodb.js';
+import { logger } from '../utils/logger.js';
 import { getPlants } from './plantService.js';
 import { listPestsForSpeciesCached } from './enrichment.js';
 import type { PerenualPestSummary } from './perenual.js';
@@ -53,22 +54,29 @@ function capitalize(m: string): string {
   return m[0].toUpperCase() + m.slice(1);
 }
 
-// Case-SENSITIVE, word-boundary match on capitalized month names. The old
-// lowercase `includes()` check treated the verb "may" ("aphids may appear")
-// as the month May — virtually every pest description contains "may", so
-// every pest looked May-only. Heuristic trade-off, documented: a lowercased
-// month mid-sentence is missed (falls through to "no month mentioned →
-// always relevant" more often), and a sentence-initial "May ..." verb still
-// false-positives; both are far rarer than the old failure mode.
-const ANY_MONTH_RE = new RegExp(`\\b(${MONTHS.map(capitalize).join('|')})\\b`);
+// Word-boundary match on month names. Every month except May is matched
+// case-INSENSITIVELY, so "JUNE"/"june"/"June" all count. "May" is kept its
+// own, case-SENSITIVE regex on purpose: the old lowercase `includes()` check
+// treated the verb "may" ("aphids may appear") as the month May — virtually
+// every pest description contains "may", so every pest looked May-only.
+// Requiring a capital M avoids that specific false positive; a case-
+// insensitive flag on this alternative alone would silently reintroduce it.
+const MAY_RE = /\bMay\b/;
+const OTHER_MONTHS_RE = new RegExp(
+  `\\b(${MONTHS.filter((m) => m !== 'may')
+    .map(capitalize)
+    .join('|')})\\b`,
+  'i'
+);
 
 export function pestActiveThisMonth(pest: PerenualPestSummary, monthName: string): boolean {
   const text = pest.description ?? '';
   // If no description mentions any month at all, treat the pest as
   // "always relevant" — better to notify than to silently skip species
   // with thin upstream data.
-  if (!ANY_MONTH_RE.test(text)) return true;
-  return new RegExp(`\\b${capitalize(monthName)}\\b`).test(text);
+  if (!MAY_RE.test(text) && !OTHER_MONTHS_RE.test(text)) return true;
+  if (monthName === 'may') return MAY_RE.test(text);
+  return new RegExp(`\\b${capitalize(monthName)}\\b`, 'i').test(text);
 }
 
 async function lastAlertedAt(plantId: string, pestId: number): Promise<string | null> {
@@ -110,18 +118,44 @@ function withinQuarter(iso: string | null, now = Date.now()): boolean {
   return now - new Date(iso).getTime() < ms;
 }
 
+export interface PestAlertsResult {
+  alerts: PestAlert[];
+  /**
+   * True when at least one eligible plant's pest data couldn't be fetched
+   * for a reason that might resolve later THIS day (budget exhausted or a
+   * transient upstream error) — NOT when Perenual is simply unconfigured,
+   * which is permanent and not worth flagging for retry. The caller
+   * (`reminders.ts`) uses this to decide whether it's safe to mark the
+   * household "checked" for today, so a transient outage doesn't silently
+   * suppress alerts until tomorrow.
+   */
+  dataUnavailable: boolean;
+}
+
 export async function evaluatePestAlerts(
   householdId: string,
   now = new Date()
-): Promise<PestAlert[]> {
+): Promise<PestAlertsResult> {
   const plants = await getPlants(householdId);
   const month = currentMonthName(now);
   const alerts: PestAlert[] = [];
+  let dataUnavailable = false;
 
   for (const plant of plants) {
     if (!plant.perenualSpeciesId || !plant.species) continue;
-    const pests = await listPestsForSpeciesCached(plant.species);
-    if (!pests || pests.length === 0) continue;
+    const lookup = await listPestsForSpeciesCached(plant.species);
+    if (!lookup.ok) {
+      if (lookup.reason !== 'unconfigured') {
+        dataUnavailable = true;
+        logger.warn(
+          { householdId, plantId: plant.id, reason: lookup.reason },
+          'pestAlerts.pest_data_unavailable'
+        );
+      }
+      continue;
+    }
+    const pests = lookup.pests;
+    if (pests.length === 0) continue;
 
     // Pick the first seasonally-active pest we haven't alerted on
     // recently. One alert per plant per cycle keeps the volume sane.
@@ -143,5 +177,5 @@ export async function evaluatePestAlerts(
     }
   }
 
-  return alerts;
+  return { alerts, dataUnavailable };
 }

--- a/backend/src/services/reminders.ts
+++ b/backend/src/services/reminders.ts
@@ -23,7 +23,7 @@
  * query per member, which both multiplied reads and silently dropped
  * unassigned tasks (they're in nobody's GSI2 partition).
  */
-import { GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb';
+import { GetCommand, PutCommand, DeleteCommand } from '@aws-sdk/lib-dynamodb';
 import { dynamodb, TABLE_NAME } from '../utils/dynamodb.js';
 import { logger } from '../utils/logger.js';
 import type { Task } from '../models/types.js';
@@ -234,6 +234,14 @@ export async function remindHousehold(
  * The 90-day per-plant/pest suppression marker is written only AFTER at least
  * one successful delivery, so a failed send doesn't mute the alert for a
  * quarter.
+ *
+ * The per-day marker itself is written BEFORE evaluation (needed as a
+ * test-and-set guard so two hourly runs for the same household don't
+ * double-process), but if evaluation reports Perenual was unreachable for
+ * any plant this hour, the marker is deleted again afterward — otherwise a
+ * transient outage or an exhausted daily budget would look exactly like
+ * "checked, nothing to report" and silently lose the whole day's pest
+ * alerts with no way to retry until tomorrow.
  */
 async function runPestAlerts(householdId: string, now: Date): Promise<void> {
   try {
@@ -257,33 +265,53 @@ async function runPestAlerts(householdId: string, now: Date): Promise<void> {
     throw err;
   }
 
-  const members = await householdService.getHouseholdMembers(householdId);
-  const optedIn = [];
-  for (const member of members) {
-    const prefs = await notificationPrefs.getPreferences(member.userId);
-    if (prefs.pestAlerts) optedIn.push(member);
-  }
-  if (optedIn.length === 0) return;
+  let dataUnavailable = false;
+  try {
+    const members = await householdService.getHouseholdMembers(householdId);
+    const optedIn = [];
+    for (const member of members) {
+      const prefs = await notificationPrefs.getPreferences(member.userId);
+      if (prefs.pestAlerts) optedIn.push(member);
+    }
+    if (optedIn.length === 0) return;
 
-  const alerts = await pestAlerts.evaluatePestAlerts(householdId, now);
-  for (const alert of alerts) {
-    let delivered = false;
-    for (const member of optedIn) {
-      try {
-        await notifier.sendToUser(
-          { userId: member.userId, email: member.email },
-          { title: 'Pest season heads-up', body: alert.message, tag: 'pest-alert' }
-        );
-        delivered = true;
-      } catch (err) {
-        logger.warn(
-          { err: (err as Error).message, householdId, userId: member.userId },
-          'reminders.pest_alert_send_failed'
-        );
+    const result = await pestAlerts.evaluatePestAlerts(householdId, now);
+    dataUnavailable = result.dataUnavailable;
+    for (const alert of result.alerts) {
+      let delivered = false;
+      for (const member of optedIn) {
+        try {
+          await notifier.sendToUser(
+            { userId: member.userId, email: member.email },
+            { title: 'Pest season heads-up', body: alert.message, tag: 'pest-alert' }
+          );
+          delivered = true;
+        } catch (err) {
+          logger.warn(
+            { err: (err as Error).message, householdId, userId: member.userId },
+            'reminders.pest_alert_send_failed'
+          );
+        }
+      }
+      if (delivered) {
+        await pestAlerts.markAlerted(alert.plantId, alert.pestId);
       }
     }
-    if (delivered) {
-      await pestAlerts.markAlerted(alert.plantId, alert.pestId);
+  } finally {
+    if (dataUnavailable) {
+      await dynamodb
+        .send(
+          new DeleteCommand({
+            TableName: TABLE_NAME,
+            Key: { PK: `HOUSEHOLD#${householdId}`, SK: `PEST_CHECK#${dateKey(now)}` },
+          })
+        )
+        .catch((err) => {
+          logger.warn(
+            { err: (err as Error).message, householdId },
+            'reminders.pest_check_marker_cleanup_failed'
+          );
+        });
     }
   }
 }

--- a/backend/tests/unit/handlers/species.test.ts
+++ b/backend/tests/unit/handlers/species.test.ts
@@ -232,6 +232,144 @@ describe('species handler', () => {
     });
   });
 
+  describe('search', () => {
+    it('reports source "disabled" only when Perenual is unconfigured', async () => {
+      const perenual = await import('../../../src/services/perenual.js');
+      vi.mocked(perenual.isConfigured).mockResolvedValueOnce(false);
+      const enrichment = await import('../../../src/services/enrichment.js');
+      // Matches enrichment.searchSpeciesCached's own behavior when
+      // unconfigured (it short-circuits to null before ever touching the
+      // budget/cache) — an auto-mocked `undefined` would take the wrong
+      // branch below (`undefined !== null` is true).
+      vi.mocked(enrichment.searchSpeciesCached).mockResolvedValueOnce(null);
+      const { search } = await import('../../../src/handlers/species/handler.js');
+
+      const res = (await search(
+        buildEvent({ path: '/species/search', queryStringParameters: { q: 'monstera' } }),
+        ctx,
+        () => {}
+      )) as APIGatewayProxyResult;
+      expect(JSON.parse(res.body).source).toBe('disabled');
+    });
+
+    it('reports source "unavailable" (not "disabled") when configured but the request got no data', async () => {
+      const enrichment = await import('../../../src/services/enrichment.js');
+      vi.mocked(enrichment.searchSpeciesCached).mockResolvedValueOnce(null);
+      const { search } = await import('../../../src/handlers/species/handler.js');
+
+      const res = (await search(
+        buildEvent({ path: '/species/search', queryStringParameters: { q: 'monstera' } }),
+        ctx,
+        () => {}
+      )) as APIGatewayProxyResult;
+      // A real outage or exhausted daily budget must not look identical to
+      // the integration being intentionally turned off.
+      expect(JSON.parse(res.body).source).toBe('unavailable');
+    });
+
+    it('reports source "perenual" and the results when the search succeeds', async () => {
+      const enrichment = await import('../../../src/services/enrichment.js');
+      vi.mocked(enrichment.searchSpeciesCached).mockResolvedValueOnce([
+        { id: 1, commonName: 'Monstera', scientificName: 'Monstera deliciosa', thumbnailUrl: null },
+      ]);
+      const { search } = await import('../../../src/handlers/species/handler.js');
+
+      const res = (await search(
+        buildEvent({ path: '/species/search', queryStringParameters: { q: 'monstera' } }),
+        ctx,
+        () => {}
+      )) as APIGatewayProxyResult;
+      const body = JSON.parse(res.body);
+      expect(body.source).toBe('perenual');
+      expect(body.results).toHaveLength(1);
+    });
+
+    it('caps an oversized query instead of forwarding it verbatim', async () => {
+      const enrichment = await import('../../../src/services/enrichment.js');
+      vi.mocked(enrichment.searchSpeciesCached).mockResolvedValueOnce([]);
+      const { search } = await import('../../../src/handlers/species/handler.js');
+
+      const huge = 'a'.repeat(5000);
+      await search(
+        buildEvent({ path: '/species/search', queryStringParameters: { q: huge } }),
+        ctx,
+        () => {}
+      );
+      expect(vi.mocked(enrichment.searchSpeciesCached)).toHaveBeenCalledWith('a'.repeat(80));
+    });
+  });
+
+  describe('invalid species id (must be rejected, not silently truncated or treated as "no data")', () => {
+    it.each(['7abc', '7e2', '-1', '0', 'NaN', ''])(
+      'detail rejects id=%s with 400, without calling the enrichment cache',
+      async (badId) => {
+        const enrichment = await import('../../../src/services/enrichment.js');
+        const { detail } = await import('../../../src/handlers/species/handler.js');
+
+        const res = (await detail(
+          buildEvent({ path: `/species/${badId}`, pathParameters: { id: badId } }),
+          ctx,
+          () => {}
+        )) as APIGatewayProxyResult;
+        expect(res.statusCode).toBe(400);
+        expect(enrichment.getSpeciesCached).not.toHaveBeenCalled();
+      }
+    );
+
+    it('guide rejects a garbage-suffixed id ("7abc") with 400 rather than silently serving species 7', async () => {
+      const enrichment = await import('../../../src/services/enrichment.js');
+      const { guide } = await import('../../../src/handlers/species/handler.js');
+
+      const res = (await guide(
+        buildEvent({ path: '/species/7abc/guide', pathParameters: { id: '7abc' } }),
+        ctx,
+        () => {}
+      )) as APIGatewayProxyResult;
+      expect(res.statusCode).toBe(400);
+      expect(enrichment.getSpeciesCached).not.toHaveBeenCalled();
+    });
+
+    it('careSuggestions rejects a garbage-suffixed id ("7abc") with 400', async () => {
+      const enrichment = await import('../../../src/services/enrichment.js');
+      const { careSuggestions } = await import('../../../src/handlers/species/handler.js');
+
+      const res = (await careSuggestions(
+        buildEvent({ path: '/species/7abc/care-suggestions', pathParameters: { id: '7abc' } }),
+        ctx,
+        () => {}
+      )) as APIGatewayProxyResult;
+      expect(res.statusCode).toBe(400);
+      expect(enrichment.getSpeciesCached).not.toHaveBeenCalled();
+    });
+
+    it('thumbnail still 404s (not 400) on a garbage-suffixed id — it is a public, unauthenticated redirect route', async () => {
+      const enrichment = await import('../../../src/services/enrichment.js');
+      const { thumbnail } = await import('../../../src/handlers/species/handler.js');
+
+      const res = (await thumbnail(
+        buildAnonymousEvent({ pathParameters: { id: '7abc' } }),
+        ctx,
+        () => {}
+      )) as APIGatewayProxyResult;
+      expect(res.statusCode).toBe(404);
+      expect(enrichment.getSpeciesCached).not.toHaveBeenCalled();
+    });
+
+    it('detail still returns 200 {result: null} for a valid but unknown/no-data id (distinct from a malformed one)', async () => {
+      const enrichment = await import('../../../src/services/enrichment.js');
+      vi.mocked(enrichment.getSpeciesCached).mockResolvedValueOnce(null);
+      const { detail } = await import('../../../src/handlers/species/handler.js');
+
+      const res = (await detail(
+        buildEvent({ path: '/species/999999', pathParameters: { id: '999999' } }),
+        ctx,
+        () => {}
+      )) as APIGatewayProxyResult;
+      expect(res.statusCode).toBe(200);
+      expect(JSON.parse(res.body).result).toBeNull();
+    });
+  });
+
   describe('toxicity (public pet-safety lookup)', () => {
     it('answers an anonymous query with cat/dog verdicts and a public cache header', async () => {
       const { toxicity } = await import('../../../src/handlers/species/handler.js');

--- a/backend/tests/unit/middleware/rateLimit.test.ts
+++ b/backend/tests/unit/middleware/rateLimit.test.ts
@@ -101,6 +101,17 @@ describe('rateLimit (per-IP)', () => {
     expect(res.statusCode).toBe(200);
   });
 
+  it('keys on the resolved route template, not the literal path, so varying an {id} cannot bypass the cap', async () => {
+    const { invoke } = makeHandler(rateLimit({ perWindowMs: 60_000, max: 1 }));
+    const eventForId = (id: string) => ({
+      ...v2Event({ ip: '7.7.7.8', path: `/species/${id}/thumbnail` }),
+      routeKey: 'GET /species/{id}/thumbnail',
+    });
+    await invoke(eventForId('1'));
+    // A different numeric id on the SAME route must share the bucket.
+    await expect(invoke(eventForId('2'))).rejects.toMatchObject({ statusCode: 429 });
+  });
+
   it('resets the bucket after the window elapses', async () => {
     vi.useFakeTimers();
     const { invoke } = makeHandler(rateLimit({ perWindowMs: 60_000, max: 1 }));
@@ -180,5 +191,18 @@ describe('userRateLimit', () => {
       expect(res.statusCode).toBe(200);
     }
     expect(__rateLimitBucketCountsForTests().user).toBe(0);
+  });
+
+  it('keys on the resolved route template, not the literal path, so varying an {id} cannot bypass the cap', async () => {
+    const { invoke } = makeHandler(userRateLimit({ perWindowMs: 60_000, max: 1 }));
+    const eventForId = (id: string) => ({
+      ...v2Event({ ip: '1.1.1.1', path: `/species/${id}/guide`, user: { userId: 'user-1' } }),
+      routeKey: 'GET /species/{id}/guide',
+    });
+    await invoke(eventForId('1'));
+    // Same user, same route template, different numeric id — must NOT get a
+    // fresh bucket (that would let one user read every species' guide by
+    // simply incrementing the id, defeating the documented 10/min cap).
+    await expect(invoke(eventForId('2'))).rejects.toMatchObject({ statusCode: 429 });
   });
 });

--- a/backend/tests/unit/services/enrichment.test.ts
+++ b/backend/tests/unit/services/enrichment.test.ts
@@ -83,7 +83,10 @@ describe('enrichment (Perenual cache + budget breaker)', () => {
     expect(await searchSpeciesCached('monstera')).toBeNull();
     expect(await getSpeciesCached(7)).toBeNull();
     expect(await getCareGuideCached(7)).toBeNull();
-    expect(await listPestsForSpeciesCached('Monstera deliciosa')).toBeNull();
+    expect(await listPestsForSpeciesCached('Monstera deliciosa')).toEqual({
+      ok: false,
+      reason: 'unconfigured',
+    });
     expect(dynamodb.send).not.toHaveBeenCalled();
   });
 
@@ -204,12 +207,49 @@ describe('enrichment (Perenual cache + budget breaker)', () => {
     });
   });
 
-  it('pest lookups key the cache on the lowercased scientific name', async () => {
+  it('pest lookups key the cache on the trimmed, lowercased scientific name', async () => {
     stubDynamo({ cacheItem: { payload: [] } });
-    expect(await listPestsForSpeciesCached('Monstera Deliciosa')).toEqual([]);
+    expect(await listPestsForSpeciesCached('  Monstera Deliciosa  ')).toEqual({
+      ok: true,
+      pests: [],
+    });
     expect(sentCommands()[0].input.Key).toEqual({
       PK: 'PERENUAL#CACHE',
       SK: 'PESTS#monstera deliciosa',
+    });
+  });
+
+  describe('listPestsForSpeciesCached (distinguishes "no data" from "confirmed no pests")', () => {
+    it('reports budget_exhausted distinctly from a genuinely empty pest list', async () => {
+      process.env.PERENUAL_DAILY_BUDGET = '10';
+      stubDynamo({ cacheItem: null, budgetUsed: 11 });
+
+      expect(await listPestsForSpeciesCached('Monstera deliciosa')).toEqual({
+        ok: false,
+        reason: 'budget_exhausted',
+      });
+    });
+
+    it('reports upstream_error when the Perenual call itself fails', async () => {
+      stubDynamo({ cacheItem: null, budgetUsed: 1 });
+      vi.mocked(perenual.listPestsForSpecies).mockResolvedValue(null as never);
+
+      expect(await listPestsForSpeciesCached('Monstera deliciosa')).toEqual({
+        ok: false,
+        reason: 'upstream_error',
+      });
+    });
+
+    it('caches and returns a genuinely empty pest list as ok:true', async () => {
+      stubDynamo({ cacheItem: null, budgetUsed: 1 });
+      vi.mocked(perenual.listPestsForSpecies).mockResolvedValue([] as never);
+
+      expect(await listPestsForSpeciesCached('Monstera deliciosa')).toEqual({
+        ok: true,
+        pests: [],
+      });
+      const kinds = sentCommands().map((c) => c.kind);
+      expect(kinds).toEqual(['Get', 'Update', 'Put']); // the empty result IS cached
     });
   });
 });

--- a/backend/tests/unit/services/perenual.test.ts
+++ b/backend/tests/unit/services/perenual.test.ts
@@ -166,4 +166,104 @@ describe('perenual client', () => {
       defaultImageUrl: 'https://img/full.jpg',
     });
   });
+
+  it('trims whitespace before matching the watering enum', async () => {
+    process.env = { ...ORIGINAL, PERENUAL_API_KEY: 'k' };
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        id: 1,
+        common_name: 'Test',
+        scientific_name: 'Testus testus',
+        watering: '  Average  ',
+        poisonous_to_pets: null,
+      }),
+    });
+    const perenual = await import('../../../src/services/perenual.js');
+    const detail = await perenual.getSpecies(1);
+    expect(detail?.watering).toBe('average');
+  });
+
+  it('distinguishes confirmed non-toxic (false/0) from unknown (null/undefined) pet toxicity', async () => {
+    process.env = { ...ORIGINAL, PERENUAL_API_KEY: 'k' };
+    const perenual = await import('../../../src/services/perenual.js');
+
+    const responseWith = (poisonous_to_pets: unknown) => ({
+      ok: true,
+      json: async () => ({
+        id: 1,
+        common_name: 'Test',
+        scientific_name: 'Testus testus',
+        poisonous_to_pets,
+      }),
+    });
+
+    fetchMock.mockResolvedValueOnce(responseWith(false));
+    expect((await perenual.getSpecies(1))?.poisonousToPets).toBe(false);
+
+    fetchMock.mockResolvedValueOnce(responseWith(0));
+    expect((await perenual.getSpecies(1))?.poisonousToPets).toBe(false);
+
+    fetchMock.mockResolvedValueOnce(responseWith(1));
+    expect((await perenual.getSpecies(1))?.poisonousToPets).toBe(true);
+
+    // The Cinnamomum-cassia-shaped case: Perenual simply has no data. Must
+    // NOT collapse to `false` ("confirmed non-toxic") — that would be a
+    // guess dressed up as a fact, exactly like the already-fixed watering bug.
+    fetchMock.mockResolvedValueOnce(responseWith(null));
+    expect((await perenual.getSpecies(1))?.poisonousToPets).toBeNull();
+
+    fetchMock.mockResolvedValueOnce(responseWith(undefined));
+    expect((await perenual.getSpecies(1))?.poisonousToPets).toBeNull();
+  });
+
+  it('falls back to the scientific name when Perenual omits common_name', async () => {
+    process.env = { ...ORIGINAL, PERENUAL_API_KEY: 'k' };
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: [
+          {
+            id: 3,
+            common_name: null,
+            scientific_name: ['Cinnamomum cassia'],
+          },
+        ],
+      }),
+    });
+    const perenual = await import('../../../src/services/perenual.js');
+    const out = await perenual.searchSpecies('cassia');
+    // Must be a usable string, never null — a null commonName crashes any
+    // caller that calls .toLowerCase() on it (e.g. the species combobox).
+    expect(out?.[0].commonName).toBe('Cinnamomum cassia');
+  });
+
+  it('returns an empty care guide instead of throwing when Perenual omits section data', async () => {
+    process.env = { ...ORIGINAL, PERENUAL_API_KEY: 'k' };
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: [{ id: 1, species_id: 5 }], // no `section` field at all
+      }),
+    });
+    const perenual = await import('../../../src/services/perenual.js');
+    // The module's own contract is "never throws" — a malformed upstream
+    // response must degrade to an empty guide, not a 500.
+    await expect(perenual.getCareGuide(5)).resolves.toEqual({ speciesId: 5, sections: [] });
+  });
+
+  it('distinguishes a genuinely empty care guide (cacheable) from a failed request (not cacheable)', async () => {
+    process.env = { ...ORIGINAL, PERENUAL_API_KEY: 'k' };
+    const perenual = await import('../../../src/services/perenual.js');
+
+    // Perenual answered successfully, but has no guide at all for this
+    // species — a real, cacheable answer (mirrors searchSpecies's `[]`).
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ data: [] }) });
+    await expect(perenual.getCareGuide(5)).resolves.toEqual({ speciesId: 5, sections: [] });
+
+    // The request itself failed — must stay null so the caller doesn't
+    // cache a transient failure as if it were a confirmed empty guide.
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 500, json: async () => ({}) });
+    await expect(perenual.getCareGuide(5)).resolves.toBeNull();
+  });
 });

--- a/backend/tests/unit/services/pestAlerts.test.ts
+++ b/backend/tests/unit/services/pestAlerts.test.ts
@@ -109,13 +109,17 @@ describe('evaluatePestAlerts', () => {
     const { evaluatePestAlerts } = await import('../../../src/services/pestAlerts.js');
 
     vi.mocked(plants.getPlants).mockResolvedValue([plant] as never);
-    vi.mocked(enrichment.listPestsForSpeciesCached).mockResolvedValue([pest(null)] as never);
+    vi.mocked(enrichment.listPestsForSpeciesCached).mockResolvedValue({
+      ok: true,
+      pests: [pest(null)],
+    } as never);
     // lastAlertedAt read → no previous alert.
     vi.mocked(dynamodb.send).mockResolvedValue({ Item: undefined } as never);
 
-    const alerts = await evaluatePestAlerts('hh', new Date('2026-06-01T00:00:00Z'));
-    expect(alerts).toHaveLength(1);
-    expect(alerts[0]).toMatchObject({ plantId: 'p1', pestId: 42, pestName: 'Spider mites' });
+    const result = await evaluatePestAlerts('hh', new Date('2026-06-01T00:00:00Z'));
+    expect(result.alerts).toHaveLength(1);
+    expect(result.alerts[0]).toMatchObject({ plantId: 'p1', pestId: 42, pestName: 'Spider mites' });
+    expect(result.dataUnavailable).toBe(false);
 
     // Only Get commands — the 90-day marker write moved to the caller
     // (after successful delivery) via markAlerted().
@@ -132,11 +136,48 @@ describe('evaluatePestAlerts', () => {
     const now = new Date('2026-06-01T00:00:00Z');
     const tenDaysAgo = new Date(now.getTime() - 10 * 24 * 60 * 60 * 1000).toISOString();
     vi.mocked(plants.getPlants).mockResolvedValue([plant] as never);
-    vi.mocked(enrichment.listPestsForSpeciesCached).mockResolvedValue([pest(null)] as never);
+    vi.mocked(enrichment.listPestsForSpeciesCached).mockResolvedValue({
+      ok: true,
+      pests: [pest(null)],
+    } as never);
     vi.mocked(dynamodb.send).mockResolvedValue({ Item: { alertedAt: tenDaysAgo } } as never);
 
-    const alerts = await evaluatePestAlerts('hh', now);
-    expect(alerts).toHaveLength(0);
+    const result = await evaluatePestAlerts('hh', now);
+    expect(result.alerts).toHaveLength(0);
+  });
+
+  it('does NOT treat "no pest data available" the same as "confirmed no pests" (the Cinnamomum-cassia-shaped bug)', async () => {
+    const plants = await import('../../../src/services/plantService.js');
+    const enrichment = await import('../../../src/services/enrichment.js');
+    const { evaluatePestAlerts } = await import('../../../src/services/pestAlerts.js');
+
+    vi.mocked(plants.getPlants).mockResolvedValue([plant] as never);
+    // Perenual's daily budget is exhausted — this is NOT the same as "we
+    // checked and there are no pests," and must be flagged so the caller
+    // knows not to treat today as fully evaluated.
+    vi.mocked(enrichment.listPestsForSpeciesCached).mockResolvedValue({
+      ok: false,
+      reason: 'budget_exhausted',
+    } as never);
+
+    const result = await evaluatePestAlerts('hh', new Date('2026-06-01T00:00:00Z'));
+    expect(result.alerts).toHaveLength(0);
+    expect(result.dataUnavailable).toBe(true);
+  });
+
+  it('does NOT flag dataUnavailable when Perenual is simply unconfigured (permanent, not worth a same-day retry)', async () => {
+    const plants = await import('../../../src/services/plantService.js');
+    const enrichment = await import('../../../src/services/enrichment.js');
+    const { evaluatePestAlerts } = await import('../../../src/services/pestAlerts.js');
+
+    vi.mocked(plants.getPlants).mockResolvedValue([plant] as never);
+    vi.mocked(enrichment.listPestsForSpeciesCached).mockResolvedValue({
+      ok: false,
+      reason: 'unconfigured',
+    } as never);
+
+    const result = await evaluatePestAlerts('hh', new Date('2026-06-01T00:00:00Z'));
+    expect(result.dataUnavailable).toBe(false);
   });
 
   it('markAlerted writes a TTL-swept marker row', async () => {

--- a/backend/tests/unit/services/reminders.test.ts
+++ b/backend/tests/unit/services/reminders.test.ts
@@ -7,6 +7,9 @@ vi.mock('@aws-sdk/lib-dynamodb', () => ({
   GetCommand: vi.fn(function (input) {
     return { input, kind: 'Get' };
   }),
+  DeleteCommand: vi.fn(function (input) {
+    return { input, kind: 'Delete' };
+  }),
 }));
 vi.mock('../../../src/utils/dynamodb.js', () => ({
   dynamodb: { send: vi.fn() },
@@ -79,7 +82,7 @@ async function mockConditionalMarkerStore() {
   const markers = new Set<string>();
   vi.mocked(dynamodb.send).mockImplementation(async (cmd: unknown) => {
     const { input, kind } = cmd as {
-      kind?: 'Put' | 'Get';
+      kind?: 'Put' | 'Get' | 'Delete';
       input: { Item?: { PK: string; SK: string }; Key?: { PK: string; SK: string } };
     };
     // GetCommand → marker pre-check (alreadyRemindedToday). Return the marker
@@ -87,6 +90,13 @@ async function mockConditionalMarkerStore() {
     if (kind === 'Get' && input.Key) {
       const key = `${input.Key.PK}|${input.Key.SK}`;
       return (markers.has(key) ? { Item: { PK: input.Key.PK, SK: input.Key.SK } } : {}) as never;
+    }
+    // DeleteCommand → the pest-check marker cleanup when data was
+    // unavailable, so a later hourly run can retry.
+    if (kind === 'Delete' && input.Key) {
+      const key = `${input.Key.PK}|${input.Key.SK}`;
+      markers.delete(key);
+      return {} as never;
     }
     // PutCommand → conditional claim. Second claim on the same key throws
     // ConditionalCheckFailed, exactly the dedupe behavior across hourly runs.
@@ -395,15 +405,18 @@ describe('reminders service', () => {
       vi.mocked(prefs.getPreferences).mockImplementation(async (userId: string) => {
         return { pestAlerts: userId === 'u1' } as never;
       });
-      vi.mocked(pestAlerts.evaluatePestAlerts).mockResolvedValue([
-        {
-          plantId: 'p1',
-          plantName: 'Monstera',
-          pestId: 42,
-          pestName: 'Spider mites',
-          message: 'Your Monstera may be entering Spider mites season — give it a quick check.',
-        },
-      ]);
+      vi.mocked(pestAlerts.evaluatePestAlerts).mockResolvedValue({
+        alerts: [
+          {
+            plantId: 'p1',
+            plantName: 'Monstera',
+            pestId: 42,
+            pestName: 'Spider mites',
+            message: 'Your Monstera may be entering Spider mites season — give it a quick check.',
+          },
+        ],
+        dataUnavailable: false,
+      });
       vi.mocked(notifier.sendToUser).mockResolvedValue(undefined as never);
 
       await remindHousehold('hh', NOW);
@@ -430,9 +443,12 @@ describe('reminders service', () => {
       vi.mocked(tasks.getTasksDueBy).mockResolvedValue([] as never);
       vi.mocked(household.getHouseholdMembers).mockResolvedValue([memberA] as never);
       vi.mocked(prefs.getPreferences).mockResolvedValue({ pestAlerts: true } as never);
-      vi.mocked(pestAlerts.evaluatePestAlerts).mockResolvedValue([
-        { plantId: 'p1', plantName: 'M', pestId: 42, pestName: 'Mites', message: 'check' },
-      ]);
+      vi.mocked(pestAlerts.evaluatePestAlerts).mockResolvedValue({
+        alerts: [
+          { plantId: 'p1', plantName: 'M', pestId: 42, pestName: 'Mites', message: 'check' },
+        ],
+        dataUnavailable: false,
+      });
       vi.mocked(notifier.sendToUser).mockRejectedValue(new Error('SES down'));
 
       await remindHousehold('hh', NOW);
@@ -450,7 +466,61 @@ describe('reminders service', () => {
       vi.mocked(tasks.getTasksDueBy).mockResolvedValue([] as never);
       vi.mocked(household.getHouseholdMembers).mockResolvedValue([memberA] as never);
       vi.mocked(prefs.getPreferences).mockResolvedValue({ pestAlerts: true } as never);
-      vi.mocked(pestAlerts.evaluatePestAlerts).mockResolvedValue([]);
+      vi.mocked(pestAlerts.evaluatePestAlerts).mockResolvedValue({
+        alerts: [],
+        dataUnavailable: false,
+      });
+
+      await remindHousehold('hh', NOW);
+      await remindHousehold('hh', new Date(NOW.getTime() + 60 * 60 * 1000));
+      expect(pestAlerts.evaluatePestAlerts).toHaveBeenCalledOnce();
+    });
+
+    it('retries later the same day when Perenual data was unavailable, instead of silently losing the day', async () => {
+      const household = await import('../../../src/services/householdService.js');
+      const tasks = await import('../../../src/services/taskService.js');
+      const prefs = await import('../../../src/services/notificationPrefs.js');
+      const pestAlerts = await import('../../../src/services/pestAlerts.js');
+      const { remindHousehold } = await import('../../../src/services/reminders.js');
+      await mockConditionalMarkerStore();
+
+      vi.mocked(tasks.getTasksDueBy).mockResolvedValue([] as never);
+      vi.mocked(household.getHouseholdMembers).mockResolvedValue([memberA] as never);
+      vi.mocked(prefs.getPreferences).mockResolvedValue({ pestAlerts: true } as never);
+      // First hour: Perenual's budget is exhausted for this plant.
+      vi.mocked(pestAlerts.evaluatePestAlerts).mockResolvedValueOnce({
+        alerts: [],
+        dataUnavailable: true,
+      });
+
+      await remindHousehold('hh', NOW);
+      expect(pestAlerts.evaluatePestAlerts).toHaveBeenCalledOnce();
+
+      // A later hour, same UTC day: must NOT be treated as "already checked"
+      // — the marker should have been cleared after the unavailable result.
+      vi.mocked(pestAlerts.evaluatePestAlerts).mockResolvedValueOnce({
+        alerts: [],
+        dataUnavailable: false,
+      });
+      await remindHousehold('hh', new Date(NOW.getTime() + 60 * 60 * 1000));
+      expect(pestAlerts.evaluatePestAlerts).toHaveBeenCalledTimes(2);
+    });
+
+    it('does NOT retry when everything was fully evaluated (no data-unavailable flag)', async () => {
+      const household = await import('../../../src/services/householdService.js');
+      const tasks = await import('../../../src/services/taskService.js');
+      const prefs = await import('../../../src/services/notificationPrefs.js');
+      const pestAlerts = await import('../../../src/services/pestAlerts.js');
+      const { remindHousehold } = await import('../../../src/services/reminders.js');
+      await mockConditionalMarkerStore();
+
+      vi.mocked(tasks.getTasksDueBy).mockResolvedValue([] as never);
+      vi.mocked(household.getHouseholdMembers).mockResolvedValue([memberA] as never);
+      vi.mocked(prefs.getPreferences).mockResolvedValue({ pestAlerts: true } as never);
+      vi.mocked(pestAlerts.evaluatePestAlerts).mockResolvedValue({
+        alerts: [],
+        dataUnavailable: false,
+      });
 
       await remindHousehold('hh', NOW);
       await remindHousehold('hh', new Date(NOW.getTime() + 60 * 60 * 1000));

--- a/frontend/src/components/SpeciesCombobox.tsx
+++ b/frontend/src/components/SpeciesCombobox.tsx
@@ -19,6 +19,18 @@ interface SpeciesComboboxProps {
   placeholder?: string;
 }
 
+/** Finds the Perenual result (if any) matching `val` by scientific or common
+ *  name, shared by the input's synchronous onChange check and the effect
+ *  that re-checks once debounced results land. */
+function matchPerenual(results: PerenualSpeciesSummary[] | undefined, val: string): number | null {
+  const hit = (results ?? []).find(
+    (r) =>
+      r.scientificName.toLowerCase() === val.toLowerCase() ||
+      r.commonName.toLowerCase() === val.toLowerCase()
+  );
+  return hit ? hit.id : null;
+}
+
 /**
  * Free-text species input backed by the native <datalist> element. Browsers
  * render their own dropdown UI and handle keyboard nav + a11y.
@@ -63,6 +75,22 @@ export function SpeciesCombobox({
     staleTime: 5 * 60 * 1000,
   });
 
+  // The debounced network results only reflect the exact keystroke that was
+  // typed when onChange fired — 300ms later, once Perenual actually answers,
+  // nothing re-checks it against what's currently typed. Re-run the same
+  // match here whenever fresh results arrive.
+  //
+  // Gate on `perenual` actually being loaded (not just changed): firing this
+  // while a query is merely in flight would report a false `null` for a
+  // value that already has a confirmed match (e.g. a plant's previously-
+  // linked species, shown on mount before the first search round-trip
+  // completes) — the onChange handler already covers the "unconfirmed yet"
+  // case for live edits.
+  useEffect(() => {
+    if (!onPerenualPick || perenual === undefined) return;
+    onPerenualPick(matchPerenual(perenual.results, value));
+  }, [perenual, value, onPerenualPick]);
+
   // Local catalog suggestions are instant; Perenual layers on top, deduped by
   // scientific name to avoid showing the same plant twice.
   //
@@ -74,10 +102,17 @@ export function SpeciesCombobox({
     if (trimmed.length === 0) return speciesCatalog;
 
     const local = searchSpecies(value, 12);
-    const remote: SpeciesEntry[] = (perenual?.results ?? []).map((r: PerenualSpeciesSummary) => ({
-      common: r.commonName,
-      scientific: r.scientificName,
-    }));
+    // `perenual` reflects debouncedQuery, which lags the live input by
+    // 300ms — while a request for the current text is in flight (or hasn't
+    // started), remote still holds the PREVIOUS query's results. Only mix
+    // them in once the query that produced them matches what's now typed.
+    const queryIsCurrent = debouncedQuery.trim().toLowerCase() === value.trim().toLowerCase();
+    const remote: SpeciesEntry[] = queryIsCurrent
+      ? (perenual?.results ?? []).map((r: PerenualSpeciesSummary) => ({
+          common: r.commonName,
+          scientific: r.scientificName,
+        }))
+      : [];
     const seen = new Set<string>();
     const out: SpeciesEntry[] = [];
     for (const entry of [...local, ...remote]) {
@@ -88,7 +123,7 @@ export function SpeciesCombobox({
       if (out.length >= 24) break;
     }
     return out;
-  }, [value, perenual]);
+  }, [value, perenual, debouncedQuery]);
 
   return (
     <div>
@@ -116,14 +151,11 @@ export function SpeciesCombobox({
             if (exact) onPick(exact);
           }
           if (onPerenualPick) {
-            const remoteHit = (perenual?.results ?? []).find(
-              (r) =>
-                r.scientificName.toLowerCase() === next.toLowerCase() ||
-                r.commonName.toLowerCase() === next.toLowerCase()
-            );
             // Pass the id when we recognize the value, otherwise null so a
             // user backspacing away from a known species clears the link.
-            onPerenualPick(remoteHit ? remoteHit.id : null);
+            // `perenual` here is almost always stale (debounced 300ms behind
+            // `next`) — the effect above re-checks once fresh results land.
+            onPerenualPick(matchPerenual(perenual?.results, next));
           }
         }}
         aria-invalid={!!error}

--- a/frontend/src/features/plants/AddPlantPage.tsx
+++ b/frontend/src/features/plants/AddPlantPage.tsx
@@ -87,6 +87,7 @@ export function AddPlantPage() {
     handleSubmit,
     setValue,
     watch,
+    getValues,
     formState: { errors },
   } = useForm<AddPlantFormData>({
     resolver: zodResolver(addPlantSchema),
@@ -157,7 +158,13 @@ export function AddPlantPage() {
       const exact = result.results.find(
         (r) => r.scientificName.toLowerCase() === s.scientificName.toLowerCase()
       );
-      setPerenualSpeciesId(exact?.id ?? null);
+      // Guard against out-of-order resolution: if the species field has
+      // moved on since this search started (a later "Use" click, or a
+      // manual edit), this result is stale — applying it would silently
+      // overwrite a newer pick with a mismatched id.
+      if (getValues('species') === s.scientificName) {
+        setPerenualSpeciesId(exact?.id ?? null);
+      }
     } catch {
       // Search failures shouldn't block the user from saving the plant.
     }

--- a/frontend/src/features/plants/CareGuideCard.tsx
+++ b/frontend/src/features/plants/CareGuideCard.tsx
@@ -42,7 +42,7 @@ export function CareGuideCard({ perenualSpeciesId }: CareGuideCardProps) {
         }
       />
 
-      {data.poisonousToPets && (
+      {data.poisonousToPets === true && (
         <div
           role="note"
           className="mb-4 flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900"

--- a/frontend/src/features/plants/EditPlantModal.tsx
+++ b/frontend/src/features/plants/EditPlantModal.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect } from 'react';
+import { Fragment, useEffect, useState } from 'react';
 import { Dialog, Transition } from '@headlessui/react';
 import { XMarkIcon } from '@heroicons/react/24/outline';
 import { useForm } from 'react-hook-form';
@@ -11,6 +11,7 @@ import { useActiveHouseholdId } from '@/hooks/useActiveHouseholdId';
 import { Button } from '@/components/Button';
 import { Input } from '@/components/Input';
 import { Alert } from '@/components/Alert';
+import { SpeciesCombobox } from '@/components/SpeciesCombobox';
 
 const plantSchema = z.object({
   name: z.string().min(1, 'Name is required').max(100),
@@ -35,6 +36,8 @@ export function EditPlantModal({ plant, isOpen, onClose }: EditPlantModalProps) 
     register,
     handleSubmit,
     reset,
+    watch,
+    setValue,
     formState: { errors },
   } = useForm<PlantFormData>({
     resolver: zodResolver(plantSchema),
@@ -46,6 +49,11 @@ export function EditPlantModal({ plant, isOpen, onClose }: EditPlantModalProps) 
     },
   });
 
+  const [perenualSpeciesId, setPerenualSpeciesId] = useState<number | null>(
+    plant.perenualSpeciesId ?? null
+  );
+  const speciesValue = watch('species') ?? '';
+
   useEffect(() => {
     if (isOpen) {
       reset({
@@ -54,6 +62,7 @@ export function EditPlantModal({ plant, isOpen, onClose }: EditPlantModalProps) 
         location: plant.location || '',
         notes: plant.notes || '',
       });
+      setPerenualSpeciesId(plant.perenualSpeciesId ?? null);
     }
   }, [isOpen, plant, reset]);
 
@@ -64,6 +73,10 @@ export function EditPlantModal({ plant, isOpen, onClose }: EditPlantModalProps) 
         species: data.species || undefined,
         location: data.location || undefined,
         notes: data.notes || undefined,
+        // Always explicit, including null — omitting it would leave the
+        // backend's existing link untouched and reintroduce stale care/
+        // toxicity data after the species text is edited away from it.
+        perenualSpeciesId,
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['plants', householdId] });
@@ -140,7 +153,12 @@ export function EditPlantModal({ plant, isOpen, onClose }: EditPlantModalProps) 
                     {...register('name')}
                   />
 
-                  <Input label="Species" error={errors.species?.message} {...register('species')} />
+                  <SpeciesCombobox
+                    value={speciesValue}
+                    onChange={(v) => setValue('species', v, { shouldValidate: true })}
+                    onPerenualPick={setPerenualSpeciesId}
+                    error={errors.species?.message}
+                  />
 
                   <Input
                     label="Location"

--- a/frontend/src/features/plants/PetToxicityNote.tsx
+++ b/frontend/src/features/plants/PetToxicityNote.tsx
@@ -8,24 +8,43 @@ interface PetToxicityNoteProps {
 
 /**
  * Inline heads-up shown on the AddPlant form once the user picks a Perenual-
- * backed species that's flagged toxic to pets. Sourced from the same species
- * detail the form already keys on (`perenualSpeciesId`) — no extra backend
- * surface, just the existing `/species/:id` lookup. If the detail fails or
- * the species isn't flagged toxic, we render nothing.
+ * backed species. Sourced from the same species detail the form already keys
+ * on (`perenualSpeciesId`) — no extra backend surface, just the existing
+ * `/species/:id` lookup.
  *
  * This is informational only: it never blocks saving. Plenty of people keep
  * toxic plants on purpose and just place them out of reach — the note is a
  * gentle heads-up, not a gate.
+ *
+ * Three distinct "nothing to warn about" states are NOT treated the same:
+ * confirmed non-toxic (`poisonousToPets === false`) renders nothing, same as
+ * before; a genuine fetch failure renders a small "couldn't check" notice
+ * rather than silently looking identical to "confirmed safe" — this is the
+ * one card in the app where that absence is actively dangerous to get wrong.
+ * Perenual having no toxicity data at all (`poisonousToPets === null`) also
+ * renders nothing, matching this app's "say nothing rather than guess"
+ * convention — it does not assert safety, it just has no warning to show.
  */
 export function PetToxicityNote({ perenualSpeciesId }: PetToxicityNoteProps) {
-  const { data } = useQuery({
+  const { data, isError } = useQuery({
     queryKey: ['species', 'detail', perenualSpeciesId],
     queryFn: () => speciesService.detail(perenualSpeciesId!),
     enabled: !!perenualSpeciesId,
     staleTime: 60 * 60 * 1000,
   });
 
-  if (!data?.poisonousToPets) return null;
+  if (!perenualSpeciesId) return null;
+
+  if (isError) {
+    return (
+      <Alert variant="info" title="Couldn't check pet toxicity">
+        We couldn&rsquo;t look up pet-safety data for this species just now. If you have pets,
+        it&rsquo;s worth checking the ASPCA&rsquo;s plant list before deciding where to put it.
+      </Alert>
+    );
+  }
+
+  if (data?.poisonousToPets !== true) return null;
 
   return (
     <Alert variant="warning" title="Toxic to pets">

--- a/frontend/src/features/plants/importParse.ts
+++ b/frontend/src/features/plants/importParse.ts
@@ -9,7 +9,9 @@
  *  - JSON, the app's own export:    { format: 'family-greenhouse-export',
  *                                     households: [{ plants, tasks }] }
  *    (plants from every household are flattened; tasks re-attached by
- *     plantId; export `createdAt` becomes `acquiredAt`)
+ *     plantId; export `createdAt` becomes `acquiredAt`; a present, valid
+ *     `perenualSpeciesId` is preserved so the care-guide/toxicity link
+ *     survives the round-trip)
  *  - CSV with a header row. The app's own plant-export headers
  *    (id,name,species,location,notes,tags,createdAt,updatedAt) are
  *    recognized; extra columns are ignored and only `name` is required.
@@ -30,6 +32,8 @@ export interface ImportTaskDraft {
 export interface ImportPlantDraft {
   name: string;
   species?: string;
+  /** Links to Perenual care-guide/toxicity data; see asPerenualSpeciesId. */
+  perenualSpeciesId?: number | null;
   location?: string;
   notes?: string;
   tags?: string[];
@@ -50,6 +54,10 @@ const importTaskDraftSchema = z.object({
 export const importPlantDraftSchema = z.object({
   name: z.string().min(1).max(100),
   species: z.string().max(100).optional(),
+  // No .nullable(): normalizeCandidate already drops anything that isn't a
+  // positive integer (including an explicit null), matching the backend's
+  // createPlantSchema which has no null case for a brand-new plant.
+  perenualSpeciesId: z.number().int().positive().optional(),
   location: z.string().max(100).optional(),
   notes: z.string().max(1000).optional(),
   tags: z.array(z.string().min(1).max(40)).max(10).optional(),
@@ -92,6 +100,15 @@ function asTags(value: unknown): string[] | undefined {
   return undefined;
 }
 
+/**
+ * Only a positive integer id is trusted (matches the backend's
+ * createPlantSchema); a string, 0, a negative/decimal number, null, or
+ * anything else from an untrusted upload is dropped rather than forwarded.
+ */
+function asPerenualSpeciesId(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0 ? value : undefined;
+}
+
 function asFrequency(value: unknown): number | unknown {
   if (typeof value === 'number') return value;
   if (typeof value === 'string' && value.trim() !== '' && !Number.isNaN(Number(value))) {
@@ -114,6 +131,10 @@ export function normalizeCandidate(raw: Record<string, unknown>): Record<string,
   };
   const species = asOptionalString(raw.species);
   if (species !== undefined) out.species = species;
+  // Only the JSON-export shape realistically carries this; CSV rows simply
+  // won't have the key, so this is a no-op for them rather than a clobber.
+  const perenualSpeciesId = asPerenualSpeciesId(raw.perenualSpeciesId);
+  if (perenualSpeciesId !== undefined) out.perenualSpeciesId = perenualSpeciesId;
   const location = asOptionalString(raw.location);
   if (location !== undefined) out.location = location;
   const notes = asOptionalString(raw.notes);

--- a/frontend/src/services/plantService.ts
+++ b/frontend/src/services/plantService.ts
@@ -129,6 +129,8 @@ export interface ImportPlantData {
   location?: string;
   notes?: string;
   tags?: string[];
+  /** From an export round-trip; the backend persists it when present. */
+  perenualSpeciesId?: number | null;
   /** Accepted for export round-trips; not persisted server-side (yet). */
   acquiredAt?: string;
   tasks?: ImportTaskData[];

--- a/frontend/src/services/speciesService.ts
+++ b/frontend/src/services/speciesService.ts
@@ -15,12 +15,18 @@ export interface PerenualSpeciesDetail extends PerenualSpeciesSummary {
   hardinessZone: string | null;
   indoor: boolean;
   edible: boolean;
-  poisonousToPets: boolean;
+  // `null` means Perenual has no toxicity data for this species — distinct
+  // from a confirmed `false`. Never render an absence of data as "confirmed
+  // safe."
+  poisonousToPets: boolean | null;
   defaultImageUrl: string | null;
 }
 
 export type SpeciesSearchResponse = {
-  source: 'perenual' | 'disabled';
+  // 'disabled' = no Perenual API key configured. 'unavailable' = configured
+  // but this request got no data (budget exhausted or a transient upstream
+  // error) — a real, possibly-transient outage, not the same as "off".
+  source: 'perenual' | 'disabled' | 'unavailable';
   results: PerenualSpeciesSummary[];
 };
 
@@ -42,7 +48,7 @@ export interface CareGuideResponse {
   cycle: string | null;
   hardinessZone: string | null;
   indoor: boolean;
-  poisonousToPets: boolean;
+  poisonousToPets: boolean | null;
   sunlight: string[];
   sections: CareGuideSection[];
 }

--- a/frontend/tests/unit/components/SpeciesCombobox.test.tsx
+++ b/frontend/tests/unit/components/SpeciesCombobox.test.tsx
@@ -1,10 +1,20 @@
 import { useState } from 'react';
-import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { SpeciesCombobox } from '@/components/SpeciesCombobox';
+import { speciesService } from '@/services/speciesService';
 import type { SpeciesEntry } from '@/utils/species';
+
+// Most tests here exercise the static-catalog path only and don't care what
+// this resolves to — the two debounce/staleness tests below set their own
+// per-test implementation.
+vi.mock('@/services/speciesService', () => ({
+  speciesService: {
+    search: vi.fn().mockResolvedValue({ source: 'perenual', results: [] }),
+  },
+}));
 
 // SpeciesCombobox calls useQuery for Perenual suggestions. The unit tests
 // don't care about the network result — they exercise the static-catalog
@@ -19,12 +29,21 @@ function withQuery(ui: React.ReactNode) {
 function ControlledCombobox({
   initial = '',
   onPick,
+  onPerenualPick,
 }: {
   initial?: string;
   onPick?: (entry: SpeciesEntry) => void;
+  onPerenualPick?: (id: number | null) => void;
 }) {
   const [value, setValue] = useState(initial);
-  return <SpeciesCombobox value={value} onChange={setValue} onPick={onPick} />;
+  return (
+    <SpeciesCombobox
+      value={value}
+      onChange={setValue}
+      onPick={onPick}
+      onPerenualPick={onPerenualPick}
+    />
+  );
 }
 
 describe('SpeciesCombobox', () => {
@@ -67,5 +86,86 @@ describe('SpeciesCombobox', () => {
   it('renders the error message when provided', () => {
     render(withQuery(<SpeciesCombobox value="" onChange={() => {}} error="Required" />));
     expect(screen.getByText('Required')).toBeInTheDocument();
+  });
+
+  describe('Perenual match re-checking (debounce lag)', () => {
+    beforeEach(() => {
+      vi.mocked(speciesService.search).mockReset();
+    });
+
+    it('re-checks for a match once debounced results land, even though every keystroke saw stale data', async () => {
+      // Resolves immediately once called — the point under test is that
+      // nothing re-checks against it until the 300ms debounce elapses, not
+      // that the network itself is slow.
+      vi.mocked(speciesService.search).mockResolvedValue({
+        source: 'perenual',
+        results: [
+          {
+            id: 99,
+            commonName: 'Monstera',
+            scientificName: 'Monstera deliciosa',
+            thumbnailUrl: null,
+          },
+        ],
+      });
+      const onPerenualPick = vi.fn();
+      render(withQuery(<ControlledCombobox onPerenualPick={onPerenualPick} />));
+      const input = screen.getByLabelText(/species/i);
+
+      // Simulate one continuous burst of typing with no pauses: a single
+      // change event straight to the final value, exactly like every
+      // keystroke's onChange would see while the 300ms debounce is still
+      // behind. `perenual` is still undefined at this point.
+      fireEvent.change(input, { target: { value: 'Monstera deliciosa' } });
+      expect(onPerenualPick).toHaveBeenLastCalledWith(null);
+
+      // Let the debounce elapse and the mocked search resolve.
+      await waitFor(() => expect(onPerenualPick).toHaveBeenLastCalledWith(99), { timeout: 2000 });
+    });
+
+    it('does not mix a stale query’s remote results into a fresh query’s merged list', async () => {
+      vi.mocked(speciesService.search).mockImplementation((query: string) => {
+        if (query.trim().toLowerCase() === 'aloe') {
+          return Promise.resolve({
+            source: 'perenual',
+            results: [
+              {
+                id: 1,
+                commonName: 'Aloe vera',
+                scientificName: 'Aloe barbadensis',
+                thumbnailUrl: null,
+              },
+            ],
+          });
+        }
+        // Never resolves within this test's window — stands in for a
+        // request that's still in flight.
+        return new Promise(() => {});
+      });
+
+      const { container } = render(withQuery(<ControlledCombobox />));
+      const input = screen.getByLabelText(/species/i);
+
+      fireEvent.change(input, { target: { value: 'aloe' } });
+      await waitFor(
+        () => {
+          const values = Array.from(container.querySelectorAll('datalist option')).map(
+            (o) => (o as HTMLOptionElement).value
+          );
+          expect(values).toContain('Aloe barbadensis');
+        },
+        { timeout: 2000 }
+      );
+
+      // Clear and type a new query with no pause — the debounced query for
+      // "philodendron" hasn't started (let alone resolved) yet.
+      fireEvent.change(input, { target: { value: '' } });
+      fireEvent.change(input, { target: { value: 'philodendron' } });
+      const values = Array.from(container.querySelectorAll('datalist option')).map(
+        (o) => (o as HTMLOptionElement).value
+      );
+      expect(values).not.toContain('Aloe barbadensis');
+      expect(values.some((v) => v.toLowerCase().includes('philodendron'))).toBe(true);
+    });
   });
 });

--- a/frontend/tests/unit/features/AddPlantPage.test.tsx
+++ b/frontend/tests/unit/features/AddPlantPage.test.tsx
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { act, render, screen, waitFor, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AddPlantPage } from '@/features/plants/AddPlantPage';
+import { plantService } from '@/services/plantService';
+import { speciesService, type SpeciesSearchResponse } from '@/services/speciesService';
+
+vi.mock('@/services/plantService', () => ({
+  plantService: {
+    identifyPlant: vi.fn(),
+  },
+}));
+
+vi.mock('@/services/speciesService', () => ({
+  speciesService: {
+    search: vi.fn(),
+    detail: vi.fn(),
+    careSuggestions: vi.fn(),
+  },
+}));
+
+/** A promise this test can resolve on demand, to control resolution order. */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+function renderPage() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <AddPlantPage />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+async function pickPhotoAndIdentify() {
+  const file = new File(['plant-bytes'], 'plant.jpg', { type: 'image/jpeg' });
+  const input = screen.getByLabelText(/choose a photo/i);
+  const user = userEvent.setup();
+  await user.upload(input, file);
+  fireEvent.click(await screen.findByRole('button', { name: /identify from photo/i }));
+  await screen.findAllByRole('button', { name: 'Use' });
+}
+
+describe('AddPlantPage acceptSuggestion race guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(plantService.identifyPlant).mockResolvedValue({
+      configured: true,
+      suggestions: [
+        { scientificName: 'Monstera deliciosa', commonName: 'Monstera', probability: 0.9 },
+        { scientificName: 'Nephrolepis exaltata', commonName: 'Boston fern', probability: 0.8 },
+      ],
+    });
+    vi.mocked(speciesService.careSuggestions).mockResolvedValue(null);
+  });
+
+  it('does not let a slower earlier pick clobber a faster later one', async () => {
+    const monsteraSearch = deferred<SpeciesSearchResponse>();
+    const fernSearch = deferred<SpeciesSearchResponse>();
+    vi.mocked(speciesService.search).mockImplementation((query: string) => {
+      if (query === 'Monstera deliciosa') return monsteraSearch.promise;
+      if (query === 'Nephrolepis exaltata') return fernSearch.promise;
+      return Promise.resolve({ source: 'perenual', results: [] });
+    });
+    vi.mocked(speciesService.detail).mockImplementation((id: number) =>
+      Promise.resolve({
+        id,
+        commonName: id === 1 ? 'Monstera' : 'Boston fern',
+        scientificName: id === 1 ? 'Monstera deliciosa' : 'Nephrolepis exaltata',
+        thumbnailUrl: null,
+        family: null,
+        cycle: null,
+        watering: null,
+        sunlight: [],
+        hardinessZone: null,
+        indoor: true,
+        edible: false,
+        // Monstera (id 1) is toxic; Boston fern (id 2) is not — lets the
+        // test tell which one "won" from the rendered alert alone.
+        poisonousToPets: id === 1,
+        defaultImageUrl: null,
+      })
+    );
+
+    renderPage();
+    await pickPhotoAndIdentify();
+
+    // Click "Use" on Monstera (the slower search) first.
+    const [useMonstera] = screen.getAllByRole('button', { name: 'Use' });
+    fireEvent.click(useMonstera);
+    await waitFor(() => expect(speciesService.search).toHaveBeenCalledWith('Monstera deliciosa'));
+
+    // Re-identify the same photo (list reappears) and pick Boston fern.
+    fireEvent.click(await screen.findByRole('button', { name: /identify from photo/i }));
+    await screen.findAllByRole('button', { name: 'Use' });
+    const [, useFern] = screen.getAllByRole('button', { name: 'Use' });
+    fireEvent.click(useFern);
+    await waitFor(() => expect(speciesService.search).toHaveBeenCalledWith('Nephrolepis exaltata'));
+
+    // The faster (later) pick resolves first and should win.
+    fernSearch.resolve({
+      source: 'perenual',
+      results: [
+        {
+          id: 2,
+          commonName: 'Boston fern',
+          scientificName: 'Nephrolepis exaltata',
+          thumbnailUrl: null,
+        },
+      ],
+    });
+    await waitFor(() => expect(speciesService.detail).toHaveBeenCalledWith(2));
+
+    // The slower (earlier) pick resolves after — it's stale and must be
+    // ignored, since the species field has already moved on to the fern.
+    // Give the stale resolution a chance to (wrongly) apply if the guard
+    // were missing, then assert it never did.
+    await act(async () => {
+      monsteraSearch.resolve({
+        source: 'perenual',
+        results: [
+          {
+            id: 1,
+            commonName: 'Monstera',
+            scientificName: 'Monstera deliciosa',
+            thumbnailUrl: null,
+          },
+        ],
+      });
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+    expect(speciesService.detail).not.toHaveBeenCalledWith(1);
+    expect(screen.queryByText('Toxic to pets')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/tests/unit/features/EditPlantModal.test.tsx
+++ b/frontend/tests/unit/features/EditPlantModal.test.tsx
@@ -1,0 +1,149 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { EditPlantModal } from '@/features/plants/EditPlantModal';
+import { Plant } from '@/services/plantService';
+import { useAuthStore } from '@/store/authStore';
+import { server } from '../../msw/server';
+
+const API = 'http://localhost:4000';
+
+function makePlant(overrides: Partial<Plant> = {}): Plant {
+  return {
+    id: 'p1',
+    householdId: 'hh-1',
+    name: 'Monstera',
+    species: 'Monstera deliciosa',
+    location: null,
+    imageUrl: null,
+    notes: null,
+    perenualSpeciesId: 42,
+    createdAt: '',
+    createdBy: 'u1',
+    updatedAt: '',
+    ...overrides,
+  };
+}
+
+function renderModal(plant: Plant) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <EditPlantModal plant={plant} isOpen onClose={() => {}} />
+    </QueryClientProvider>
+  );
+}
+
+describe('EditPlantModal', () => {
+  beforeEach(() => {
+    useAuthStore.setState({ accessToken: 'access-1' });
+    // No species has a Perenual match by default in these tests — the
+    // combobox's own debounced lookup is not what's under test here.
+    server.use(
+      http.get(`${API}/species/search`, () =>
+        HttpResponse.json({ source: 'perenual', results: [] })
+      )
+    );
+  });
+
+  it('renders the species field as a combobox seeded with the plant value', () => {
+    renderModal(makePlant());
+    const input = screen.getByLabelText(/species/i) as HTMLInputElement;
+    expect(input.value).toBe('Monstera deliciosa');
+    // Regression guard: a plain <Input> has no `list` attribute — this must
+    // be the SpeciesCombobox, not the old plain text input.
+    expect(input.getAttribute('list')).toBeTruthy();
+  });
+
+  it('sends null for perenualSpeciesId once the species text no longer matches a known species', async () => {
+    let body: Record<string, unknown> | undefined;
+    server.use(
+      http.put(`${API}/plants/p1`, async ({ request }) => {
+        body = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json(makePlant({ ...(body as Partial<Plant>) }));
+      })
+    );
+    const user = userEvent.setup();
+    renderModal(makePlant());
+
+    const input = screen.getByLabelText(/species/i);
+    await user.clear(input);
+    await user.type(input, 'not a real species');
+    await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => expect(body).toBeDefined());
+    expect(body?.perenualSpeciesId).toBeNull();
+  });
+
+  it('still sends the original perenualSpeciesId when the species field is left untouched', async () => {
+    let body: Record<string, unknown> | undefined;
+    server.use(
+      http.put(`${API}/plants/p1`, async ({ request }) => {
+        body = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json(makePlant({ ...(body as Partial<Plant>) }));
+      })
+    );
+    const user = userEvent.setup();
+    renderModal(makePlant({ perenualSpeciesId: 42 }));
+
+    await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => expect(body).toBeDefined());
+    // Never omitted — omitting it would leave the backend's existing value
+    // untouched, which reads as "unchanged" but is indistinguishable from
+    // the stale-attachment bug in a request-body assertion, so we assert
+    // the key is explicitly present with the right value.
+    expect(body).toHaveProperty('perenualSpeciesId', 42);
+  });
+
+  it('updates perenualSpeciesId to a newly recognized species when the text is edited to match one', async () => {
+    server.use(
+      http.get(`${API}/species/search`, ({ request }) => {
+        const q = new URL(request.url).searchParams.get('q');
+        if (q?.toLowerCase().includes('nephrolepis')) {
+          return HttpResponse.json({
+            source: 'perenual',
+            results: [
+              {
+                id: 7,
+                commonName: 'Boston fern',
+                scientificName: 'Nephrolepis exaltata',
+                thumbnailUrl: null,
+              },
+            ],
+          });
+        }
+        return HttpResponse.json({ source: 'perenual', results: [] });
+      })
+    );
+    let body: Record<string, unknown> | undefined;
+    server.use(
+      http.put(`${API}/plants/p1`, async ({ request }) => {
+        body = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json(makePlant({ ...(body as Partial<Plant>) }));
+      })
+    );
+    const user = userEvent.setup();
+    renderModal(makePlant());
+
+    const input = screen.getByLabelText(/species/i);
+    await user.clear(input);
+    await user.type(input, 'Nephrolepis exaltata');
+
+    // Give the combobox's 300ms debounce + mocked fetch time to resolve and
+    // re-check the match (Bug 3's catch-up effect).
+    await waitFor(() => expect((input as HTMLInputElement).value).toBe('Nephrolepis exaltata'), {
+      timeout: 2000,
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 400));
+    });
+
+    await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => expect(body).toBeDefined());
+    expect(body?.perenualSpeciesId).toBe(7);
+  });
+});

--- a/frontend/tests/unit/features/PetToxicityNote.test.tsx
+++ b/frontend/tests/unit/features/PetToxicityNote.test.tsx
@@ -64,6 +64,23 @@ describe('PetToxicityNote', () => {
     expect(screen.queryByText(/keep it out of reach/i)).not.toBeInTheDocument();
   });
 
+  it('renders nothing when Perenual has no toxicity data (never claims "safe")', async () => {
+    detail.mockResolvedValue(makeDetail({ id: 9, poisonousToPets: null }));
+    renderNote(9);
+
+    await waitFor(() => expect(detail).toHaveBeenCalledWith(9));
+    expect(screen.queryByText(/keep it out of reach/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/couldn.?t check/i)).not.toBeInTheDocument();
+  });
+
+  it('shows an honest "couldn\'t check" notice on a fetch failure, instead of looking like confirmed-safe', async () => {
+    detail.mockRejectedValue(new Error('network error'));
+    renderNote(11);
+
+    expect(await screen.findByText(/couldn.?t check pet toxicity/i)).toBeInTheDocument();
+    expect(screen.queryByText(/keep it out of reach/i)).not.toBeInTheDocument();
+  });
+
   it('does not fetch or render when no species is picked', () => {
     renderNote(null);
 

--- a/frontend/tests/unit/features/importParse.test.ts
+++ b/frontend/tests/unit/features/importParse.test.ts
@@ -54,6 +54,7 @@ describe('parseImportFile — JSON shapes', () => {
               notes: null,
               status: 'active',
               tags: ['easy'],
+              perenualSpeciesId: 42,
               createdAt: '2025-01-01T00:00:00.000Z',
               createdBy: 'u1',
               updatedAt: '2025-01-01T00:00:00.000Z',
@@ -83,9 +84,32 @@ describe('parseImportFile — JSON shapes', () => {
       species: 'Epipremnum',
       location: 'Kitchen',
       tags: ['easy'],
+      perenualSpeciesId: 42,
       acquiredAt: '2025-01-01T00:00:00.000Z',
       tasks: [{ type: 'water', frequency: 7, notes: 'from the top' }],
     });
+  });
+
+  it('drops an absent or malformed perenualSpeciesId instead of forwarding garbage', () => {
+    const rows = parseImportFile(
+      'json',
+      JSON.stringify([
+        { name: 'No link' },
+        { name: 'Null link', perenualSpeciesId: null },
+        { name: 'String id', perenualSpeciesId: '42' },
+        { name: 'Negative id', perenualSpeciesId: -5 },
+        { name: 'Decimal id', perenualSpeciesId: 1.5 },
+        { name: 'Zero id', perenualSpeciesId: 0 },
+        { name: 'Valid id', perenualSpeciesId: 7 },
+      ])
+    );
+    expect(rows[0].data).toEqual({ name: 'No link' });
+    expect(rows[1].data).toEqual({ name: 'Null link' });
+    expect(rows[2].data).toEqual({ name: 'String id' });
+    expect(rows[3].data).toEqual({ name: 'Negative id' });
+    expect(rows[4].data).toEqual({ name: 'Decimal id' });
+    expect(rows[5].data).toEqual({ name: 'Zero id' });
+    expect(rows[6].data).toEqual({ name: 'Valid id', perenualSpeciesId: 7 });
   });
 
   it('throws a typed error for unparseable JSON', () => {


### PR DESCRIPTION
## Why

The Cinnamomum cassia fix (#170, already merged) turned out to be one instance of a recurring pattern: **"Perenual has no data" silently collapsing into a specific, false answer** instead of being surfaced honestly. This PR is the result of a four-track audit of the whole integration (data mapping, caching/pest-alerts, handlers/import, frontend consumption) hunting for the same defect class plus adjacent bugs, followed by fixes + regression tests for everything confirmed real.

## Safety-relevant

- **`poisonousToPets` collapsed "no data" into `false`** ("confirmed non-toxic"), so a plant Perenual simply hadn't checked rendered with **zero pet-toxicity warning** — visually identical to a confirmed-safe plant. Now a real tri-state (`true`/`false`/`null`) end to end.
- `PetToxicityNote` now distinguishes a genuine fetch failure ("couldn't check") from "confirmed safe" or "no data" — previously all three rendered identically (nothing).

## Silent data loss

- `pestAlerts.ts`/`reminders.ts` treated "Perenual unavailable this hour" (budget exhausted, transient error) the same as "confirmed no pests" — and the per-household daily marker was written **before** evaluation ran, so a transient outage silently and **permanently** lost that day's pest alerts with no trace. `listPestsForSpeciesCached` now returns a discriminated result; the marker is deleted again when data was unavailable so a later hour that day retries.

## Correctness bugs

- Null/thin-data `commonName` crashed the species combobox (`.toLowerCase()` on null).
- A malformed care-guide response threw a 500 instead of degrading (violates the module's own "never throws" contract).
- `getCareGuide` never cached a genuinely-empty guide, re-spending API budget on every request forever.
- `SpeciesCombobox` never re-checked for a Perenual match once its debounced network results actually arrived — **continuous, non-pausing typing usually never linked a species to Perenual at all**, silently disabling suggested care/toxicity for most real users.
- Editing a plant's species in `EditPlantModal` (a plain text input) could never update or clear its Perenual link — care/toxicity data stayed attached to the wrong species indefinitely.
- A slower, superseded species search in the photo-ID accept flow could clobber a faster, later pick (race condition, no staleness guard).

## Also fixed

- `/species/{id}`, `/guide`, `/care-suggestions` returned an identical 200 for a malformed id and for "no data" — now 400 vs 200.
- `search`'s `source` field labeled a real outage the same as "integration disabled."
- The rate limiter keyed on the **literal request path**, so varying a numeric `{id}` trivially bypassed a documented per-route cap (e.g. hitting 50 different species ids bypassed a "10/min" limit entirely). Now keys on the resolved route template.
- No max length on the search query (mirrors the cap already on `/species/toxicity`).
- Re-importing the app's own data export silently dropped every plant's Perenual link.
- Case-sensitive month matching in pest-season detection missed mixed-case descriptions.

## Deliberately not changed (noted, not silently dropped)

- Full runtime (zod) validation of Perenual's JSON responses — the root enabler of several of these bugs, but a larger, separate effort.
- Server-side verification that a client-supplied `perenualSpeciesId` actually matches the plant's species text.
- Bulk CSV import never attempts species matching at all (a feature gap, not a regression).
- `indoor`/`edible` have the same unknown-vs-false gap as `poisonousToPets` but zero current consumers — left as plain booleans rather than expanding surface area for no observable benefit.

## Verification

- `tsc --noEmit` + `eslint --max-warnings 0` clean on both workspaces.
- Backend: **1040/1040** tests passing (28 new).
- Frontend: **354/354** tests passing (9 new + 2 new test files: `AddPlantPage.test.tsx`, `EditPlantModal.test.tsx`).
- Both production builds succeed; `size-limit` budgets pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)