### PR TITLE
chore(release): prepare v0.15.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ reaches 1.0.0 (pre-1.0: minor bumps may include breaking changes — see
 
 ## [Unreleased]
 
+## [0.15.4] - 2026-07-11
+
+### Fixed
+
+- The edit-plant species test now waits for observable remote lookup results instead of racing a fixed delay during release builds.
+
 ## [0.15.3] - 2026-07-11
 
 ### Added

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "description": "Family Greenhouse API — AWS Lambda + DynamoDB single-table + Cognito, with a local Express mock that mirrors the handlers.",
   "license": "Elastic-2.0",
   "private": true,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.15.3",
+  "version": "0.15.4",
   "description": "Family Greenhouse web app — React + TypeScript + Vite PWA for collaborative household plant care.",
   "license": "Elastic-2.0",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "family-greenhouse",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "family-greenhouse",
-      "version": "0.15.3",
+      "version": "0.15.4",
       "license": "Elastic-2.0",
       "workspaces": [
         "frontend",
@@ -37,7 +37,7 @@
       }
     },
     "backend": {
-      "version": "0.15.3",
+      "version": "0.15.4",
       "license": "Elastic-2.0",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.1073.0",
@@ -448,7 +448,7 @@
       }
     },
     "frontend": {
-      "version": "0.15.3",
+      "version": "0.15.4",
       "license": "Elastic-2.0",
       "dependencies": {
         "@fontsource-variable/instrument-sans": "^5.0.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "family-greenhouse",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "license": "Elastic-2.0",
   "private": true,
   "description": "A shared plant-care journal for the whole household — per-plant schedules, reminders that find the right person across browser/email/SMS, and a care log everyone can see. React + TypeScript on AWS Lambda + DynamoDB + Cognito.",


### PR DESCRIPTION
## Summary
- bump all workspace manifests and lock metadata to v0.15.4
- document the release-gate reliability remediation
- retain v0.15.3 as the immutable record of the stopped pre-deploy run

## Validation
- remediation PR #213 passed all required checks
- all manifest and lockfile versions agree at 0.15.4
- changelog contains a dated v0.15.4 entry