### PR TITLE
feat(seo): enrich route metadata and structured data

### DIFF
--- a/frontend/src/components/NotFoundPage.tsx
+++ b/frontend/src/components/NotFoundPage.tsx
@@ -1,7 +1,14 @@
 import { Link } from 'react-router-dom';
 import { EmptySearch } from './illustrations/EmptySearch';
+import { useMetaTags } from '@/hooks/useMetaTags';
 
 export function NotFoundPage() {
+  useMetaTags({
+    title: 'Page not found — Family Greenhouse',
+    description: 'This page does not exist in Family Greenhouse.',
+    robots: 'noindex, nofollow',
+  });
+
   return (
     <main className="min-h-screen flex flex-col items-center justify-center px-4 bg-paper text-center">
       <EmptySearch className="h-36 w-auto" />

--- a/frontend/src/features/blog/BlogPost.tsx
+++ b/frontend/src/features/blog/BlogPost.tsx
@@ -21,30 +21,43 @@ export function BlogPost() {
           title: `${post.title} — Family Greenhouse`,
           description: post.description,
           canonical: `${SITE_URL}/blog/${post.slug}`,
+          ogType: 'article',
           // Article schema makes the post eligible for Google's article
           // rich-results treatment. We don't have author photos or a
           // publisher logo URL set up yet — those are nice-to-haves that
           // strengthen eligibility but aren't required.
           jsonLd: {
             '@context': 'https://schema.org',
-            '@type': 'Article',
-            headline: post.title,
-            description: post.description,
-            datePublished: post.date,
-            dateModified: post.date,
-            author: { '@type': 'Organization', name: 'Family Greenhouse' },
-            publisher: {
-              '@type': 'Organization',
-              name: 'Family Greenhouse',
-              logo: {
-                '@type': 'ImageObject',
-                url: `${SITE_URL}/brand/icon-512.png`,
+            '@graph': [
+              {
+                '@type': 'Article',
+                headline: post.title,
+                description: post.description,
+                datePublished: post.date,
+                dateModified: post.date,
+                author: { '@type': 'Organization', name: 'Family Greenhouse' },
+                publisher: {
+                  '@type': 'Organization',
+                  name: 'Family Greenhouse',
+                  logo: {
+                    '@type': 'ImageObject',
+                    url: `${SITE_URL}/brand/icon-512.png`,
+                  },
+                },
+                mainEntityOfPage: {
+                  '@type': 'WebPage',
+                  '@id': `${SITE_URL}/blog/${post.slug}`,
+                },
               },
-            },
-            mainEntityOfPage: {
-              '@type': 'WebPage',
-              '@id': `${SITE_URL}/blog/${post.slug}`,
-            },
+              {
+                '@type': 'BreadcrumbList',
+                itemListElement: [
+                  { '@type': 'ListItem', position: 1, name: 'Home', item: SITE_URL },
+                  { '@type': 'ListItem', position: 2, name: 'Blog', item: `${SITE_URL}/blog` },
+                  { '@type': 'ListItem', position: 3, name: post.title },
+                ],
+              },
+            ],
           },
         }
       : {}

--- a/frontend/src/features/care/CareGuidePage.tsx
+++ b/frontend/src/features/care/CareGuidePage.tsx
@@ -41,6 +41,7 @@ export function CareGuidePage() {
           title: guide.metaTitle,
           description: guide.metaDescription,
           canonical: `${SITE}/care/${guide.slug}`,
+          ogType: 'article',
           jsonLd: {
             '@context': 'https://schema.org',
             '@graph': [
@@ -76,6 +77,14 @@ export function CareGuidePage() {
                   name: f.q,
                   acceptedAnswer: { '@type': 'Answer', text: f.a },
                 })),
+              },
+              {
+                '@type': 'BreadcrumbList',
+                itemListElement: [
+                  { '@type': 'ListItem', position: 1, name: 'Home', item: SITE },
+                  { '@type': 'ListItem', position: 2, name: 'Plant care', item: `${SITE}/care` },
+                  { '@type': 'ListItem', position: 3, name: `${guide.commonName} care` },
+                ],
               },
             ],
           },

--- a/frontend/src/features/landing/LandingPage.tsx
+++ b/frontend/src/features/landing/LandingPage.tsx
@@ -37,6 +37,8 @@ import { GrowthRingsIcon } from '@/components/icons/GrowthRingsIcon';
 import { RootLockIcon } from '@/components/icons/RootLockIcon';
 import { useHeroVariant, HERO_EXPERIMENT, type Variant } from '@/lib/experiment';
 import { track, registerSuperProperties } from '@/services/analytics';
+import { useMetaTags } from '@/hooks/useMetaTags';
+import { SITE_URL, siteUrl } from '@/config/site';
 import clsx from 'clsx';
 
 // Hero copy for the two framings under test. Variant A (control) is the
@@ -561,6 +563,51 @@ export function LandingPage() {
   // A/B test of the hero framing (control vs solo-first). Bucketing is
   // stable per browser; see lib/experiment.ts.
   const variant = useHeroVariant();
+
+  useMetaTags({
+    title: 'Family Greenhouse — Shared Plant Care & Watering Reminders',
+    description:
+      'Share plant watering schedules, reminders, care logs, and tasks with your household. Family Greenhouse is free for up to 10 plants.',
+    canonical: siteUrl('/'),
+    ogType: 'website',
+    ogImage: siteUrl('/brand/og-image.png'),
+    jsonLd: {
+      '@context': 'https://schema.org',
+      '@graph': [
+        {
+          '@type': 'Organization',
+          '@id': `${SITE_URL}/#organization`,
+          name: 'Family Greenhouse',
+          url: SITE_URL,
+          logo: siteUrl('/brand/icon-512.png'),
+        },
+        {
+          '@type': 'WebSite',
+          '@id': `${SITE_URL}/#website`,
+          name: 'Family Greenhouse',
+          url: SITE_URL,
+          publisher: { '@id': `${SITE_URL}/#organization` },
+        },
+        {
+          '@type': 'SoftwareApplication',
+          '@id': `${SITE_URL}/#app`,
+          name: 'Family Greenhouse',
+          applicationCategory: 'LifestyleApplication',
+          operatingSystem: 'Web',
+          description:
+            'A collaborative plant care app for household watering schedules, reminders, tasks, and care logs.',
+          url: SITE_URL,
+          offers: {
+            '@type': 'Offer',
+            price: '0',
+            priceCurrency: 'USD',
+            description: 'Free for up to 10 plants',
+          },
+          publisher: { '@id': `${SITE_URL}/#organization` },
+        },
+      ],
+    },
+  });
 
   useEffect(() => {
     // Fire once per landing-page mount: records the impression and pins the

--- a/frontend/src/hooks/useMetaTags.ts
+++ b/frontend/src/hooks/useMetaTags.ts
@@ -17,10 +17,16 @@ export interface MetaTags {
   description?: string;
   /** Path under /og-cards/ for a per-post OG image, if shipped. */
   ogImage?: string;
+  /** Open Graph object type. Marketing pages default to `website`; posts and
+   * care guides should use `article`. */
+  ogType?: 'website' | 'article';
   /** Absolute canonical URL for this route. Sets <link rel="canonical"> + og:url
    *  so Google (which renders the SPA) attributes the page to the right URL
    *  instead of guessing — important for the indexable marketing routes. */
   canonical?: string;
+  /** Search-engine indexing policy. Use `noindex, nofollow` for app-only,
+   * tokenized, or error pages that can otherwise look like valid SPA URLs. */
+  robots?: 'index, follow' | 'noindex, follow' | 'noindex, nofollow';
   /** Optional JSON-LD payload (Article, FAQ, etc.). The shape isn't
    *  validated here — caller is responsible for emitting valid schema.org. */
   jsonLd?: Record<string, unknown>;
@@ -77,12 +83,21 @@ export function useMetaTags(meta: MetaTags): void {
     if (meta.description) {
       cleanups.push(setMeta('description', meta.description));
       cleanups.push(setMeta('og:description', meta.description, 'property'));
+      cleanups.push(setMeta('twitter:description', meta.description));
     }
     if (meta.title) {
       cleanups.push(setMeta('og:title', meta.title, 'property'));
+      cleanups.push(setMeta('twitter:title', meta.title));
     }
     if (meta.ogImage) {
       cleanups.push(setMeta('og:image', meta.ogImage, 'property'));
+      cleanups.push(setMeta('twitter:image', meta.ogImage));
+    }
+    if (meta.ogType) {
+      cleanups.push(setMeta('og:type', meta.ogType, 'property'));
+    }
+    if (meta.robots) {
+      cleanups.push(setMeta('robots', meta.robots));
     }
     if (meta.canonical) {
       cleanups.push(setCanonical(meta.canonical));
@@ -103,5 +118,13 @@ export function useMetaTags(meta: MetaTags): void {
     return () => {
       for (const cleanup of cleanups) cleanup();
     };
-  }, [meta.title, meta.description, meta.ogImage, meta.canonical, jsonLdKey]);
+  }, [
+    meta.title,
+    meta.description,
+    meta.ogImage,
+    meta.ogType,
+    meta.canonical,
+    meta.robots,
+    jsonLdKey,
+  ]);
 }

--- a/frontend/tests/unit/hooks/useMetaTags.test.tsx
+++ b/frontend/tests/unit/hooks/useMetaTags.test.tsx
@@ -22,6 +22,36 @@ describe('useMetaTags canonical', () => {
     expect(document.querySelector('meta[property="og:url"]')).toBeNull();
   });
 
+  it('keeps Open Graph, Twitter, and robots metadata in sync per route', () => {
+    const { unmount } = renderHook(() =>
+      useMetaTags({
+        title: 'A dramatic fern',
+        description: 'Fern care without the guesswork.',
+        ogImage: 'https://familygreenhouse.net/fern.png',
+        ogType: 'article',
+        robots: 'noindex, follow',
+      })
+    );
+
+    expect(document.querySelector('meta[name="twitter:title"]')?.getAttribute('content')).toBe(
+      'A dramatic fern'
+    );
+    expect(
+      document.querySelector('meta[name="twitter:description"]')?.getAttribute('content')
+    ).toBe('Fern care without the guesswork.');
+    expect(document.querySelector('meta[name="twitter:image"]')?.getAttribute('content')).toBe(
+      'https://familygreenhouse.net/fern.png'
+    );
+    expect(document.querySelector('meta[property="og:type"]')?.getAttribute('content')).toBe(
+      'article'
+    );
+    expect(document.querySelector('meta[name="robots"]')?.getAttribute('content')).toBe(
+      'noindex, follow'
+    );
+
+    unmount();
+  });
+
   it('overrides a pre-existing homepage canonical and restores its href on unmount', () => {
     // If a canonical link already exists (e.g. one route navigating to another
     // before cleanup), the hook overrides its href and restores it on unmount


### PR DESCRIPTION
## What changed

- adds a self-referencing homepage canonical and route-level Open Graph metadata
- adds `Organization`, `WebSite`, and `SoftwareApplication` JSON-LD to the homepage
- adds `BreadcrumbList` schema and `og:type=article` to blog posts and plant-care guides
- keeps Twitter title, description, and image tags synchronized with route metadata
- adds configurable robots directives and marks the SPA 404 page `noindex, nofollow`
- expands metadata-hook regression coverage

## Why

The public SEO surface already had a sitemap and route canonicals for most content pages, but the homepage lacked route-specific canonical and structured data, social metadata could drift between Open Graph and Twitter, and the client-rendered 404 could be indexed as a soft 404.

## User and crawler impact

Search engines receive clearer site, application, article, and breadcrumb signals. Shared links receive consistent route metadata after rendering, while invalid SPA URLs explicitly opt out of indexing.

## Validation

- metadata hook tests
- frontend ESLint and TypeScript
- i18n catalog and hardcoded-string gates
- production frontend build
