### PR TITLE
fix(climate): geocode space-separated "city country/state" queries

### DIFF
--- a/backend/src/services/weather.ts
+++ b/backend/src/services/weather.ts
@@ -79,6 +79,91 @@ interface RawGeocode {
   country?: string;
 }
 
+// US state postal codes. OpenWeatherMap's geocoding `q` format is strictly
+// `{city},{state},{country}` — state is only meaningful in that 3-part form.
+// A bare 2-part `{city},{state}` reads the second segment as an ISO country
+// code instead, so "Davis,CA" tries to match Canada (ISO "CA"), not
+// California. Recognizing the code lets us retry with the country made
+// explicit: "Davis,CA,US".
+const US_STATE_CODES = new Set([
+  'AL',
+  'AK',
+  'AZ',
+  'AR',
+  'CA',
+  'CO',
+  'CT',
+  'DE',
+  'FL',
+  'GA',
+  'HI',
+  'ID',
+  'IL',
+  'IN',
+  'IA',
+  'KS',
+  'KY',
+  'LA',
+  'ME',
+  'MD',
+  'MA',
+  'MI',
+  'MN',
+  'MS',
+  'MO',
+  'MT',
+  'NE',
+  'NV',
+  'NH',
+  'NJ',
+  'NM',
+  'NY',
+  'NC',
+  'ND',
+  'OH',
+  'OK',
+  'OR',
+  'PA',
+  'RI',
+  'SC',
+  'SD',
+  'TN',
+  'TX',
+  'UT',
+  'VT',
+  'VA',
+  'WA',
+  'WV',
+  'WI',
+  'WY',
+  'DC',
+]);
+
+/**
+ * OpenWeatherMap only recognizes a comma-separated query — but the natural
+ * way to add a disambiguating country/state (the way our own error message's
+ * example, "Austin, US", implies, and the way most people actually type it)
+ * is a trailing code separated by a SPACE. "davis us" and "davis ca," typed
+ * exactly as prompted, matched nothing upstream because OWM read the whole
+ * string as one unmatched place name. Insert the comma OWM needs whenever
+ * the query isn't already comma-structured; leave an already-structured
+ * query (the user typed their own comma) untouched.
+ */
+function normalizeGeocodeQuery(query: string): string {
+  const trimmed = query.trim();
+  if (trimmed.includes(',')) return trimmed;
+  const parts = trimmed.split(/\s+/);
+  if (parts.length < 2) return trimmed;
+  const code = parts[parts.length - 1];
+  if (!/^[a-zA-Z]{2}$/.test(code)) return trimmed;
+  const city = parts.slice(0, -1).join(' ');
+  return `${city}, ${code.toUpperCase()}`;
+}
+
+function toResult(best: RawGeocode): GeocodeResult {
+  return { city: best.name, lat: best.lat, lon: best.lon, country: best.country ?? null };
+}
+
 interface RawOneCall {
   current?: {
     dt: number;
@@ -99,18 +184,24 @@ interface RawOneCall {
  * responsible for prompting the user to refine.
  */
 export async function geocode(query: string): Promise<GeocodeResult | null> {
-  const raw = await fetchJson<RawGeocode[]>('/geo/1.0/direct', {
-    q: query.trim(),
-    limit: '1',
-  });
-  if (!raw || raw.length === 0) return null;
-  const best = raw[0];
-  return {
-    city: best.name,
-    lat: best.lat,
-    lon: best.lon,
-    country: best.country ?? null,
-  };
+  const normalized = normalizeGeocodeQuery(query);
+  const raw = await fetchJson<RawGeocode[]>('/geo/1.0/direct', { q: normalized, limit: '1' });
+  if (raw && raw.length > 0) return toResult(raw[0]);
+
+  // The trailing code (if any) didn't resolve as an ISO country. Retry
+  // assuming it's a US state abbreviation instead — see US_STATE_CODES.
+  const match = /^(.*),\s*([a-zA-Z]{2})$/.exec(normalized);
+  if (match) {
+    const [, city, code] = match;
+    if (US_STATE_CODES.has(code.toUpperCase())) {
+      const retry = await fetchJson<RawGeocode[]>('/geo/1.0/direct', {
+        q: `${city}, ${code.toUpperCase()}, US`,
+        limit: '1',
+      });
+      if (retry && retry.length > 0) return toResult(retry[0]);
+    }
+  }
+  return null;
 }
 
 export async function getWeather(lat: number, lon: number): Promise<WeatherSnapshot | null> {

--- a/backend/tests/unit/services/weather.test.ts
+++ b/backend/tests/unit/services/weather.test.ts
@@ -59,6 +59,74 @@ describe('weather client (OpenWeatherMap)', () => {
       fetchMock.mockResolvedValueOnce({ ok: true, json: async () => [] });
       expect(await geocode('xyzzy nowhere')).toBeNull();
     });
+
+    describe('space-separated country/state qualifiers (the "davis us" / "davis ca" bug)', () => {
+      it('inserts the comma OWM requires for a space-separated "city country" query', async () => {
+        fetchMock.mockResolvedValueOnce({
+          ok: true,
+          json: async () => [{ name: 'Davis', lat: 38.5449, lon: -121.7405, country: 'US' }],
+        });
+
+        const out = await geocode('davis us');
+        expect(out).toEqual({ city: 'Davis', lat: 38.5449, lon: -121.7405, country: 'US' });
+
+        const url = new URL(fetchMock.mock.calls[0][0] as string);
+        expect(url.searchParams.get('q')).toBe('davis, US');
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+      });
+
+      it('retries as a US state when the 2-letter code fails as a country ("davis ca" → Davis, CA, US)', async () => {
+        // First attempt: "davis, CA" — OWM reads CA as Canada; no Davis there.
+        fetchMock.mockResolvedValueOnce({ ok: true, json: async () => [] });
+        // Retry: "davis, CA, US" — resolves correctly to Davis, California.
+        fetchMock.mockResolvedValueOnce({
+          ok: true,
+          json: async () => [{ name: 'Davis', lat: 38.5449, lon: -121.7405, country: 'US' }],
+        });
+
+        const out = await geocode('davis ca');
+        expect(out).toEqual({ city: 'Davis', lat: 38.5449, lon: -121.7405, country: 'US' });
+
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(new URL(fetchMock.mock.calls[0][0] as string).searchParams.get('q')).toBe(
+          'davis, CA'
+        );
+        expect(new URL(fetchMock.mock.calls[1][0] as string).searchParams.get('q')).toBe(
+          'davis, CA, US'
+        );
+      });
+
+      it('does not retry when the trailing code is not a recognized US state', async () => {
+        fetchMock.mockResolvedValueOnce({ ok: true, json: async () => [] });
+        expect(await geocode('tokyo xx')).toBeNull();
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+      });
+
+      it('leaves an already comma-structured query untouched (no double-normalizing)', async () => {
+        fetchMock.mockResolvedValueOnce({
+          ok: true,
+          json: async () => [{ name: 'Davis', lat: 38.5449, lon: -121.7405, country: 'US' }],
+        });
+        await geocode('davis, ca');
+        // The user's own comma structure is trusted as-is — no state retry
+        // logic kicks in even though "ca" alone would otherwise qualify,
+        // because the first (only) call already succeeded.
+        expect(new URL(fetchMock.mock.calls[0][0] as string).searchParams.get('q')).toBe(
+          'davis, ca'
+        );
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+      });
+
+      it('leaves a single-word query (no code to normalize) untouched', async () => {
+        fetchMock.mockResolvedValueOnce({
+          ok: true,
+          json: async () => [{ name: 'Davis', lat: 38.5449, lon: -121.7405, country: 'US' }],
+        });
+        await geocode('davis');
+        expect(new URL(fetchMock.mock.calls[0][0] as string).searchParams.get('q')).toBe('davis');
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+      });
+    });
   });
 
   describe('getWeather', () => {


### PR DESCRIPTION
## Bug

Typing "davis us" or "davis ca" into the household location field returned "Could not find that location. Try adding the country (e.g. \"Austin, US\")..." — even though a country/state qualifier was added, exactly as suggested.

## Root cause

`weather.geocode()` forwards the query string verbatim to OpenWeatherMap's geocoding API, which only recognizes a **comma-separated** `city,state,country` format. The natural way to type a qualifier — and the way the app's own error message's example ("Austin, US") reads — is a space, which OWM doesn't parse as a qualifier at all. The whole string ("davis us") was read as one unmatched place name.

A second, subtler bug sat underneath: OWM's 2-part `city,state` form (no explicit country) reads a bare 2-letter code as an **ISO country code**, not a US state. So even a correctly-punctuated "Davis,CA" resolves `CA` as Canada, not California, and finds nothing.

## Fix

`geocode()` now:
1. Normalizes a space-separated trailing 2-letter code into comma form before querying OpenWeatherMap ("davis us" → "davis, US").
2. If that fails and the code is a recognized US state abbreviation, retries with the country made explicit ("davis, CA" → "davis, CA, US").
3. Leaves an already comma-structured query untouched (no double-normalizing user-typed structure).

## Verification

- 5 new tests covering: space-normalization succeeding on the first try ("davis us"), the CA→Canada-then-US-state retry ("davis ca"), no retry when the trailing code isn't a recognized state, comma-structured input left as-is, and single-word queries unaffected.
- Full backend suite: **1045/1045** passing, `tsc`/`eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)