### PR TITLE
fix(notifications): fail closed when sms unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ reaches 1.0.0 (pre-1.0: minor bumps may include breaking changes — see
 
 ## [Unreleased]
 
+## [0.14.2] - 2026-07-10
+
+### Fixed
+
+- SMS verification now returns a clear service-unavailable response when delivery is disabled or rejected instead of falsely reporting that a code was sent.
+- Failed verification deliveries remove their unusable pending code, and SMS dry-run logs no longer expose phone numbers or one-time codes.
+- Wired the root Terraform SMS gate through to the API module so production configuration can enable delivery after AWS approves SMS production access and origination registration.
+
 ## [0.14.1] - 2026-07-10
 
 ### Fixed

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Family Greenhouse API — AWS Lambda + DynamoDB single-table + Cognito, with a local Express mock that mirrors the handlers.",
   "license": "Elastic-2.0",
   "private": true,

--- a/backend/src/services/notificationPrefs.ts
+++ b/backend/src/services/notificationPrefs.ts
@@ -245,8 +245,9 @@ function hashCode(code: string): string {
  * Start verifying a phone number: store SHA-256(code) + expiry + attempt
  * counter on `USER#{id} / PHONE_VERIFY` (overwriting any previous attempt —
  * requesting a new code invalidates the old one), then text the code via SNS.
- * When SMS is disabled (`SMS_NOTIFICATIONS_ENABLED` ≠ 1) `sendSms` dry-run
- * logs the message, so the flow is exercisable in dev without spending money.
+ * If delivery is disabled or SNS rejects the message, remove the pending row
+ * and fail loudly. A verification endpoint must never claim success for a
+ * code that did not leave the service.
  */
 export async function startPhoneVerification(
   userId: string,
@@ -274,10 +275,34 @@ export async function startPhoneVerification(
       },
     })
   );
-  await smsNotifier.sendSms({
-    to: phone,
-    text: `Family Greenhouse verification code: ${code}. It expires in 10 minutes.`,
-  });
+  try {
+    const sent = await smsNotifier.sendSms({
+      to: phone,
+      text: `Family Greenhouse verification code: ${code}. It expires in 10 minutes.`,
+    });
+    if (!sent) throw new Error('SMS delivery is disabled');
+  } catch (err) {
+    try {
+      await dynamodb.send(
+        new DeleteCommand({
+          TableName: TABLE_NAME,
+          Key: { PK: `USER#${userId}`, SK: 'PHONE_VERIFY' },
+        })
+      );
+    } catch (cleanupErr) {
+      logger.error(
+        { err: cleanupErr, userId, msg: 'phone_verification_cleanup_failed' },
+        'phone_verification_cleanup_failed'
+      );
+    }
+    logger.warn(
+      { err, userId, msg: 'phone_verification_delivery_failed' },
+      'phone_verification_delivery_failed'
+    );
+    throw createHttpError(503, 'SMS verification is temporarily unavailable. Try again later.', {
+      expose: true,
+    });
+  }
   logger.info({ userId, msg: 'phone_verification_started' }, 'phone_verification_started');
 }
 

