### PR TITLE
chore(release): prepare v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ reaches 1.0.0 (pre-1.0: minor bumps may include breaking changes — see
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-07-12
+
+### Added
+
+- Native iOS and Android app shells (Capacitor) wrap the existing web app so it can ship to the App Store and Play Store; build flow and store-submission checklist live in `docs/mobile.md`.
+- Inside the mobile apps, the notification settings device toggle registers a native push device token with the backend (capture-only groundwork — reminder delivery to native devices ships with the APNs/FCM sender).
+
+### Changed
+
+- Billing inside the mobile apps is read-only for store payment compliance: plan checkout and subscription-management actions stay web-only, with a neutral notice shown in the apps.
+- The API's CORS allowlist now also accepts the mobile shells' origins, and the layout respects device safe areas (notch, status bar, home indicator) on edge-to-edge screens.
+
 ## [0.15.4] - 2026-07-11
 
 ### Fixed

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.15.4",
+  "version": "0.16.0",
   "description": "Family Greenhouse API — AWS Lambda + DynamoDB single-table + Cognito, with a local Express mock that mirrors the handlers.",
   "license": "Elastic-2.0",
   "private": true,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.15.4",
+  "version": "0.16.0",
   "description": "Family Greenhouse web app — React + TypeScript + Vite PWA for collaborative household plant care.",
   "license": "Elastic-2.0",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "family-greenhouse",
-  "version": "0.15.4",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "family-greenhouse",
-      "version": "0.15.4",
+      "version": "0.16.0",
       "license": "Elastic-2.0",
       "workspaces": [
         "frontend",
@@ -37,7 +37,7 @@
       }
     },
     "backend": {
-      "version": "0.15.4",
+      "version": "0.16.0",
       "license": "Elastic-2.0",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.1073.0",
@@ -448,7 +448,7 @@
       }
     },
     "frontend": {
-      "version": "0.15.4",
+      "version": "0.16.0",
       "license": "Elastic-2.0",
       "dependencies": {
         "@capacitor/android": "^8.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "family-greenhouse",
-  "version": "0.15.4",
+  "version": "0.16.0",
   "license": "Elastic-2.0",
   "private": true,
   "description": "A shared plant-care journal for the whole household — per-plant schedules, reminders that find the right person across browser/email/SMS, and a care log everyone can see. React + TypeScript on AWS Lambda + DynamoDB + Cognito.",


### PR DESCRIPTION
## What this changes

Release prep for **v0.16.0** — the Capacitor mobile-app release (#215). Bumps root/frontend/backend package versions 0.15.4 → 0.16.0 and adds the dated CHANGELOG entry (REL-02/REL-03 tag↔version consistency, REL-10 changelog gate). After merge, tagging `v0.16.0` on this commit triggers the production deploy.

## How it was tested

- `npm version --workspaces --include-workspace-root` for the bumps; lockfile updated in the same pass
- Version/changelog-only change; the code it releases was fully gated in #215 (all 17 checks green)

## Checklist

- [x] Commits follow Conventional Commits (`feat:`, `fix:`, …) — the commitlint hook enforces this
- [x] `npm test` passes for the workspace(s) you touched
- [x] No secrets, credentials, or personal data added to the tree or history
- [x] Docs/changelog updated if behavior changed (CHANGELOG entry for 0.16.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WR7ja2HoA6vbY6yhGrq6Jh

---
_Generated by [Claude Code](https://claude.ai/code/session_01WR7ja2HoA6vbY6yhGrq6Jh)_