### PR TITLE
Prepare v0.15.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ reaches 1.0.0 (pre-1.0: minor bumps may include breaking changes — see
 
 ## [Unreleased]
 
+## [0.15.3] - 2026-07-11
+
 ### Added
 
 - Plants can be archived without losing tasks, photos, care history, or propagation lineage, then restored through the cap-safe lifecycle flow.

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "Family Greenhouse API — AWS Lambda + DynamoDB single-table + Cognito, with a local Express mock that mirrors the handlers.",
   "license": "Elastic-2.0",
   "private": true,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "Family Greenhouse web app — React + TypeScript + Vite PWA for collaborative household plant care.",
   "license": "Elastic-2.0",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "family-greenhouse",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "family-greenhouse",
-      "version": "0.15.2",
+      "version": "0.15.3",
       "license": "Elastic-2.0",
       "workspaces": [
         "frontend",
@@ -37,7 +37,7 @@
       }
     },
     "backend": {
-      "version": "0.15.2",
+      "version": "0.15.3",
       "license": "Elastic-2.0",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.1073.0",
@@ -448,7 +448,7 @@
       }
     },
     "frontend": {
-      "version": "0.15.2",
+      "version": "0.15.3",
       "license": "Elastic-2.0",
       "dependencies": {
         "@fontsource-variable/instrument-sans": "^5.0.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "family-greenhouse",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "license": "Elastic-2.0",
   "private": true,
   "description": "A shared plant-care journal for the whole household — per-plant schedules, reminders that find the right person across browser/email/SMS, and a care log everyone can see. React + TypeScript on AWS Lambda + DynamoDB + Cognito.",


### PR DESCRIPTION
## Release
Prepare `v0.15.3` for the safe plant archiving and recovery lifecycle.

## Changes
- bump root, frontend, backend, and lockfile versions to `0.15.3`
- promote the archive/recovery changelog notes into a dated `0.15.3` entry

## Deployment
After CI and merge, tag the release merge commit as `v0.15.3` to trigger the protected production workflow.
