### PR TITLE
fix(frontend): make task completion visible

### DIFF
--- a/frontend/src/features/dashboard/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/DashboardPage.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
 import { CheckIcon } from '@heroicons/react/24/outline';
 import { useAuthStore } from '@/store/authStore';
@@ -16,6 +16,7 @@ import {
 } from '@/features/tasks/taskRowExtras';
 import {
   useClaimTaskMutation,
+  useCompleteTaskMutation,
   useSkipCycleMutation,
   useUnclaimTaskMutation,
 } from '@/features/tasks/taskMutations';
@@ -37,7 +38,6 @@ import clsx from 'clsx';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { taskTypeLabels, taskTypeStyles } from '@/utils/taskTypeConfig';
 import { formatDueDate, isOverdue } from '@/utils/date';
-import { toast } from '@/store/toastStore';
 
 type ActivityFilter = 'all' | 'tasks' | 'plants' | 'people';
 
@@ -74,7 +74,6 @@ export function DashboardPage() {
   useDocumentTitle('Dashboard');
   const user = useAuthStore((state) => state.user);
   const { householdId, householdQuery } = useActiveHousehold();
-  const queryClient = useQueryClient();
 
   const {
     data: upcomingTasks,
@@ -112,18 +111,7 @@ export function DashboardPage() {
     [activity, activityFilter]
   );
 
-  const completeTaskMutation = useMutation({
-    mutationFn: (taskId: string) => taskService.completeTask(taskId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['tasks', householdId] });
-      // Completing a task advances the plant's care state; refresh plants too
-      // (TasksPage already invalidates both) so the dashboard plant grid and
-      // each plant card's derived care status don't go stale.
-      queryClient.invalidateQueries({ queryKey: ['plants', householdId] });
-      toast.success('Task completed');
-    },
-    onError: (err) => toast.error(getErrorMessage(err)),
-  });
+  const completeTaskMutation = useCompleteTaskMutation(householdId);
 
   const handleCompleteTask = async (taskId: string) => {
     try {
@@ -230,7 +218,9 @@ export function DashboardPage() {
                 key={task.id}
                 task={task}
                 onComplete={handleCompleteTask}
-                isCompleting={completeTaskMutation.isPending}
+                isCompleting={
+                  completeTaskMutation.isPending && completeTaskMutation.variables === task.id
+                }
                 skipReason={climateSkipSuggestion(
                   task,
                   tagsByPlantId.get(task.plantId),

--- a/frontend/src/features/plants/PlantDetailPage.tsx
+++ b/frontend/src/features/plants/PlantDetailPage.tsx
@@ -15,6 +15,7 @@ import {
 } from '@heroicons/react/24/outline';
 import { plantService, Task } from '@/services/plantService';
 import { taskService } from '@/services/taskService';
+import { useCompleteTaskMutation } from '@/features/tasks/taskMutations';
 import { Button } from '@/components/Button';
 import { Card, CardHeader } from '@/components/Card';
 import { LoadingSpinner } from '@/components/LoadingSpinner';
@@ -111,15 +112,7 @@ export function PlantDetailPage() {
     onError: (err) => toast.error(getErrorMessage(err)),
   });
 
-  const completeTaskMutation = useMutation({
-    mutationFn: (taskId: string) => taskService.completeTask(taskId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['plants', householdId, plantId] });
-      queryClient.invalidateQueries({ queryKey: ['tasks', householdId] });
-      toast.success('Task completed');
-    },
-    onError: (err) => toast.error(getErrorMessage(err)),
-  });
+  const completeTaskMutation = useCompleteTaskMutation(householdId);
 
   const snoozeTaskMutation = useMutation({
     mutationFn: ({ taskId, days }: { taskId: string; days: number }) =>
@@ -360,7 +353,9 @@ export function PlantDetailPage() {
                 onComplete={() => completeTaskMutation.mutate(task.id)}
                 onSnooze={(days) => snoozeTaskMutation.mutate({ taskId: task.id, days })}
                 onEdit={() => setEditingTask(task)}
-                isCompleting={completeTaskMutation.isPending}
+                isCompleting={
+                  completeTaskMutation.isPending && completeTaskMutation.variables === task.id
+                }
                 isSnoozing={snoozeTaskMutation.isPending}
               />
             ))}

--- a/frontend/src/features/tasks/TasksPage.tsx
+++ b/frontend/src/features/tasks/TasksPage.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
 import { CheckIcon } from '@heroicons/react/24/outline';
 import { taskService, SnoozeReason, TaskWithCoverage } from '@/services/taskService';
@@ -9,6 +9,7 @@ import { deriveClimateSignals, climateSkipSuggestion } from './climateSignals';
 import { ClaimControls, ClimateSkipChip, CoveringBadge, UpForGrabsBadge } from './taskRowExtras';
 import {
   useClaimTaskMutation,
+  useCompleteTaskMutation,
   useSkipCycleMutation,
   useUnclaimTaskMutation,
 } from './taskMutations';
@@ -26,7 +27,6 @@ import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { taskTypeLabels, taskTypeStyles } from '@/utils/taskTypeConfig';
 import { calendarDaysBetween } from '@/utils/date';
 import { useActiveHousehold } from '@/hooks/useActiveHousehold';
-import { toast } from '@/store/toastStore';
 
 type FilterType = 'all' | 'mine' | 'overdue' | 'today' | 'week';
 
@@ -70,7 +70,6 @@ export function TasksPage() {
   useDocumentTitle('Tasks');
   const user = useAuthStore((state) => state.user);
   const { householdId, householdQuery } = useActiveHousehold();
-  const queryClient = useQueryClient();
   const [filter, setFilter] = useState<FilterType>('all');
 
   const {
@@ -105,15 +104,7 @@ export function TasksPage() {
     [plants]
   );
 
-  const completeTaskMutation = useMutation({
-    mutationFn: (taskId: string) => taskService.completeTask(taskId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['tasks', householdId] });
-      queryClient.invalidateQueries({ queryKey: ['plants', householdId] });
-      toast.success('Task completed');
-    },
-    onError: (err) => toast.error(getErrorMessage(err)),
-  });
+  const completeTaskMutation = useCompleteTaskMutation(householdId);
 
   const claimMutation = useClaimTaskMutation(householdId);
   const unclaimMutation = useUnclaimTaskMutation(householdId);
@@ -236,7 +227,9 @@ export function TasksPage() {
               title="Overdue"
               tasks={overdueTasks}
               onComplete={(id) => completeTaskMutation.mutate(id)}
-              isCompleting={completeTaskMutation.isPending}
+              completingTaskId={
+                completeTaskMutation.isPending ? completeTaskMutation.variables : null
+              }
               variant="danger"
               extras={rowExtras}
             />
@@ -247,7 +240,9 @@ export function TasksPage() {
               title="Today"
               tasks={todayTasks}
               onComplete={(id) => completeTaskMutation.mutate(id)}
-              isCompleting={completeTaskMutation.isPending}
+              completingTaskId={
+                completeTaskMutation.isPending ? completeTaskMutation.variables : null
+              }
               extras={rowExtras}
             />
           )}
@@ -257,7 +252,9 @@ export function TasksPage() {
               title="Upcoming"
               tasks={upcomingTasks}
               onComplete={(id) => completeTaskMutation.mutate(id)}
-              isCompleting={completeTaskMutation.isPending}
+              completingTaskId={
+                completeTaskMutation.isPending ? completeTaskMutation.variables : null
+              }
               extras={rowExtras}
             />
           )}
@@ -281,7 +278,7 @@ interface TaskSectionProps {
   title: string;
   tasks: TaskWithCoverage[];
   onComplete: (taskId: string) => void;
-  isCompleting: boolean;
+  completingTaskId: string | null;
   variant?: 'default' | 'danger';
   extras: TaskRowExtras;
 }
@@ -290,7 +287,7 @@ function TaskSection({
   title,
   tasks,
   onComplete,
-  isCompleting,
+  completingTaskId,
   variant = 'default',
   extras,
 }: TaskSectionProps) {
@@ -379,7 +376,7 @@ function TaskSection({
                   variant="secondary"
                   size="sm"
                   onClick={() => onComplete(task.id)}
-                  disabled={isCompleting}
+                  disabled={completingTaskId === task.id}
                   leftIcon={<CheckIcon className="h-4 w-4" aria-hidden="true" />}
                 >
                   Done

--- a/frontend/src/features/tasks/taskMutations.test.ts
+++ b/frontend/src/features/tasks/taskMutations.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { Task } from '@/services/plantService';
+import { replaceCompletedTaskInCache, replaceCompletedTaskInTaskQuery } from './taskMutations';
+
+const task: Task = {
+  id: 'task-1',
+  plantId: 'plant-1',
+  plantName: 'Monstera',
+  type: 'water',
+  frequency: 7,
+  lastCompleted: null,
+  nextDue: '2026-07-10T08:00:00.000Z',
+  assignedTo: null,
+  assignedToName: null,
+  notes: null,
+  createdBy: 'user-1',
+  createdAt: '2026-07-01T08:00:00.000Z',
+};
+
+const completed = {
+  ...task,
+  lastCompleted: '2026-07-10T09:00:00.000Z',
+  nextDue: '2026-07-17T09:00:00.000Z',
+};
+
+describe('replaceCompletedTaskInCache', () => {
+  it('replaces stale task-list data with the authoritative completion response', () => {
+    const staleList = [task, { ...task, id: 'task-2' }];
+
+    expect(replaceCompletedTaskInCache(staleList, completed)).toEqual([
+      completed,
+      { ...task, id: 'task-2' },
+    ]);
+  });
+
+  it('updates the task nested in a plant-detail response', () => {
+    const plantDetail = {
+      id: 'plant-1',
+      upcomingTasks: [task],
+      recentCompletions: [],
+    };
+
+    expect(replaceCompletedTaskInCache(plantDetail, completed)).toEqual({
+      ...plantDetail,
+      upcomingTasks: [completed],
+    });
+  });
+
+  it('removes a completed row from the dashboard care queue', () => {
+    expect(
+      replaceCompletedTaskInTaskQuery(['tasks', 'household-1', 'upcoming'], [task], completed)
+    ).toEqual([]);
+  });
+});

--- a/frontend/src/features/tasks/taskMutations.ts
+++ b/frontend/src/features/tasks/taskMutations.ts
@@ -11,12 +11,146 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { taskService, SnoozeReason, TaskWithCoverage } from '@/services/taskService';
-import { Task } from '@/services/plantService';
+import { PlantWithTasks, Task } from '@/services/plantService';
 import { useAuthStore } from '@/store/authStore';
 import { getErrorMessage } from '@/services/api';
 import { toast } from '@/store/toastStore';
 
 type TasksPatch = (tasks: TaskWithCoverage[]) => TaskWithCoverage[];
+
+type CachedQuerySnapshot = Array<[readonly unknown[], unknown]>;
+
+function replaceTask(tasks: TaskWithCoverage[], updatedTask: Task): TaskWithCoverage[] {
+  return tasks.map((task) => (task.id === updatedTask.id ? { ...task, ...updatedTask } : task));
+}
+
+/**
+ * Patch either task-list data or a plant-detail response with the authoritative
+ * task returned by POST /tasks/:id/complete. Keeping this pure makes the
+ * eventual-consistency regression independently testable.
+ */
+export function replaceCompletedTaskInCache(value: unknown, updatedTask: Task): unknown {
+  if (Array.isArray(value)) {
+    return replaceTask(value as TaskWithCoverage[], updatedTask);
+  }
+  if (value && typeof value === 'object') {
+    const plant = value as PlantWithTasks;
+    if (Array.isArray(plant.upcomingTasks)) {
+      return { ...plant, upcomingTasks: replaceTask(plant.upcomingTasks, updatedTask) };
+    }
+  }
+  return value;
+}
+
+/** Dashboard's upcoming list represents the current care queue: a completed
+ * row leaves it immediately. Full task lists keep the recurring task and show
+ * its newly scheduled due date. */
+export function replaceCompletedTaskInTaskQuery(
+  queryKey: readonly unknown[],
+  value: unknown,
+  updatedTask: Task
+): unknown {
+  if (Array.isArray(value) && queryKey[2] === 'upcoming') {
+    return (value as TaskWithCoverage[]).filter((task) => task.id !== updatedTask.id);
+  }
+  return replaceCompletedTaskInCache(value, updatedTask);
+}
+
+function optimisticCompletion(task: Task): Task {
+  const completedAt = new Date();
+  const nextDue = new Date(completedAt);
+  nextDue.setDate(nextDue.getDate() + task.frequency);
+  return {
+    ...task,
+    lastCompleted: completedAt.toISOString(),
+    nextDue: nextDue.toISOString(),
+  };
+}
+
+function findTaskInSnapshots(snapshots: CachedQuerySnapshot, taskId: string): Task | undefined {
+  for (const [, value] of snapshots) {
+    if (Array.isArray(value)) {
+      const task = (value as Task[]).find((candidate) => candidate.id === taskId);
+      if (task) return task;
+    }
+    if (value && typeof value === 'object') {
+      const task = (value as Partial<PlantWithTasks>).upcomingTasks?.find(
+        (candidate) => candidate.id === taskId
+      );
+      if (task) return task;
+    }
+  }
+  return undefined;
+}
+
+export function useCompleteTaskMutation(householdId: string | null) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (taskId: string) => taskService.completeTask(taskId),
+    onMutate: async (taskId: string) => {
+      await Promise.all([
+        queryClient.cancelQueries({ queryKey: ['tasks', householdId] }),
+        queryClient.cancelQueries({ queryKey: ['plants', householdId] }),
+      ]);
+
+      const previousTasks = queryClient.getQueriesData({
+        queryKey: ['tasks', householdId],
+      }) as CachedQuerySnapshot;
+      const previousPlants = queryClient.getQueriesData({
+        queryKey: ['plants', householdId],
+      }) as CachedQuerySnapshot;
+      const cachedTask = findTaskInSnapshots([...previousTasks, ...previousPlants], taskId);
+
+      if (cachedTask) {
+        const optimisticTask = optimisticCompletion(cachedTask);
+        previousTasks.forEach(([key, value]) =>
+          queryClient.setQueryData(key, replaceCompletedTaskInTaskQuery(key, value, optimisticTask))
+        );
+        queryClient.setQueriesData({ queryKey: ['plants', householdId] }, (value: unknown) =>
+          replaceCompletedTaskInCache(value, optimisticTask)
+        );
+      }
+
+      return { previousTasks, previousPlants };
+    },
+    onSuccess: (updatedTask) => {
+      // The mutation response is strongly authoritative. Do not immediately
+      // replace it with an eventually consistent list/GSI read, which can
+      // briefly return the old nextDue and make the completion look inert.
+      queryClient
+        .getQueriesData({ queryKey: ['tasks', householdId] })
+        .forEach(([key, value]) =>
+          queryClient.setQueryData(key, replaceCompletedTaskInTaskQuery(key, value, updatedTask))
+        );
+      queryClient.setQueriesData({ queryKey: ['plants', householdId] }, (value: unknown) =>
+        replaceCompletedTaskInCache(value, updatedTask)
+      );
+      toast.success('Task completed');
+    },
+    onError: (err, _taskId, context) => {
+      context?.previousTasks.forEach(([key, value]) => queryClient.setQueryData(key, value));
+      context?.previousPlants.forEach(([key, value]) => queryClient.setQueryData(key, value));
+      toast.error(getErrorMessage(err));
+    },
+    onSettled: () => {
+      // Mark related views stale for the next mount/focus without triggering
+      // the immediate eventually-consistent refetch that caused this bug.
+      queryClient.invalidateQueries({
+        queryKey: ['tasks', householdId],
+        refetchType: 'none',
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['plants', householdId],
+        refetchType: 'none',
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['household', householdId, 'activity'],
+        refetchType: 'none',
+      });
+    },
+  });
+}
 
 function useOptimisticTasksMutation(
   householdId: string | null,


### PR DESCRIPTION
## What changed

- Centralizes task completion into one optimistic React Query mutation used by Tasks, Dashboard, and Plant Detail.
- Writes the authoritative completion response into task and plant caches instead of immediately replacing it with an eventually consistent DynamoDB list read.
- Removes completed rows from the dashboard care queue, rolls recurring tasks forward in full lists, limits pending state to the selected row, and restores cache snapshots on failure.
- Adds regression tests for task-list, dashboard-queue, and plant-detail cache updates.

## Root cause

The completion endpoint returned the advanced task, but each screen ignored that response and immediately invalidated/refetched list queries. DynamoDB list/GSI reads can briefly return the old nextDue, visually undoing the click and making completion appear inert.

## Validation

- Frontend tests: 367 passed
- Focused Chromium E2E: 4 passed
- Frontend lint and typecheck passed
- Full frontend/backend build passed
- Repository-wide format/backend test gates remain blocked by pre-existing main issues: unrelated Prettier failures and Express 5 route-parity access to deprecated app.router.