### PR TITLE
Make plant name suggestions species aware

### DIFF
--- a/frontend/src/features/plants/PlantNameNursery.tsx
+++ b/frontend/src/features/plants/PlantNameNursery.tsx
@@ -121,6 +121,17 @@ export function PlantNameNursery({ species, onUseName }: PlantNameNurseryProps) 
             <p className="text-[10px] font-bold uppercase tracking-[0.18em] text-accent-700">
               {t('plants.nameNursery.ready')}
             </p>
+            {suggestion.speciesMatch && (
+              <p className="mx-auto mt-2 w-fit rounded-full border border-primary-200 bg-primary-50 px-2.5 py-1 text-[11px] font-semibold text-primary-800">
+                <span aria-hidden="true">🧬</span>{' '}
+                {t('plants.nameNursery.speciesInspired', {
+                  species: t(
+                    `plants.nameNursery.speciesFamilies.${suggestion.speciesMatch.id}`,
+                    suggestion.speciesMatch.label
+                  ),
+                })}
+              </p>
+            )}
             <p className="mt-1 font-serif text-2xl leading-tight text-ink">{suggestion.name}</p>
             <p className="mt-1 text-xs italic text-gray-600">{suggestion.note}</p>
 

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -59,6 +59,23 @@
       "close": "Close",
       "personalityLabel": "Name personality",
       "ready": "Ready for adoption",
