### PR TITLE
feat(plants): add species-based care tasks

### DIFF
--- a/frontend/src/features/plants/AddPlantPage.tsx
+++ b/frontend/src/features/plants/AddPlantPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo } from 'react';
 import { useNavigate, useLocation, Link } from 'react-router-dom';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -8,7 +8,7 @@ import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
 import { ArrowLeftIcon, SparklesIcon, CameraIcon } from '@heroicons/react/24/outline';
 import { plantService, IdentificationSuggestion } from '@/services/plantService';
-import { taskService } from '@/services/taskService';
+import { suggestTaskTemplate, taskService } from '@/services/taskService';
 import { speciesService } from '@/services/speciesService';
 import { track } from '@/services/analytics';
 import { getErrorMessage } from '@/services/api';
@@ -25,6 +25,7 @@ import { downscaleImage } from '@/utils/image';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { useActiveHouseholdId } from '@/hooks/useActiveHouseholdId';
 import { toast } from '@/store/toastStore';
+import { taskTypeLabels } from '@/utils/taskTypeConfig';
 
 const MAX_BYTES = 5 * 1024 * 1024;
 const ACCEPTED_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
@@ -88,6 +89,7 @@ export function AddPlantPage() {
   const [suggestions, setSuggestions] = useState<IdentificationSuggestion[] | null>(null);
   const [identifyNotice, setIdentifyNotice] = useState<string | null>(null);
   const [isIdentifying, setIsIdentifying] = useState(false);
+  const [autoAddCareTasks, setAutoAddCareTasks] = useState(true);
 
   const {
     register,
@@ -106,6 +108,15 @@ export function AddPlantPage() {
   const speciesValue = watch('species') ?? '';
   const nameValue = watch('name') ?? '';
   const [perenualSpeciesId, setPerenualSpeciesId] = useState<number | null>(null);
+  const { data: taskTemplates = [] } = useQuery({
+    queryKey: ['task-templates'],
+    queryFn: taskService.listTemplates,
+    staleTime: 60 * 60 * 1000,
+  });
+  const suggestedTaskTemplate = useMemo(
+    () => suggestTaskTemplate(taskTemplates, speciesValue),
+    [speciesValue, taskTemplates]
+  );
 
   const handleFilePick = async (e: React.ChangeEvent<HTMLInputElement>) => {
     setError(null);
@@ -239,10 +250,20 @@ export function AddPlantPage() {
         await plantService.uploadImage(uploadUrl, blob, contentType, setUploadProgress);
         await plantService.confirmImageUpload(plant.id, imageUrl);
       }
-      // Best-effort: if Perenual gave us a watering cadence, seed a task. We
-      // don't block plant creation on this — the user can always add tasks
-      // manually if the suggestion fetch fails.
-      if (perenualSpeciesId) {
+      // Best-effort: seed the visible, user-approved species care plan. A
+      // curated bundle wins because it covers the whole routine; Perenual's
+      // water-only cadence remains the fallback for recognized species that
+      // do not match a curated bundle.
+      let tasksAdded = 0;
+      let taskSetupFailed = false;
+      if (autoAddCareTasks && suggestedTaskTemplate) {
+        try {
+          const result = await taskService.applyTemplate(plant.id, suggestedTaskTemplate.id);
+          tasksAdded = result.created.length;
+        } catch {
+          taskSetupFailed = true;
+        }
+      } else if (autoAddCareTasks && perenualSpeciesId) {
         try {
           const suggestion = await speciesService.careSuggestions(perenualSpeciesId);
           if (suggestion?.wateringDays && suggestion.wateringDays > 0) {
@@ -251,17 +272,26 @@ export function AddPlantPage() {
               type: 'water',
               frequency: suggestion.wateringDays,
             });
+            tasksAdded = 1;
           }
         } catch {
-          // Silent failure is intentional — plant is already saved.
+          taskSetupFailed = true;
         }
       }
-      return { plant, wasFirstPlant };
+      return { plant, wasFirstPlant, tasksAdded, taskSetupFailed };
     },
-    onSuccess: ({ plant, wasFirstPlant }) => {
+    onSuccess: ({ plant, wasFirstPlant, tasksAdded, taskSetupFailed }) => {
       track('plant_added', { ordinal: wasFirstPlant ? 'first' : 'subsequent' });
       queryClient.invalidateQueries({ queryKey: ['plants', householdId] });
-      toast.success(`${plant.name} added`);
+      queryClient.invalidateQueries({ queryKey: ['tasks', householdId] });
+      toast.success(
+        tasksAdded > 0
+          ? `${plant.name} added with ${tasksAdded} care task${tasksAdded === 1 ? '' : 's'}`
+          : `${plant.name} added`
+      );
+      if (taskSetupFailed) {
+        toast.info('The plant was saved, but its recommended tasks could not be added.');
+      }
       navigate(`/plants/${plant.id}`);
     },
     onError: (err) => {
@@ -438,7 +468,49 @@ export function AddPlantPage() {
 
           <PetToxicityNote perenualSpeciesId={perenualSpeciesId} />
 
-          <SuggestedCareCard perenualSpeciesId={perenualSpeciesId} />
+          <SuggestedCareCard
+            perenualSpeciesId={perenualSpeciesId}
+            showWateringTaskNotice={autoAddCareTasks && !suggestedTaskTemplate}
+          />
+
+          {suggestedTaskTemplate && (
+            <div
+              className="rounded-lg border border-primary-200 bg-primary-50 p-4"
+              aria-label="Recommended care tasks"
+            >
+              <label
+                htmlFor="auto-add-care-tasks"
+                className="flex cursor-pointer items-start gap-3"
+              >
+                <span className="sr-only">Automatically add recommended care tasks</span>
+                <input
+                  id="auto-add-care-tasks"
+                  type="checkbox"
+                  className="mt-1 h-4 w-4 rounded border-primary-300 text-primary-700 focus:ring-primary-500"
+                  checked={autoAddCareTasks}
+                  onChange={(event) => setAutoAddCareTasks(event.target.checked)}
+                />
+                <span>
+                  <span className="block text-sm font-semibold text-primary-900">
+                    Automatically add {suggestedTaskTemplate.name.toLowerCase()} care tasks
+                  </span>
+                  <span className="mt-1 block text-xs text-primary-800">
+                    Based on “{speciesValue}”. You can edit or remove these tasks any time.
+                  </span>
+                </span>
+              </label>
+              <ul className="mt-3 grid gap-2 pl-7 text-xs text-primary-900 sm:grid-cols-2">
+                {suggestedTaskTemplate.tasks.map((task) => (
+                  <li key={`${task.type}-${task.customType ?? ''}`}>
+                    <span className="font-medium">
+                      {task.customType || taskTypeLabels[task.type]}
+                    </span>{' '}
+                    every {task.frequencyDays} day{task.frequencyDays === 1 ? '' : 's'}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
 
           <Input
             label="Location"

--- a/frontend/src/features/plants/SuggestedCareCard.tsx
+++ b/frontend/src/features/plants/SuggestedCareCard.tsx
@@ -3,6 +3,8 @@ import { speciesService } from '@/services/speciesService';
 
 interface SuggestedCareCardProps {
   perenualSpeciesId: number | null;
+  /** The add flow may use a richer curated bundle instead of this fallback. */
+  showWateringTaskNotice: boolean;
 }
 
 /**
@@ -13,7 +15,10 @@ interface SuggestedCareCardProps {
  * the watering task is created from the suggestion *after* the plant is
  * saved (see AddPlantPage.applySuggestedSchedule).
  */
-export function SuggestedCareCard({ perenualSpeciesId }: SuggestedCareCardProps) {
+export function SuggestedCareCard({
+  perenualSpeciesId,
+  showWateringTaskNotice,
+}: SuggestedCareCardProps) {
   const { data, isLoading } = useQuery({
     queryKey: ['species', 'care-suggestions', perenualSpeciesId],
     queryFn: () => speciesService.careSuggestions(perenualSpeciesId!),
@@ -30,7 +35,7 @@ export function SuggestedCareCard({ perenualSpeciesId }: SuggestedCareCardProps)
     >
       <p className="font-semibold text-primary-900">Suggested care</p>
       <p className="mt-1 text-primary-900">{data.summary}</p>
-      {data.wateringDays !== null && (
+      {showWateringTaskNotice && data.wateringDays !== null && (
         <p className="mt-2 text-xs text-primary-700">
           We&rsquo;ll create a watering task on a {data.wateringDays}-day cadence after you save
           this plant. You can edit it any time.

--- a/frontend/src/services/taskService.test.ts
+++ b/frontend/src/services/taskService.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { suggestTaskTemplate, TaskTemplate } from './taskService';
+
+const templates: TaskTemplate[] = [
+  {
+    id: 'tropical',
+    name: 'Tropical',
+    description: '',
+    suitsKeywords: ['monstera', 'philodendron', 'aroid'],
+    tasks: [{ type: 'water', frequencyDays: 7 }],
+  },
+  {
+    id: 'succulent',
+    name: 'Succulent',
+    description: '',
+    suitsKeywords: ['succulent', 'aloe'],
+    tasks: [{ type: 'water', frequencyDays: 21 }],
+  },
+];
+
+describe('suggestTaskTemplate', () => {
+  it('matches species names case-insensitively', () => {
+    expect(suggestTaskTemplate(templates, 'Monstera deliciosa')?.id).toBe('tropical');
+    expect(suggestTaskTemplate(templates, 'ALOE VERA')?.id).toBe('succulent');
+  });
+
+  it('uses the template with the most matching keywords', () => {
+    expect(suggestTaskTemplate(templates, 'monstera aroid')?.id).toBe('tropical');
+  });
+
+  it('does not guess for unknown or empty species', () => {
+    expect(suggestTaskTemplate(templates, 'Quercus robur')).toBeUndefined();
+    expect(suggestTaskTemplate(templates, ' ')).toBeUndefined();
+    expect(suggestTaskTemplate(templates, null)).toBeUndefined();
+  });
+});

--- a/frontend/src/services/taskService.ts
+++ b/frontend/src/services/taskService.ts
@@ -32,6 +32,30 @@ export interface TaskFilters {
   overdue?: boolean;
 }
 
+/**
+ * Pick the most specific curated task bundle for a species name. Unknown
+ * species deliberately return undefined so the UI never invents a schedule.
+ */
+export function suggestTaskTemplate(
+  templates: TaskTemplate[],
+  species: string | null | undefined
+): TaskTemplate | undefined {
+  const normalized = species?.trim().toLowerCase();
+  if (!normalized) return undefined;
+
+  let bestMatch: { template: TaskTemplate; score: number } | undefined;
+  for (const template of templates) {
+    const score = template.suitsKeywords.reduce(
+      (total, keyword) => total + (normalized.includes(keyword.toLowerCase()) ? 1 : 0),
+      0
+    );
+    if (score > 0 && (!bestMatch || score > bestMatch.score)) {
+      bestMatch = { template, score };
+    }
+  }
+  return bestMatch?.template;
+}
+
 /** Why a snooze happened — mirrored from backend snoozeReasonEnum. */
 export type SnoozeReason = 'rain' | 'frost' | 'heat' | 'other';
 

--- a/frontend/tests/e2e/create-plant.spec.ts
+++ b/frontend/tests/e2e/create-plant.spec.ts
@@ -36,16 +36,25 @@ test.describe('Create plant flow', () => {
 
     // Use a uniquely-named plant so re-runs against a sticky local server
     // don't collide and produce ambiguous selectors.
-    const uniqueName = `Hibiscus ${Date.now()}`;
+    const uniqueName = `Monstera ${Date.now()}`;
     await page.getByLabel(/plant name/i).fill(uniqueName);
-    // Hibiscus is in the species catalog (added this session); typing the
-    // common name should produce a usable suggestion path.
-    await page.getByLabel(/species/i).fill('Hibiscus');
+    await page.getByLabel(/species/i).fill('Monstera deliciosa');
+
+    const autoTasks = page.getByRole('checkbox', {
+      name: /automatically add recommended care tasks/i,
+    });
+    await expect(autoTasks).toBeChecked();
+    await expect(page.getByLabel('Recommended care tasks', { exact: true })).toContainText(
+      'Water every 7 days'
+    );
 
     await page.getByRole('button', { name: /add plant/i }).click();
 
     // After save we should land on the new plant's detail page.
     await expect(page.getByRole('heading', { name: uniqueName })).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText('Every 7 days')).toBeVisible();
+    await expect(page.getByText('Every 30 days')).toBeVisible();
+    await expect(page.getByText('Every 90 days')).toBeVisible();
 
     // No JS errors thrown during the round-trip.
     expect(consoleErrors).toEqual([]);

--- a/frontend/tests/unit/features/AddPlantPage.test.tsx
+++ b/frontend/tests/unit/features/AddPlantPage.test.tsx
@@ -6,6 +6,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AddPlantPage } from '@/features/plants/AddPlantPage';
 import { plantService } from '@/services/plantService';
 import { speciesService, type SpeciesSearchResponse } from '@/services/speciesService';
+import { taskService } from '@/services/taskService';
 
 vi.mock('@/services/plantService', () => ({
   plantService: {
@@ -19,6 +20,13 @@ vi.mock('@/services/speciesService', () => ({
     detail: vi.fn(),
     careSuggestions: vi.fn(),
   },
+}));
+
+vi.mock('@/services/taskService', () => ({
+  taskService: {
+    listTemplates: vi.fn(),
+  },
+  suggestTaskTemplate: vi.fn(),
 }));
 
 // jsdom has no real image decoder, so the canvas pipeline never resolves —
@@ -68,6 +76,7 @@ describe('AddPlantPage acceptSuggestion race guard', () => {
       ],
     });
     vi.mocked(speciesService.careSuggestions).mockResolvedValue(null);
+    vi.mocked(taskService.listTemplates).mockResolvedValue([]);
   });
 
   it('does not let a slower earlier pick clobber a faster later one', async () => {


### PR DESCRIPTION
## What changed

- Matches a typed species against the existing curated care-template catalog.
- Shows the recommended tasks and cadences before save, with automatic creation enabled by default and an opt-out checkbox.
- Applies the full bundle after plant creation; Perenual watering remains the fallback when no curated species match exists.
- Avoids duplicate/conflicting watering notices when a curated bundle is selected.
- Keeps plant creation successful if task setup fails and surfaces the partial result to the user.
- Adds matching unit coverage and extends the create-plant E2E through the generated task list.

## Product direction

The implementation uses an automatic, visible, reversible model: users get the convenience of default-on automation, can inspect the exact schedule before committing, and can opt out. Unknown species receive no invented schedule. Alternatives considered included silent server-side creation, a manual recommendation button, and purely Perenual-derived schedules; the chosen approach offers better trust and works with the existing curated catalog without adding a vendor dependency.

## Validation

- Frontend tests: 367 passed
- Focused Chromium create-plant E2E: passed and verified 3 generated Monstera tasks
- Frontend lint and typecheck passed
- Full frontend/backend build passed
- Repository-wide format/backend test gates remain blocked by pre-existing main issues: unrelated Prettier failures and Express 5 route-parity access to deprecated app.router.