### PR TITLE
chore(release): prepare v0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ reaches 1.0.0 (pre-1.0: minor bumps may include breaking changes — see
 
 ## [Unreleased]
 
+## [0.15.1] - 2026-07-11
+
+### Added
+
+- Public pages now publish route-specific Open Graph, Twitter, canonical, robots, breadcrumb, and structured application metadata for stronger search and link previews.
+- Stripe Tax can be enabled explicitly after registrations and product tax codes are configured, with deployment wiring and operator documentation included.
+
+### Fixed
+
+- Checkout attempts now carry household-scoped idempotency keys, preventing duplicate Stripe sessions during transport retries.
+- Delayed lifetime payments grant access only after Stripe confirms payment, and replacing an existing subscription retries safely if cancellation is temporarily unavailable instead of risking continued billing.
+
 ## [0.15.0] - 2026-07-11
 
 ### Fixed

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Family Greenhouse API — AWS Lambda + DynamoDB single-table + Cognito, with a local Express mock that mirrors the handlers.",
   "license": "Elastic-2.0",
   "private": true,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Family Greenhouse web app — React + TypeScript + Vite PWA for collaborative household plant care.",
   "license": "Elastic-2.0",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "family-greenhouse",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "family-greenhouse",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "Elastic-2.0",
       "workspaces": [
         "frontend",
@@ -37,7 +37,7 @@
       }
     },
     "backend": {
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "Elastic-2.0",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.1073.0",
@@ -448,7 +448,7 @@
       }
     },
     "frontend": {
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "Elastic-2.0",
       "dependencies": {
         "@fontsource-variable/instrument-sans": "^5.0.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "family-greenhouse",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "license": "Elastic-2.0",
   "private": true,
   "description": "A shared plant-care journal for the whole household — per-plant schedules, reminders that find the right person across browser/email/SMS, and a care log everyone can see. React + TypeScript on AWS Lambda + DynamoDB + Cognito.",


### PR DESCRIPTION
## Release v0.15.1

Patch release for the completed checkout reliability and public discoverability sweep.

### Included

- Stripe checkout idempotency and delayed lifetime-payment handling
- retry-safe cancellation of replaced subscriptions
- opt-in Stripe Tax deployment wiring and setup documentation
- Open Graph, Twitter, canonical, robots, breadcrumb, and structured application metadata

### Validation

- full local `npm run verify`
- PR #206 passed unit, E2E, accessibility, Lighthouse, bundle, CodeQL, Semgrep, security, i18n, build, and Terraform gates
- package versions and lockfile aligned at `0.15.1`
- changelog entry added for `0.15.1`
