### PR TITLE
chore(release): prepare v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,16 @@ reaches 1.0.0 (pre-1.0: minor bumps may include breaking changes — see
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-07-10
+
 ### Fixed
 
+- Completing a task now updates the UI immediately and can no longer be visually undone by an eventually consistent list refresh.
 - Downscale photos client-side before the "Identify from photo" upload, closing the iPhone leaf-health upload size-mismatch class of bugs.
 
 ### Added
 
+- New plants can automatically receive a visible, editable care-task bundle based on their species, with an opt-out before saving.
 - README `## Standards conformance` table declaring applicability/state for all 11 vendored standards (DOC-11/12/13).
 - `docs/RESPONSIBLE-TECH-AUDITS.md`: ASVS level, RTF §A–F applicability, SEC-40 §F declarations, and the dated AI-EVALUATION-STANDARD waiver (AIEV-01).
 - `evals/` — starter AI-evaluation harness for the Bedrock plant-care chat: a corpus-grounded benchmark set, a citation/grounding guard with unit tests, and a committed `eval-baseline.json` wired into a new CI job (AIEV-02, AIEV-12, AIEV-26).

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "Family Greenhouse API — AWS Lambda + DynamoDB single-table + Cognito, with a local Express mock that mirrors the handlers.",
   "license": "Elastic-2.0",
   "private": true,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "Family Greenhouse web app — React + TypeScript + Vite PWA for collaborative household plant care.",
   "license": "Elastic-2.0",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "family-greenhouse",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "family-greenhouse",
-      "version": "0.13.1",
+      "version": "0.14.0",
       "license": "Elastic-2.0",
       "workspaces": [
         "frontend",
@@ -37,7 +37,7 @@
       }
     },
     "backend": {
-      "version": "0.13.1",
+      "version": "0.14.0",
       "license": "Elastic-2.0",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.1073.0",
@@ -448,7 +448,7 @@
       }
     },
     "frontend": {
-      "version": "0.13.1",
+      "version": "0.14.0",
       "license": "Elastic-2.0",
       "dependencies": {
         "@fontsource-variable/instrument-sans": "^5.0.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "family-greenhouse",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "license": "Elastic-2.0",
   "private": true,
   "description": "A shared plant-care journal for the whole household — per-plant schedules, reminders that find the right person across browser/email/SMS, and a care log everyone can see. React + TypeScript on AWS Lambda + DynamoDB + Cognito.",


### PR DESCRIPTION
## Release

Prepares the production release containing #200 and #201.

- Bumps root, frontend, backend, and lockfile versions to 0.14.0.
- Promotes the accumulated Unreleased changelog into a dated 0.14.0 section.
- Calls out the task-completion fix and species-based automatic care tasks.

## Validation

- Version metadata is 0.14.0 across all packages.
- Scoped Prettier check passed.
- Root typecheck passed.
- Production dependency audit reports 0 vulnerabilities.
- Both implementation PRs passed full CI, Lighthouse, bundle-size, security, and Playwright gates.