### PR TITLE
fix: downscale photo before "Identify from photo" upload

### DIFF
--- a/frontend/src/features/plants/AddPlantPage.tsx
+++ b/frontend/src/features/plants/AddPlantPage.tsx
@@ -29,6 +29,13 @@ import { toast } from '@/store/toastStore';
 const MAX_BYTES = 5 * 1024 * 1024;
 const ACCEPTED_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
 
+// The identify endpoint shares leaf-health's 256 KiB body cap. Downscaling to
+// 1024px before encoding lands comfortably under that; MAX_BASE64_CHARS
+// mirrors the backend schema's limit so an oversized photo fails fast with a
+// clear message instead of a raw "payload too large" from the server.
+const IDENTIFY_PHOTO_MAX_EDGE = 1024;
+const MAX_BASE64_CHARS = 350_000;
+
 // Rebuilt per-render from the active locale so validation messages translate.
 const makeAddPlantSchema = (t: TFunction) =>
   z.object({
@@ -52,7 +59,7 @@ interface PropagationState {
   species?: string | null;
 }
 
-async function fileToBase64(file: File): Promise<string> {
+async function fileToBase64(file: Blob): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
     reader.onload = () => resolve(reader.result as string);
@@ -124,7 +131,16 @@ export function AddPlantPage() {
     setError(null);
     setIdentifyNotice(null);
     try {
-      const dataUrl = await fileToBase64(pickedFile);
+      // Downscale BEFORE encoding — a raw iPhone photo (multi-MB HEIC/JPEG)
+      // blows past the endpoint's body cap and the server rejects it outright.
+      const downscaled = await downscaleImage(pickedFile, IDENTIFY_PHOTO_MAX_EDGE);
+      const blob: Blob =
+        downscaled && ACCEPTED_TYPES.includes(downscaled.type) ? downscaled : pickedFile;
+      const dataUrl = await fileToBase64(blob);
+      if (dataUrl.length > MAX_BASE64_CHARS) {
+        setError('Image is too large to identify — try a smaller or less detailed photo.');
+        return;
+      }
       const result = await plantService.identifyPlant(dataUrl);
       if (!result.suggestions || result.suggestions.length === 0) {
         setIdentifyNotice('No suggestions came back — fill in the species manually.');

--- a/frontend/tests/unit/features/AddPlantPage.test.tsx
+++ b/frontend/tests/unit/features/AddPlantPage.test.tsx
@@ -21,6 +21,13 @@ vi.mock('@/services/speciesService', () => ({
   },
 }));
 
+// jsdom has no real image decoder, so the canvas pipeline never resolves —
+// mock the module to behave like the "pipeline unavailable" fallback path
+// (null), which is what downscaleImage itself returns in that case.
+vi.mock('@/utils/image', () => ({
+  downscaleImage: vi.fn().mockResolvedValue(null),
+}));
+
 /** A promise this test can resolve on demand, to control resolution order. */
 function deferred<T>() {
   let resolve!: (value: T) => void;


### PR DESCRIPTION
## Summary
- "Identify from photo" (Add Plant page) sent the raw picked file straight to `/plants/identify`, so a multi-MB iPhone photo blew past the endpoint's body cap and surfaced as a raw "payload too large" error.
- The sibling "Check leaf health" flow already downscales before upload; this mirrors that pattern in `AddPlantPage.tsx`'s `runIdentify`: downscale to a 1024px long edge, then check the base64 length client-side and fail fast with a clear message if it's still too big.

## Test plan
- [x] `npx tsc --noEmit` clean (frontend)
- [x] `npx eslint` clean on changed files
- [x] Full frontend test suite passes (61 files / 364 tests), including updated `AddPlantPage.test.tsx` (mocks `downscaleImage` since jsdom has no real canvas/image decoder)
- [x] Full backend test suite passes (81 files / 1071 tests, unaffected by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)