--- a/backend/src/services/smsNotifier.ts
+++ b/backend/src/services/smsNotifier.ts
@@ -40,7 +40,9 @@ export async function sendSms(msg: SmsMessage): Promise<boolean> {
   const text = msg.text.slice(0, 140);
 
   if (process.env.SMS_NOTIFICATIONS_ENABLED !== '1') {
-    logger.info({ msg: 'sms_dry_run', to: msg.to, body: text }, 'sms_dry_run');
+    // Never log destinations or message bodies here. Verification messages
+    // contain both a phone number and a live one-time code.
+    logger.info({ msg: 'sms_dry_run' }, 'sms_dry_run');
     return false;
   }
 

--- a/backend/tests/unit/services/phoneVerification.test.ts
+++ b/backend/tests/unit/services/phoneVerification.test.ts
@@ -28,7 +28,7 @@ vi.mock('../../../src/utils/dynamodb.js', () => ({
 }));
 
 vi.mock('../../../src/services/smsNotifier.js', () => ({
-  sendSms: vi.fn().mockResolvedValue(undefined),
+  sendSms: vi.fn().mockResolvedValue(true),
 }));
 
 const NOW = new Date('2026-06-11T12:00:00.000Z');
@@ -113,6 +113,31 @@ describe('phone verification', () => {
     });
     expect(rows.size).toBe(0);
     expect(smsNotifier.sendSms).not.toHaveBeenCalled();
+  });
+
+  it('fails with 503 and removes the pending code when SMS is disabled', async () => {
+    const rows = await mockTable();
+    const smsNotifier = await import('../../../src/services/smsNotifier.js');
+    vi.mocked(smsNotifier.sendSms).mockResolvedValueOnce(false);
+    const { startPhoneVerification } = await import('../../../src/services/notificationPrefs.js');
+
+    await expect(startPhoneVerification('u1', PHONE, NOW)).rejects.toMatchObject({
+      statusCode: 503,
+      message: 'SMS verification is temporarily unavailable. Try again later.',
+    });
+    expect(rows.has('USER#u1|PHONE_VERIFY')).toBe(false);
+  });
+
+  it('fails with 503 and removes the pending code when SNS rejects delivery', async () => {
+    const rows = await mockTable();
+    const smsNotifier = await import('../../../src/services/smsNotifier.js');
+    vi.mocked(smsNotifier.sendSms).mockRejectedValueOnce(new Error('SNS sandbox'));
+    const { startPhoneVerification } = await import('../../../src/services/notificationPrefs.js');
+
+    await expect(startPhoneVerification('u1', PHONE, NOW)).rejects.toMatchObject({
+      statusCode: 503,
+    });
+    expect(rows.has('USER#u1|PHONE_VERIFY')).toBe(false);
   });
 
   it('happy path: correct code stamps phoneVerified + number and deletes the row', async () => {

--- a/backend/tests/unit/services/smsNotifier.test.ts
+++ b/backend/tests/unit/services/smsNotifier.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const snsSendMock = vi.fn();
+const loggerInfoMock = vi.fn();
 vi.mock('@aws-sdk/client-sns', () => ({
   SNSClient: vi.fn(function () {
     return { send: snsSendMock };
@@ -8,6 +9,9 @@ vi.mock('@aws-sdk/client-sns', () => ({
   PublishCommand: vi.fn(function (input) {
     return { input, kind: 'Publish' };
   }),
+}));
+vi.mock('../../../src/utils/logger.js', () => ({
+  logger: { info: loggerInfoMock },
 }));
 
 const ORIGINAL = process.env;
@@ -32,8 +36,11 @@ describe('smsNotifier', () => {
     process.env = { ...ORIGINAL };
     delete process.env.SMS_NOTIFICATIONS_ENABLED;
     const { sendSms } = await import('../../../src/services/smsNotifier.js');
-    await sendSms({ to: '+15551234567', text: 'hello' });
+    const sent = await sendSms({ to: '+15551234567', text: 'secret verification 123456' });
+    expect(sent).toBe(false);
     expect(snsSendMock).not.toHaveBeenCalled();
+    expect(JSON.stringify(loggerInfoMock.mock.calls)).not.toContain('+15551234567');
+    expect(JSON.stringify(loggerInfoMock.mock.calls)).not.toContain('123456');
   });
 
   it('publishes to SNS when enabled, with Transactional attribute', async () => {

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -62,7 +62,7 @@ For any EU user/customer:
 SMS notifications are currently **gated off** (`SMS_NOTIFICATIONS_ENABLED` unset). **Do not enable SMS in production until all of the following exist**, or you risk TCPA liability (statutory damages per message):
 
 1. **Explicit, logged opt-in** — the user must affirmatively check a box to receive SMS, with consent timestamp + the exact consent language stored. A pre-checked box is not consent.
-2. **Phone-number verification** — send a one-time code and verify it before the number can receive any notification (prevents sending to a number the user mistyped or doesn't own). _This flow does not exist yet — it's the blocking work item._
+2. **Phone-number verification** — send a one-time code and verify it before the number can receive any notification (prevents sending to a number the user mistyped or doesn't own). Implemented; production delivery remains gated on AWS SMS production access and origination registration.
 3. **STOP / unsubscribe** — honor inbound STOP, and include opt-out guidance ("Reply STOP to unsubscribe") in messages. Wire SNS opt-out handling.
 4. **Quiet hours / DND** — already implemented (`isInDndWindow`); keep it.
 5. **Records** — retain consent + opt-out records.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -115,14 +115,17 @@ We mark messages as `Transactional` (vs `Promotional`) — this gets you better 
 
 In SNS sandbox mode (default for new accounts), you can only send to verified phone numbers. To get out of sandbox you fill in a use-case form in the SNS console; AWS approves on the order of a day. Until then your test recipients need to verify themselves via the console.
 
-#### Phone-number verification (TODO)
+Production must also set `sms_notifications_enabled = "1"` in the root
+Terraform environment after sandbox exit and origination registration. The
+phone-verification endpoint returns 503 while the flag is off or SNS rejects
+delivery; it never reports a code as sent unless SNS accepted the publish.
 
-We don't currently send a verification code before enabling SMS for a new phone number. That's a real gap — a user could enter someone else's number and we'd happily send reminders to it. The right fix is to wire up a 2-step:
+#### Phone-number verification
 
-1. User enters phone, we send a confirmation code via SNS
-2. User enters code, we mark the number verified and persist
-
-It's a half-day's work; deferred until SMS gets actual usage. Tracked in [`production-checklist.md`](production-checklist.md).
+Users enter an E.164 number, receive a six-digit one-time code, and confirm it
+before SMS can be enabled. Codes expire after ten minutes, are stored only as
+hashes, and lock after five incorrect attempts. Changing the number clears its
+verified state.
 
 ## Sending arbitrary notifications
 
@@ -134,7 +137,7 @@ All channels degrade to structured `pino` log lines when their env vars aren't s
 
 ```
 {"level":"info","msg":"email_dry_run","to":"alice@example.com","subject":"Plant care reminder"}
-{"level":"info","msg":"sms_dry_run","to":"+15551234567","body":"3 tasks due"}
+{"level":"info","msg":"sms_dry_run"}
 {"level":"info","msg":"push_dry_run","userId":"user-1","count":2,"payload":{...}}
 ```
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Family Greenhouse web app — React + TypeScript + Vite PWA for collaborative household plant care.",
   "license": "Elastic-2.0",
   "type": "module",

--- a/infrastructure/environments/production/terraform.tfvars
+++ b/infrastructure/environments/production/terraform.tfvars
@@ -27,6 +27,12 @@ monthly_budget_usd = "30"
 # cost-amplified by concurrency. Beta default is tracking-only ("").
 identify_metering_enabled = "1"
 
+# Keep SMS fail-closed until AWS approves SMS Production Access in us-east-1
+# and the required origination identity/registration is active. Once both are
+# confirmed, change this to "1" and deploy; the API returns 503 while disabled
+# instead of claiming that an undelivered verification code was sent.
+sms_notifications_enabled = ""
+
 # --- Stripe billing ---
 # Price IDs are NOT secret (they're just `price_…` references), so they live
 # here. Leaving one "" disables that cadence: an empty monthly ID makes the whole

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -106,6 +106,7 @@ module "api" {
   openweather_daily_budget   = var.openweather_daily_budget
   bedrock_embed_model_id     = var.bedrock_embed_model_id
   identify_metering_enabled  = var.identify_metering_enabled
+  sms_notifications_enabled  = var.sms_notifications_enabled
 
   # Stripe. See variables.tf — these must be declared at THIS level too, or
   # Terraform silently drops the tfvars/TF_VAR_* values (undeclared variable

--- a/infrastructure/modules/api/variables.tf
+++ b/infrastructure/modules/api/variables.tf
@@ -142,7 +142,7 @@ variable "web_push_vapid_subject" {
 }
 
 variable "sms_notifications_enabled" {
-  description = "Set to '1' to actually publish SMS via SNS. Off by default; reminder code dry-runs to logs."
+  description = "Set to '1' only with SMS production access and an approved origination identity. Off by default; verification fails with 503 and reminders dry-run."
   type        = string
   default     = ""
 }

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -123,6 +123,17 @@ variable "identify_metering_enabled" {
   default     = ""
 }
 
+variable "sms_notifications_enabled" {
+  description = "Set to '1' only after this region has SMS production access and an approved origination identity. Blank keeps paid SMS disabled."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = contains(["", "1"], var.sms_notifications_enabled)
+    error_message = "sms_notifications_enabled must be blank or '1'."
+  }
+}
+
 # --- Stripe ---
 # Mirrors modules/api/variables.tf. These MUST be declared here too: Terraform
 # only warns (and silently drops the value) on an undeclared variable passed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "family-greenhouse",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "family-greenhouse",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "license": "Elastic-2.0",
       "workspaces": [
         "frontend",
@@ -37,7 +37,7 @@
       }
     },
     "backend": {
-      "version": "0.14.1",
+      "version": "0.14.2",
       "license": "Elastic-2.0",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.1073.0",
@@ -448,7 +448,7 @@
       }
     },
     "frontend": {
-      "version": "0.14.1",
+      "version": "0.14.2",
       "license": "Elastic-2.0",
       "dependencies": {
         "@fontsource-variable/instrument-sans": "^5.0.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "family-greenhouse",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "license": "Elastic-2.0",
   "private": true,
   "description": "A shared plant-care journal for the whole household — per-plant schedules, reminders that find the right person across browser/email/SMS, and a care log everyone can see. React + TypeScript on AWS Lambda + DynamoDB + Cognito.",


### PR DESCRIPTION
## Incident
Production SMS verification reported success while the notifications Lambda was configured to dry-run SMS. AWS account 014248889144 is also still in the us-east-1 SMS sandbox, so ordinary user destinations cannot receive messages.

## Mitigation
- return an exposed 503 when SMS is disabled or SNS rejects delivery
- delete pending verification rows when delivery fails
- stop logging destination phone numbers and one-time-code message bodies
- wire the missing root Terraform SMS gate into the API module
- keep production sending fail-closed until AWS approves SMS Production Access and origination registration
- prepare patch release v0.14.2

## Verification
- 371 frontend tests
- 1083 backend tests
- lint and TypeScript checks
- Terraform format and validate
- dependency and secret scans

## Remaining provider dependency
AWS Support must approve SMS Production Access for us-east-1 and the required origination identity/registration must be active before sms_notifications_enabled can safely change from blank to 1.