+      "speciesInspired": "Inspired by {{species}}",
+      "speciesFamilies": {
+        "fern": "ferns",
+        "cactus": "cacti",
+        "pothos": "pothos",
+        "monstera": "monsteras",
+        "orchid": "orchids",
+        "palm": "palms",
+        "snake-plant": "snake plants",
+        "spider-plant": "spider plants",
+        "prayer-plant": "prayer plants",
+        "peace-lily": "peace lilies",
+        "rubber-plant": "rubber plants",
+        "aloe": "aloes and agaves",
+        "succulent": "succulents",
+        "philodendron": "philodendrons"
+      },
       "another": "Another one",
       "useName": "Use this name",
       "vibes": {

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -60,6 +60,23 @@
       "close": "Cerrar",
       "personalityLabel": "Personalidad del nombre",
       "ready": "Lista para adoptar",
+      "speciesInspired": "Inspirado en {{species}}",
+      "speciesFamilies": {
+        "fern": "helechos",
+        "cactus": "cactus",
+        "pothos": "potos",
+        "monstera": "plantas monstera",
+        "orchid": "orquídeas",
+        "palm": "palmeras",
+        "snake-plant": "sansevierias",
+        "spider-plant": "cintas",
+        "prayer-plant": "plantas de oración",
+        "peace-lily": "espatifilos",
+        "rubber-plant": "ficus de caucho",
+        "aloe": "aloes y agaves",
+        "succulent": "suculentas",
+        "philodendron": "filodendros"
+      },
       "another": "Otro nombre",
       "useName": "Usar este nombre",
       "vibes": {

--- a/frontend/src/utils/plantNameGenerator.ts
+++ b/frontend/src/utils/plantNameGenerator.ts
@@ -5,6 +5,10 @@ export interface PlantNameSuggestion {
   name: string;
   vibe: PlantNameVibe;
   note: string;
+  speciesMatch?: {
+    id: string;
+    label: string;
+  };
 }
 
 const vibes: readonly PlantNameVibe[] = ['punny', 'distinguished', 'chaotic', 'sweet'];
@@ -123,21 +127,179 @@ const sweetLasts = [
   'the Brave',
 ];
 
-const speciesBits: ReadonlyArray<[RegExp, readonly string[]]> = [
-  [/fern/i, ['Fernie', 'Frond Expectations', 'Ferninand']],
-  [/(cactus|cacti)/i, ['Spike Leeaf', 'Prickly Business', 'Pointy Potter']],
-  [/(aloe|agave)/i, ['Aloe There', 'Vera Good Plant', 'Agave It My All']],
-  [/pothos/i, ['Poth Malone', 'Pothos With the Mostest', 'Sir Trails-a-Lot']],
-  [/monstera/i, ['Monsterra Deliciosa', 'Swiss Cheese Louise', 'Monstera Mash']],
-  [/orchid/i, ['Orchid You Not', 'Bloom Hilda', 'Petal to the Metal']],
-  [/(palm|parlor)/i, ['Palmela', 'Frond of the Family', 'Palm Springs']],
-  [/(succulent|echeveria|sedum)/i, ['Succ It Up', 'Thiccums', 'Water? Never Met Her']],
+interface SpeciesNameProfile {
+  id: string;
+  label: string;
+  patterns: readonly RegExp[];
+  names: Record<PlantNameVibe, readonly string[]>;
+}
+
+/**
+ * Common and botanical names share a profile, so “pothos” and
+ * “Epipremnum aureum” produce the same family of jokes. Keep profiles broad
+ * enough to recognize useful input without pretending to identify a plant.
+ */
+const speciesProfiles: readonly SpeciesNameProfile[] = [
+  {
+    id: 'fern',
+    label: 'ferns',
+    patterns: [/fern/i, /nephrolepis/i, /adiantum/i, /asplenium/i],
+    names: {
+      punny: ['Fernie', 'Fernie Sanders', 'Frond Expectations'],
+      distinguished: ['Ferninand Frondsworth', 'Lady Boston of the Bathroom'],
+      chaotic: ['The Humidity Department', 'Frond and Disorder'],
+      sweet: ['Fernie Baby', 'Fuzzy Frond'],
+    },
+  },
+  {
+    id: 'cactus',
+    label: 'cacti',
+    patterns: [/cactus/i, /cacti/i, /opuntia/i, /mammillaria/i, /cereus/i],
+    names: {
+      punny: ['Spike Leeaf', 'Prickly Business', 'Cactus Everdeen'],
+      distinguished: ['Sir Prickleton', 'Baron von Spine'],
+      chaotic: ['Personal Space Enforcer', 'Touch Me and Find Out'],
+      sweet: ['Pokey Bean', 'Tiny Spike'],
+    },
+  },
+  {
+    id: 'pothos',
+    label: 'pothos',
+    patterns: [/pothos/i, /epipremnum/i],
+    names: {
+      punny: ['Poth Malone', 'Pothos With the Mostest'],
+      distinguished: ['Sir Trails-a-Lot', 'Duchess Epipremnum'],
+      chaotic: ['The Cabinet Escapee', 'Vine and Punishment'],
+      sweet: ['Pothie', 'Little Golden Trail'],
+    },
+  },
+  {
+    id: 'monstera',
+    label: 'monsteras',
+    patterns: [/monstera/i, /deliciosa/i, /adansonii/i],
+    names: {
+      punny: ['Monsterra Deliciosa', 'Swiss Cheese Louise'],
+      distinguished: ['Professor Fenestration', 'Lady Monstera of the Split Leaf'],
+      chaotic: ['The Hole Situation', 'Unauthorized Window Factory'],
+      sweet: ['Little Monster', 'Swiss Cheese Baby'],
+    },
+  },
+  {
+    id: 'orchid',
+    label: 'orchids',
+    patterns: [/orchid/i, /phalaenopsis/i, /dendrobium/i],
+    names: {
+      punny: ['Orchid You Not', 'Petal to the Metal'],
+      distinguished: ['Dame Phalaenopsis', 'Orchid von Bloom'],
+      chaotic: ['Rebloom Pending', 'Root Inspection Denied'],
+      sweet: ['Petal', 'Moth Baby'],
+    },
+  },
+  {
+    id: 'palm',
+    label: 'palms',
+    patterns: [/palm/i, /chamaedorea/i, /dypsis/i, /areca/i],
+    names: {
+      punny: ['Palmela Anderson', 'Frond of the Family'],
+      distinguished: ['Lady Chamaedorea', 'Sir Palm Springs'],
+      chaotic: ['Vacation Mode', 'Lobby Plant Energy'],
+      sweet: ['Palmy', 'Little Frond'],
+    },
+  },
+  {
+    id: 'snake-plant',
+    label: 'snake plants',
+    patterns: [/snake plant/i, /sansevieria/i, /dracaena trifasciata/i],
+    names: {
+      punny: ['Snake Gyllenhaal', 'Hiss Majesty'],
+      distinguished: ['Lady Sansevieria', 'Sir Stands-a-Lot'],
+      chaotic: ['Vertical Threat', 'Mother-in-Law Enforcement'],
+      sweet: ['Noodle', 'Little Snek'],
+    },
+  },
+  {
+    id: 'spider-plant',
+    label: 'spider plants',
+    patterns: [/spider plant/i, /chlorophytum/i],
+    names: {
+      punny: ['Peter Parker Plant', 'Web Developer'],
+      distinguished: ['Count Chlorophytum', 'Madame Spiderette'],
+      chaotic: ['Baby Factory', 'Eight Legs Zero Plans'],
+      sweet: ['Spiderling', 'Tiny Tuft'],
+    },
+  },
+  {
+    id: 'prayer-plant',
+    label: 'prayer plants',
+    patterns: [/prayer plant/i, /calathea/i, /goeppertia/i, /maranta/i],
+    names: {
+      punny: ['Maranta Del Rey', 'Thoughts and Prayers'],
+      distinguished: ['Countess Calathea', 'Lady Maranta at Vespers'],
+      chaotic: ['Curling for Attention', 'The Evening Performance'],
+      sweet: ['Prayer Bear', 'Stripey'],
+    },
+  },
+  {
+    id: 'peace-lily',
+    label: 'peace lilies',
+    patterns: [/peace lily/i, /spathiphyllum/i],
+    names: {
+      punny: ['Lily Tomlinson', 'Give Leaves a Chance'],
+      distinguished: ['Ambassador Spathiphyllum', 'Lady Lily of Peace'],
+      chaotic: ['Thirst Trap', 'Peace Was Never an Option'],
+      sweet: ['Lily Bean', 'Peace Pea'],
+    },
+  },
+  {
+    id: 'rubber-plant',
+    label: 'rubber plants',
+    patterns: [/rubber plant/i, /ficus elastica/i],
+    names: {
+      punny: ['Rubber Plant Downey Jr.', 'Ficus Pocus'],
+      distinguished: ['Lord Elastica', 'Ficus Fitzgerald'],
+      chaotic: ['Bounce House', 'Tireless Employee'],
+      sweet: ['Gummy', 'Rubber Ducky'],
+    },
+  },
+  {
+    id: 'aloe',
+    label: 'aloes and agaves',
+    patterns: [/aloe/i, /agave/i, /haworthia/i],
+    names: {
+      punny: ['Aloe There', 'Vera Good Plant'],
+      distinguished: ['Aloe Vera Wang', 'Agave Christie'],
+      chaotic: ['First Aid Department', 'Tequila Mockingbird'],
+      sweet: ['Aloe Baby', 'Vera Bean'],
+    },
+  },
+  {
+    id: 'succulent',
+    label: 'succulents',
+    patterns: [/succulent/i, /echeveria/i, /sedum/i, /crassula/i],
+    names: {
+      punny: ['Succ It Up', 'Aloe by Another Name'],
+      distinguished: ['Duchess Echeveria', 'Sir Sedum of the Saucer'],
+      chaotic: ['Water? Never Met Her', 'Thiccums'],
+      sweet: ['Chonky Bean', 'Rosette'],
+    },
+  },
+  {
+    id: 'philodendron',
+    label: 'philodendrons',
+    patterns: [/philodendron/i],
+    names: {
+      punny: ['Phil O. Dendron', 'Phil Collins'],
+      distinguished: ['Professor Philodendron', 'Philippa von Heartleaf'],
+      chaotic: ['Pole Dancer', 'Certified Tree Hugger'],
+      sweet: ['Philly', 'Heartleaf'],
+    },
+  },
 ];
 
 /**
  * Produces a name plus its tiny character bio. Supplying an rng keeps the
- * generator deterministic in tests; species is used occasionally for a
- * tailored joke without ever sending form data over the network.
+ * generator deterministic in tests. Recognized common or scientific species
+ * names tailor every vibe without ever sending form data over the network.
  */
 export function generatePlantNameSuggestion(
   vibe: PlantNameVibe | 'surprise' = 'surprise',
@@ -145,26 +307,38 @@ export function generatePlantNameSuggestion(
   rng: () => number = Math.random
 ): PlantNameSuggestion {
   const resolvedVibe = vibe === 'surprise' ? pick(vibes, rng) : vibe;
-  const contextualNames = speciesBits.find(([pattern]) => pattern.test(species))?.[1];
-  const useContextualPun = resolvedVibe === 'punny' && contextualNames && rng() < 0.55;
+  const speciesProfile = speciesProfiles.find((profile) =>
+    profile.patterns.some((pattern) => pattern.test(species))
+  );
 
   let name: string;
-  switch (resolvedVibe) {
-    case 'punny':
-      name = useContextualPun ? pick(contextualNames, rng) : pick(punnyNames, rng);
-      break;
-    case 'distinguished':
-      name = `${pick(titles, rng)} ${pick(distinguishedFirsts, rng)} ${pick(distinguishedLasts, rng)}`;
-      break;
-    case 'chaotic':
-      name = pick(chaoticNames, rng);
-      break;
-    case 'sweet':
-      name = `${pick(sweetFirsts, rng)} ${pick(sweetLasts, rng)}`;
-      break;
+  if (speciesProfile) {
+    name = pick(speciesProfile.names[resolvedVibe], rng);
+  } else {
+    switch (resolvedVibe) {
+      case 'punny':
+        name = pick(punnyNames, rng);
+        break;
+      case 'distinguished':
+        name = `${pick(titles, rng)} ${pick(distinguishedFirsts, rng)} ${pick(distinguishedLasts, rng)}`;
+        break;
+      case 'chaotic':
+        name = pick(chaoticNames, rng);
+        break;
+      case 'sweet':
+        name = `${pick(sweetFirsts, rng)} ${pick(sweetLasts, rng)}`;
+        break;
+    }
   }
 
-  return { name, vibe: resolvedVibe, note: pick(notes[resolvedVibe], rng) };
+  return {
+    name,
+    vibe: resolvedVibe,
+    note: pick(notes[resolvedVibe], rng),
+    ...(speciesProfile && {
+      speciesMatch: { id: speciesProfile.id, label: speciesProfile.label },
+    }),
+  };
 }
 
 /** Backwards-compatible one-line helper for callers that only need a name. */

--- a/frontend/tests/unit/features/PlantNameNursery.test.tsx
+++ b/frontend/tests/unit/features/PlantNameNursery.test.tsx
@@ -13,6 +13,7 @@ describe('PlantNameNursery', () => {
     expect(screen.getByRole('region', { name: 'Plant name nursery' })).toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: /Punny/ }));
+    expect(screen.getByText('Inspired by ferns')).toBeInTheDocument();
     const firstSuggestion = screen.getByText('Ready for adoption').nextElementSibling?.textContent;
     expect(firstSuggestion).toBeTruthy();
 

--- a/frontend/tests/unit/utils/plantNameGenerator.test.ts
+++ b/frontend/tests/unit/utils/plantNameGenerator.test.ts
@@ -24,9 +24,43 @@ describe('plant name generator', () => {
     }
   );
 
-  it('uses the species for a tailored pun when one is available', () => {
+  it('uses a common species name for a tailored pun', () => {
     const suggestion = generatePlantNameSuggestion('punny', 'Boston fern', () => 0);
     expect(suggestion.name).toBe('Fernie');
+    expect(suggestion.speciesMatch).toEqual({ id: 'fern', label: 'ferns' });
+  });
+
+  it.each<PlantNameVibe>(['punny', 'distinguished', 'chaotic', 'sweet'])(
+    'tailors the %s personality to the species',
+    (vibe) => {
+      const suggestion = generatePlantNameSuggestion(vibe, 'Monstera deliciosa', () => 0);
+
+      expect(suggestion.speciesMatch).toEqual({ id: 'monstera', label: 'monsteras' });
+      expect(suggestion.name).toMatch(
+        /Monsterra Deliciosa|Professor Fenestration|The Hole Situation|Little Monster/
+      );
+    }
+  );
+
+  it('recognizes a scientific name even when the common name is absent', () => {
+    const suggestion = generatePlantNameSuggestion('distinguished', 'Epipremnum aureum', () => 0);
+
+    expect(suggestion.name).toBe('Sir Trails-a-Lot');
+    expect(suggestion.speciesMatch?.id).toBe('pothos');
+  });
+
+  it('preserves tailored palm support', () => {
+    const suggestion = generatePlantNameSuggestion('chaotic', 'Parlor palm', () => 0);
+
+    expect(suggestion.name).toBe('Vacation Mode');
+    expect(suggestion.speciesMatch?.id).toBe('palm');
+  });
+
+  it('falls back gracefully for an unknown species', () => {
+    const suggestion = generatePlantNameSuggestion('sweet', 'Mysteriophyta fabulous', () => 0);
+
+    expect(suggestion.name).toBe('Bean Baby');
+    expect(suggestion.speciesMatch).toBeUndefined();
   });
 
   it('is deterministic when supplied with a seeded rng', () => {


### PR DESCRIPTION
## What changed
- match 14 plant families from common and botanical species names
- tailor punny, distinguished, chaotic, and sweet suggestions to the matched family
- show a localized species-inspired badge in the name nursery
- preserve generic fallback behavior for unknown species
- add coverage for common names, scientific names, all personalities, palms, fallback behavior, and the nursery UI

## Why
Species previously influenced only an occasional pun for a small set of plants. This makes the generator consistently feel aware of the plant being named while keeping everything client-side.

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run i18n:check`
- `npm test` (385 tests)
- `npm run build`
- `npm run size`
