### PR TITLE
feat: integrate grounded sprout plant care

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 # Dependencies & lockfiles (npm owns the lock's formatting)
 node_modules
+.claude/worktrees
 package-lock.json
 
 # Build outputs and generated artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ reaches 1.0.0 (pre-1.0: minor bumps may include breaking changes — see
 
 ## [Unreleased]
 
+### Added
+
+- Feature-flagged, server-to-server Sprout integration for corpus-grounded plant-care answers,
+  with HMAC authentication, minimized household context, nickname/contact redaction, citation
+  persistence, and a temporary fallback to the existing assistant.
+- Independent application-domain and Route 53 hosted-zone configuration, allowing an app
+  subdomain without treating it as its own hosted zone or automatically creating a `www` alias.
+
+### Changed
+
+- The public OpenAPI contract now documents the implemented, opt-in `write:tasks` complete and
+  snooze endpoints instead of incorrectly describing v1 as read-only.
+
 ## [0.16.0] - 2026-07-12
 
 ### Added

--- a/backend/src/services/chat/index.ts
+++ b/backend/src/services/chat/index.ts
@@ -12,6 +12,7 @@ import createHttpError from 'http-errors';
 import { logger } from '../../utils/logger.js';
 import { audit } from '../../utils/auditLog.js';
 import * as billing from '../billing.js';
+import { askSprout, isSproutIntegrationEnabled, type SproutCitation } from '../sprout.js';
 import { getPlan } from '../../models/plans.js';
 import {
   invokeChatModel,
@@ -31,6 +32,7 @@ import {
   appendMessagePair,
   claimTurn,
   finalizeTurn,
+  getBudget,
   getConversation,
   incrementBudget,
   newConversationId,
@@ -138,6 +140,9 @@ export interface RunChatTurnResult {
     inputTokens: number;
     outputTokens: number;
   };
+  /** Present when the feature-flagged first-party Sprout path answered. */
+  citations?: SproutCitation[];
+  provider?: 'sprout' | 'bedrock';
 }
 
 /**
@@ -148,7 +153,10 @@ export interface RunChatTurnResult {
 function toBedrockMessages(history: ChatMessageRecord[]): BedrockMessage[] {
   return history.map((m) => ({
     role: m.role,
-    content: m.content,
+    // Citation blocks are Family Greenhouse display metadata, not Anthropic
+    // content blocks. Strip them before replaying a Sprout-authored turn into
+    // a later Bedrock fallback.
+    content: m.content.filter((block) => block.type !== 'citation'),
   }));
 }
 
@@ -269,6 +277,66 @@ async function* turnEvents(
       throw createHttpError(409, 'This message is already being processed — hang tight.');
     }
     // 'claimed' → we own this turn; run it (and finalize/release below).
+  }
+
+  // Phase A of the Sprout integration is intentionally read-only. It returns
+  // corpus-grounded prose and citations using only a minimized selector
+  // context. If the feature is enabled but unavailable, fall back to the
+  // existing assistant during rollout; no household payload has been persisted
+  // and the idempotency claim remains owned by this turn.
+  if (isSproutIntegrationEnabled()) {
+    let sprout: Awaited<ReturnType<typeof askSprout>> | undefined;
+    try {
+      sprout = await askSprout({ householdId, question: message });
+    } catch (err) {
+      logger.warn({ err: (err as Error).message }, 'sprout_integration_fallback');
+    }
+    if (sprout) {
+      const userRecord: ChatMessageRecord = {
+        conversationId,
+        timestamp: new Date().toISOString(),
+        role: 'user',
+        content: [{ type: 'text', text: message }],
+      };
+      const assistantRecord: ChatMessageRecord = {
+        conversationId,
+        timestamp: new Date().toISOString(),
+        role: 'assistant',
+        content: [
+          { type: 'text', text: sprout.text },
+          ...sprout.citations.map((citation) => ({ type: 'citation' as const, ...citation })),
+        ],
+      };
+      await appendMessage(householdId, userRecord);
+      await appendMessage(householdId, assistantRecord);
+      const budget = await getBudget(householdId);
+      const result: RunChatTurnResult = {
+        conversationId,
+        assistantText: sprout.text,
+        proposals: [],
+        citations: sprout.citations,
+        provider: 'sprout',
+        budgetRemaining: {
+          inputTokens: Math.max(0, BUDGET_CONFIG.maxInputTokensPerMonth - budget.inputTokens),
+          outputTokens: Math.max(0, BUDGET_CONFIG.maxOutputTokensPerMonth - budget.outputTokens),
+        },
+      };
+      if (turnId) {
+        try {
+          await finalizeTurn(householdId, turnId, result as unknown as Record<string, unknown>);
+        } catch (err) {
+          logger.warn({ err: (err as Error).message, turnId }, 'chat_turn_finalize_failed');
+        }
+      }
+      audit('chat.message_sent', {
+        actorId: userId,
+        householdId,
+        metadata: { conversationId, provider: 'sprout', citationCount: sprout.citations.length },
+      });
+      yield { type: 'start', conversationId };
+      yield { type: 'done', result };
+      return result;
+    }
   }
 
   // Atomic budget gate (#4): reserve a representative turn up front. The
@@ -529,6 +597,7 @@ async function* turnEvents(
       extractAssistantText(finalAssistantBlocks) ||
       "I wasn't able to come up with a response — try rephrasing.",
     proposals,
+    provider: 'bedrock',
     budgetRemaining: {
       inputTokens: Math.max(
         0,

--- a/backend/src/services/chat/types.ts
+++ b/backend/src/services/chat/types.ts
@@ -22,11 +22,20 @@ export interface ChatMessageRecord {
   costUsd?: number;
 }
 
-export type ContentBlock = TextBlock | ToolUseBlock | ToolResultBlock;
+export type ContentBlock = TextBlock | ToolUseBlock | ToolResultBlock | CitationBlock;
 
 export interface TextBlock {
   type: 'text';
   text: string;
+}
+
+/** Family Greenhouse display metadata. Never forwarded to Bedrock. */
+export interface CitationBlock {
+  type: 'citation';
+  title: string;
+  url: string;
+  source: string;
+  fetch_date: string;
 }
 
 export interface ToolUseBlock {

--- a/backend/src/services/sprout.ts
+++ b/backend/src/services/sprout.ts
@@ -1,0 +1,190 @@
+/** First-party Sprout client with a deliberately minimized household context. */
+import { createHash, createHmac } from 'node:crypto';
+import { GetSecretValueCommand, SecretsManagerClient } from '@aws-sdk/client-secrets-manager';
+import * as plantService from './plantService.js';
+import * as taskService from './taskService.js';
+
+export interface SproutCitation {
+  title: string;
+  url: string;
+  source: string;
+  fetch_date: string;
+}
+
+export interface SproutHouseholdObservation {
+  kind: 'collection' | 'tasks';
+  value: Record<string, number>;
+  provenance: 'household';
+}
+
+export interface SproutChatResult {
+  text: string;
+  citations: SproutCitation[];
+  observations: SproutHouseholdObservation[];
+  disclosure: string;
+}
+
+interface SproutResponse {
+  answer: {
+    display_text: string;
+    citations: SproutCitation[];
+    disclosure: string;
+    provenance: 'corpus';
+  };
+  household_observations: SproutHouseholdObservation[];
+  context_policy: 'household-data-selects-corpus-facts';
+}
+
+export function isSproutIntegrationEnabled(): boolean {
+  return process.env.SPROUT_INTEGRATION_ENABLED === '1';
+}
+
+let cachedSecret: string | undefined;
+const secretsClient = new SecretsManagerClient({ region: process.env.AWS_REGION || 'us-east-1' });
+
+async function resolveSecret(): Promise<string | undefined> {
+  if (cachedSecret) return cachedSecret;
+  const secretId = process.env.SPROUT_INTEGRATION_SECRET_ID?.trim();
+  if (secretId) {
+    const result = await secretsClient.send(new GetSecretValueCommand({ SecretId: secretId }));
+    cachedSecret = result.SecretString?.trim();
+    if (cachedSecret) return cachedSecret;
+  }
+  cachedSecret = process.env.SPROUT_INTEGRATION_SECRET?.trim();
+  return cachedSecret;
+}
+
+export function __resetSproutSecretForTests(): void {
+  cachedSecret = undefined;
+}
+
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+  if (value !== null && typeof value === 'object') {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, item]) => `${JSON.stringify(key)}:${canonicalJson(item)}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+export function signSproutBody(secret: string, timestamp: string, body: string): string {
+  const digest = createHash('sha256').update(body).digest('hex');
+  return createHmac('sha256', secret).update(`${timestamp}\n${digest}`).digest('hex');
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** Remove known local identifiers before a user's free-text question crosses services. */
+export function redactSproutQuestion(
+  question: string,
+  plants: Array<{ name: string; species: string | null }>
+): string {
+  let redacted = question;
+  const namedPlants = [...plants]
+    .filter((plant) => plant.name.trim().length > 0)
+    .sort((a, b) => b.name.length - a.name.length);
+  for (const plant of namedPlants) {
+    redacted = redacted.replace(
+      new RegExp(escapeRegExp(plant.name), 'giu'),
+      plant.species?.trim() || 'this plant'
+    );
+  }
+  return redacted
+    .replace(/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/giu, '[email redacted]')
+    .replace(/(?:\+?\d[\d().\s-]{7,}\d)/gu, '[phone redacted]');
+}
+
+function daysBetween(date: string, now: Date): number {
+  return Math.round((new Date(date).getTime() - now.getTime()) / 86_400_000);
+}
+
+/**
+ * Build the only payload permitted to cross into Sprout. No nickname, free-form
+ * location, notes, images, member data, household id, or exact timestamps.
+ */
+export async function buildSproutContext(householdId: string, now = new Date(), question?: string) {
+  const [plants, tasks] = await Promise.all([
+    plantService.getPlants(householdId),
+    taskService.getTasks(householdId),
+  ]);
+  const speciesByPlant = new Map(
+    plants.filter((plant) => plant.species).map((plant) => [plant.id, plant.species as string])
+  );
+  return {
+    sanitizedQuestion: question === undefined ? undefined : redactSproutQuestion(question, plants),
+    plants: plants
+      .filter((plant) => plant.species)
+      .slice(0, 100)
+      .map((plant) => ({ species: plant.species as string, light_profile: 'unknown' as const })),
+    tasks: tasks
+      .flatMap((task) => {
+        const species = speciesByPlant.get(task.plantId);
+        if (!species) return [];
+        return [
+          {
+            plant_species: species,
+            task_type: task.type,
+            due_in_days: Math.max(-365, Math.min(365, daysBetween(task.nextDue, now))),
+            last_completed_days_ago: task.lastCompleted
+              ? Math.max(0, Math.min(3650, -daysBetween(task.lastCompleted, now)))
+              : null,
+          },
+        ];
+      })
+      .slice(0, 100),
+  };
+}
+
+export async function askSprout(input: {
+  householdId: string;
+  question: string;
+  language?: 'en' | 'es';
+}): Promise<SproutChatResult> {
+  const baseUrl = process.env.SPROUT_API_URL?.replace(/\/$/, '');
+  const secret = await resolveSecret();
+  if (!baseUrl || !secret) throw new Error('Sprout integration is enabled but not configured');
+
+  const context = await buildSproutContext(input.householdId, new Date(), input.question);
+  const payload = {
+    question: context.sanitizedQuestion ?? input.question,
+    language: input.language ?? 'en',
+    plants: context.plants,
+    tasks: context.tasks,
+  };
+  const body = canonicalJson(payload);
+  const timestamp = Math.floor(Date.now() / 1000).toString();
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 8_000);
+  try {
+    const response = await fetch(`${baseUrl}/api/integrations/family-greenhouse/chat`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Sprout-Timestamp': timestamp,
+        'X-Sprout-Signature': signSproutBody(secret, timestamp, body),
+      },
+      body,
+      signal: controller.signal,
+    });
+    if (!response.ok) throw new Error(`Sprout returned HTTP ${response.status}`);
+    const result = (await response.json()) as SproutResponse;
+    if (
+      result.answer?.provenance !== 'corpus' ||
+      result.context_policy !== 'household-data-selects-corpus-facts'
+    ) {
+      throw new Error('Sprout returned an invalid provenance contract');
+    }
+    return {
+      text: result.answer.display_text,
+      citations: result.answer.citations ?? [],
+      observations: result.household_observations ?? [],
+      disclosure: result.answer.disclosure,
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/backend/tests/unit/services/chatTurn.test.ts
+++ b/backend/tests/unit/services/chatTurn.test.ts
@@ -6,6 +6,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('../../../src/services/chat/bedrock.js');
+vi.mock('../../../src/services/sprout.js', () => ({
+  askSprout: vi.fn(),
+  isSproutIntegrationEnabled: vi.fn(() => false),
+}));
 vi.mock('../../../src/services/chat/persistence.js', async () => {
   const actual = await vi.importActual<typeof import('../../../src/services/chat/persistence.js')>(
     '../../../src/services/chat/persistence.js'
@@ -16,6 +20,13 @@ vi.mock('../../../src/services/chat/persistence.js', async () => {
     appendMessage: vi.fn(async () => undefined),
     appendMessagePair: vi.fn(async () => undefined),
     getConversation: vi.fn(async () => []),
+    getBudget: vi.fn(async () => ({
+      householdId: 'hh-1',
+      yearMonth: '2026-07',
+      inputTokens: 100,
+      outputTokens: 20,
+      costUsd: 0,
+    })),
     // The atomic gate: returns the POST-reservation committed totals. Default to
     // a fresh budget (committed 0 → post-reserve == the reservation).
     reserveBudget: vi.fn(
@@ -52,6 +63,7 @@ import {
   RESERVE_OUTPUT_TOKENS,
 } from '../../../src/services/chat/index.js';
 import * as billing from '../../../src/services/billing.js';
+import { askSprout, isSproutIntegrationEnabled } from '../../../src/services/sprout.js';
 import { invokeChatModel, type BedrockMessage } from '../../../src/services/chat/bedrock.js';
 import {
   appendMessage,
@@ -73,6 +85,7 @@ import * as plantService from '../../../src/services/plantService.js';
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.mocked(isSproutIntegrationEnabled).mockReturnValue(false);
 });
 
 /**
@@ -110,6 +123,62 @@ function expectValidToolPairing(messages: BedrockMessage[]): void {
 }
 
 describe('runChatTurn', () => {
+  it('uses Sprout without Bedrock and persists citation metadata', async () => {
+    vi.mocked(isSproutIntegrationEnabled).mockReturnValueOnce(true);
+    vi.mocked(askSprout).mockResolvedValueOnce({
+      text: 'Grounded care.',
+      citations: [
+        {
+          title: 'Pothos care',
+          url: 'https://example.test/pothos',
+          source: 'pothos.md',
+          fetch_date: '2026-05-01',
+        },
+      ],
+      observations: [],
+      disclosure: 'AI-generated',
+    });
+
+    const result = await runChatTurn({
+      userId: 'u1',
+      householdId: 'hh-1',
+      message: 'Pothos care?',
+      turnId: 'turn-sprout',
+    });
+
+    expect(result.provider).toBe('sprout');
+    expect(result.budgetRemaining).toEqual({
+      inputTokens: BUDGET_CONFIG.maxInputTokensPerMonth - 100,
+      outputTokens: BUDGET_CONFIG.maxOutputTokensPerMonth - 20,
+    });
+    expect(invokeChatModel).not.toHaveBeenCalled();
+    expect(reserveBudget).not.toHaveBeenCalled();
+    expect(appendMessage).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(appendMessage).mock.calls[1][1].content[1]).toMatchObject({
+      type: 'citation',
+      source: 'pothos.md',
+    });
+    expect(finalizeTurn).toHaveBeenCalled();
+  });
+
+  it('falls back before persistence when Sprout is unavailable', async () => {
+    vi.mocked(isSproutIntegrationEnabled).mockReturnValueOnce(true);
+    vi.mocked(askSprout).mockRejectedValueOnce(new Error('sprout unavailable'));
+    vi.mocked(invokeChatModel).mockResolvedValueOnce({
+      content: [{ type: 'text', text: 'Bedrock fallback.' }],
+      stopReason: 'end_turn',
+      inputTokens: 10,
+      outputTokens: 5,
+      costUsd: 0.0001,
+    });
+
+    const result = await runChatTurn({ userId: 'u1', householdId: 'hh-1', message: 'care?' });
+
+    expect(result.provider).toBe('bedrock');
+    expect(invokeChatModel).toHaveBeenCalledOnce();
+    expect(appendMessage).toHaveBeenCalledTimes(2);
+  });
+
   it('returns the assistant text and persists exactly the right turns on a no-tool answer', async () => {
     vi.mocked(invokeChatModel).mockResolvedValueOnce({
       content: [{ type: 'text', text: 'You have no plants yet.' }],

--- a/backend/tests/unit/services/sprout.test.ts
+++ b/backend/tests/unit/services/sprout.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../src/services/plantService.js');
+vi.mock('../../../src/services/taskService.js');
+
+import * as plantService from '../../../src/services/plantService.js';
+import * as taskService from '../../../src/services/taskService.js';
+import {
+  __resetSproutSecretForTests,
+  askSprout,
+  buildSproutContext,
+  redactSproutQuestion,
+  signSproutBody,
+} from '../../../src/services/sprout.js';
+
+describe('Sprout integration', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    __resetSproutSecretForTests();
+    process.env.SPROUT_API_URL = 'https://api.sprout.example';
+    process.env.SPROUT_INTEGRATION_SECRET = 'test-secret';
+    delete process.env.SPROUT_INTEGRATION_SECRET_ID;
+  });
+
+  it('sends only coarse species and relative task data', async () => {
+    vi.mocked(plantService.getPlants).mockResolvedValueOnce([
+      {
+        id: 'p1',
+        householdId: 'private-household',
+        name: 'SENTINEL NICKNAME',
+        species: 'Monstera deliciosa',
+        location: 'SENTINEL ADDRESS',
+        imageUrl: 'https://private/photo.jpg',
+        notes: 'SENTINEL NOTES',
+        status: 'active',
+        tags: [],
+        createdAt: '2026-01-01T00:00:00Z',
+        createdBy: 'private-user',
+        updatedAt: '2026-01-01T00:00:00Z',
+      },
+    ]);
+    vi.mocked(taskService.getTasks).mockResolvedValueOnce([
+      {
+        id: 't1',
+        householdId: 'private-household',
+        plantId: 'p1',
+        plantName: 'SENTINEL NICKNAME',
+        type: 'water',
+        customType: null,
+        frequency: 7,
+        lastCompleted: '2026-06-28T00:00:00Z',
+        nextDue: '2026-07-10T00:00:00Z',
+        assignedTo: 'private-user',
+        assignedToName: 'SENTINEL PERSON',
+        notes: 'SENTINEL TASK NOTES',
+        createdBy: 'private-user',
+        createdAt: '2026-01-01T00:00:00Z',
+      },
+    ] as never);
+
+    const context = await buildSproutContext('private-household', new Date('2026-07-12T00:00:00Z'));
+    const serialized = JSON.stringify(context);
+    expect(context).toEqual({
+      sanitizedQuestion: undefined,
+      plants: [{ species: 'Monstera deliciosa', light_profile: 'unknown' }],
+      tasks: [
+        {
+          plant_species: 'Monstera deliciosa',
+          task_type: 'water',
+          due_in_days: -2,
+          last_completed_days_ago: 14,
+        },
+      ],
+    });
+    expect(serialized).not.toContain('SENTINEL');
+    expect(serialized).not.toContain('private-household');
+    expect(serialized).not.toContain('private-user');
+  });
+
+  it('redacts plant nicknames and common contact identifiers from questions', () => {
+    const result = redactSproutQuestion(
+      'Is Bertha okay? Email me@example.com or call +1 (530) 555-0100.',
+      [{ name: 'Bertha', species: 'Monstera deliciosa' }]
+    );
+    expect(result).toContain('Monstera deliciosa');
+    expect(result).toContain('[email redacted]');
+    expect(result).toContain('[phone redacted]');
+    expect(result).not.toContain('Bertha');
+    expect(result).not.toContain('me@example.com');
+    expect(result).not.toContain('555-0100');
+  });
+
+  it('signs the request and rejects a response without the provenance contract', async () => {
+    vi.mocked(plantService.getPlants).mockResolvedValue([]);
+    vi.mocked(taskService.getTasks).mockResolvedValue([]);
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          answer: {
+            display_text: 'Grounded.',
+            citations: [],
+            disclosure: '',
+            provenance: 'corpus',
+          },
+          household_observations: [],
+          context_policy: 'household-data-selects-corpus-facts',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+    const result = await askSprout({ householdId: 'hh', question: 'pothos care' });
+    expect(result.text).toBe('Grounded.');
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect((init.headers as Record<string, string>)['X-Sprout-Signature']).toMatch(
+      /^[a-f0-9]{64}$/
+    );
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ answer: { provenance: 'household' } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    await expect(askSprout({ householdId: 'hh', question: 'pothos care' })).rejects.toThrow(
+      'invalid provenance'
+    );
+  });
+
+  it('produces a stable SHA-256 HMAC', () => {
+    expect(signSproutBody('secret', '123', '{}')).toMatch(/^[a-f0-9]{64}$/);
+  });
+});

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,6 +1,6 @@
 # Family Greenhouse public API v1
 #
-# Read-only endpoints scoped to the household that owns the API key. Issue
+# Read and opt-in task-write endpoints scoped to the household that owns the API key. Issue
 # keys from Settings → API keys (Greenhouse plan only). Authenticate either
 # with `Authorization: Bearer fg_...` or `X-Api-Key: fg_...`.
 #
@@ -11,9 +11,9 @@ info:
   title: Family Greenhouse API
   version: 1.0.0
   description: |
-    Read-only access to your household's plants, tasks, and activity feed.
+    Read access to your household's plants, tasks, and activity feed, plus
+    opt-in task completion and snoozing for keys granted `write:tasks`.
     Designed for personal automations (Home Assistant, scripts, dashboards).
-    Write access is not provided in v1 — use the web app to make changes.
 servers:
   - url: https://api.family-greenhouse.example/api/v1
     description: Production
@@ -147,6 +147,74 @@ paths:
               schema:
                 type: array
                 items: { $ref: '#/components/schemas/Task' }
+  /tasks/{id}/complete:
+    post:
+      summary: Complete a task and advance its schedule
+      description: Requires the `write:tasks` scope. The action is attributed to the integration key.
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string, format: uuid }
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                notes: { type: string, maxLength: 500 }
+      responses:
+        '200':
+          description: Completed task with its next due date advanced
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Task' }
+        '403':
+          description: API key lacks `write:tasks`
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '404':
+          description: Task not found
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+  /tasks/{id}/snooze:
+    post:
+      summary: Move a task's next due date forward
+      description: Requires the `write:tasks` scope. The action is attributed to the integration key.
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string, format: uuid }
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                days: { type: integer, minimum: 1, maximum: 365 }
+      responses:
+        '200':
+          description: Snoozed task
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Task' }
+        '403':
+          description: API key lacks `write:tasks`
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '404':
+          description: Task not found
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
   /activity:
     get:
       summary: List recent task completions across the household

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,8 @@
 # Architecture
 
+See [Sprout integration](sprout-integration.md) for the feature-flagged,
+privacy-minimized plant-care assistant boundary.
+
 A family-scale collaborative app, designed for low ops cost: serverless on the backend, a static SPA on the frontend, a single DynamoDB table, and a thin Express mock for local dev that mirrors the production API.
 
 ## Block diagram

--- a/docs/sprout-integration.md
+++ b/docs/sprout-integration.md
@@ -1,0 +1,36 @@
+# Sprout integration
+
+Family Greenhouse can route authenticated plant-care chat through the separate
+Apache-2.0 [Sprout](https://github.com/ChelseaKR/sprout) service. This is a
+first-party API integration, not a code or data merge.
+
+## Privacy boundary
+
+The backend sends only the user's question plus species, a coarse light category,
+task type, and relative days due/completed. Before transmission it replaces known
+plant nicknames with their species and redacts common email and phone patterns. It
+never sends stored notes, photos, household/member IDs, member records, free-form
+locations, coordinates, or exact task timestamps. Sprout rejects unknown payload
+fields and labels corpus answers and household observations separately. As with
+any free-text field, users should not put sensitive personal information in a chat question.
+
+## Enablement
+
+Store the same high-entropy HMAC secret in each deployment. For Family
+Greenhouse, create a Secrets Manager value under the existing
+`family-greenhouse/*` namespace and set:
+
+```hcl
+sprout_integration_enabled   = "1"
+sprout_api_url               = "https://api.sprout.chelseakr.com"
+sprout_integration_secret_id = "family-greenhouse/sprout-integration"
+```
+
+Set `SPROUT_FAMILY_GREENHOUSE_SECRET` to the secret value in the Sprout API
+runtime. Signed requests expire after five minutes. The rollout is read-only;
+task proposals and mutations remain in Family Greenhouse and require the
+existing explicit confirmation flow.
+
+If Sprout is unavailable during the initial rollout, the existing assistant is
+used as a temporary fallback and a structured warning is emitted. Disable the
+feature immediately by clearing `sprout_integration_enabled`.

--- a/frontend/src/features/chat/ChatPage.tsx
+++ b/frontend/src/features/chat/ChatPage.tsx
@@ -97,6 +97,7 @@ export function ChatPage() {
         role: 'assistant',
         text: displayText,
         proposals: data.proposals?.length ? data.proposals : undefined,
+        citations: data.citations?.length ? data.citations : undefined,
       },
     ]);
   }
@@ -251,6 +252,23 @@ export function ChatPage() {
                   <ProposalCard key={p.proposalId ?? `${m.id}#${idx}`} proposal={p} />
                 ))}
               </div>
+            )}
+            {m.role === 'assistant' && m.citations && m.citations.length > 0 && (
+              <ul className="mt-2 max-w-xl space-y-1 text-xs text-gray-600" aria-label="Sources">
+                {m.citations.map((citation) => (
+                  <li key={`${citation.source}:${citation.fetch_date}`}>
+                    <a
+                      className="underline decoration-primary-300 underline-offset-2 hover:text-primary-800"
+                      href={citation.url}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      {citation.title}
+                    </a>{' '}
+                    <span>({citation.fetch_date})</span>
+                  </li>
+                ))}
+              </ul>
             )}
           </div>
         ))}

--- a/frontend/src/features/chat/chatHistory.test.ts
+++ b/frontend/src/features/chat/chatHistory.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { historyToDisplayMessages } from './chatHistory';
+
+describe('chat history', () => {
+  it('restores persisted Sprout citations on reload', () => {
+    const messages = historyToDisplayMessages([
+      {
+        timestamp: '2026-07-12T00:00:00Z',
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Use bright indirect light.' },
+          {
+            type: 'citation',
+            title: 'Monstera care',
+            url: 'https://example.test/monstera',
+            source: 'monstera.md',
+            fetch_date: '2026-05-01',
+          },
+        ],
+      },
+    ]);
+
+    expect(messages).toEqual([
+      {
+        id: 'h-0',
+        role: 'assistant',
+        text: 'Use bright indirect light.',
+        proposals: undefined,
+        citations: [
+          {
+            title: 'Monstera care',
+            url: 'https://example.test/monstera',
+            source: 'monstera.md',
+            fetch_date: '2026-05-01',
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/frontend/src/features/chat/chatHistory.ts
+++ b/frontend/src/features/chat/chatHistory.ts
@@ -11,6 +11,7 @@ export interface DisplayMessage {
   /** Reminder proposals attached to this assistant turn (only on assistant
    *  messages, and only when the bot called `propose_reminder_task`). */
   proposals?: ProposedReminderTask[];
+  citations?: Array<{ title: string; url: string; source: string; fetch_date: string }>;
 }
 
 /**
@@ -35,6 +36,18 @@ export function historyToDisplayMessages(history: ChatMessage[]): DisplayMessage
       .map((b) => b.text ?? '')
       .join('\n')
       .trim();
+    const citations = m.content.flatMap((block) =>
+      block.type === 'citation' && block.title && block.url && block.source && block.fetch_date
+        ? [
+            {
+              title: block.title,
+              url: block.url,
+              source: block.source,
+              fetch_date: block.fetch_date,
+            },
+          ]
+        : []
+    );
 
     if (m.role === 'user') {
       for (const block of m.content) {
@@ -57,6 +70,7 @@ export function historyToDisplayMessages(history: ChatMessage[]): DisplayMessage
         role: 'assistant',
         text,
         proposals: pendingProposals.length > 0 ? pendingProposals : undefined,
+        citations: citations.length > 0 ? citations : undefined,
       });
       pendingProposals = [];
     }

--- a/frontend/src/services/chatService.ts
+++ b/frontend/src/services/chatService.ts
@@ -12,6 +12,11 @@ export interface ChatContentBlock {
   tool_use_id?: string;
   /** tool_result payload — JSON-stringified tool output. */
   content?: string;
+  /** citation blocks persisted by the Sprout integration */
+  title?: string;
+  url?: string;
+  source?: string;
+  fetch_date?: string;
 }
 
 export interface ChatMessage {
@@ -47,6 +52,13 @@ export interface SendMessageResponse {
     inputTokens: number;
     outputTokens: number;
   };
+  provider?: 'sprout' | 'bedrock';
+  citations?: Array<{
+    title: string;
+    url: string;
+    source: string;
+    fetch_date: string;
+  }>;
 }
 
 export interface BudgetSnapshot {

--- a/infrastructure/environments/production/terraform.tfvars
+++ b/infrastructure/environments/production/terraform.tfvars
@@ -1,11 +1,14 @@
-environment        = "production"
-aws_region         = "us-east-1"
-project_name       = "family-greenhouse"
-domain_name        = "familygreenhouse.net"
-alert_email        = "support@familygreenhouse.net"
-email_from_address = "Family Greenhouse <hello@familygreenhouse.net>"
-email_reply_to     = "support@familygreenhouse.net"
-dmarc_rua_email    = "dmarc@familygreenhouse.net"
+environment                    = "production"
+aws_region                     = "us-east-1"
+project_name                   = "family-greenhouse"
+domain_name                    = "familygreenhouse.net"
+application_domain             = "familygreenhouse.net"
+hosted_zone_name               = "familygreenhouse.net"
+application_domain_include_www = true
+alert_email                    = "support@familygreenhouse.net"
+email_from_address             = "Family Greenhouse <hello@familygreenhouse.net>"
+email_reply_to                 = "support@familygreenhouse.net"
+dmarc_rua_email                = "dmarc@familygreenhouse.net"
 
 # Perenual: only the secret NAME goes through Terraform. The actual API key
 # was put into Secrets Manager via the AWS CLI and is never tracked by IAC.

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -26,6 +26,11 @@ provider "aws" {
   }
 }
 
+locals {
+  application_domain = var.application_domain != "" ? var.application_domain : var.domain_name
+  hosted_zone_name   = var.hosted_zone_name != "" ? var.hosted_zone_name : var.domain_name
+}
+
 # Provider for CloudFront certificates (must be us-east-1)
 provider "aws" {
   alias  = "us_east_1"
@@ -100,13 +105,16 @@ module "api" {
   # — set via tfvars when you have credentials.
   # Perenual uses the Secrets-Manager-ID indirection so the API key never
   # touches Terraform state (see modules/api/main.tf IAM block).
-  perenual_api_key_secret_id = var.perenual_api_key_secret_id
-  perenual_daily_budget      = var.perenual_daily_budget
-  openweather_api_key        = var.openweather_api_key
-  openweather_daily_budget   = var.openweather_daily_budget
-  bedrock_embed_model_id     = var.bedrock_embed_model_id
-  identify_metering_enabled  = var.identify_metering_enabled
-  sms_notifications_enabled  = var.sms_notifications_enabled
+  perenual_api_key_secret_id   = var.perenual_api_key_secret_id
+  perenual_daily_budget        = var.perenual_daily_budget
+  openweather_api_key          = var.openweather_api_key
+  openweather_daily_budget     = var.openweather_daily_budget
+  bedrock_embed_model_id       = var.bedrock_embed_model_id
+  sprout_integration_enabled   = var.sprout_integration_enabled
+  sprout_api_url               = var.sprout_api_url
+  sprout_integration_secret_id = var.sprout_integration_secret_id
+  identify_metering_enabled    = var.identify_metering_enabled
+  sms_notifications_enabled    = var.sms_notifications_enabled
 
   # Stripe. See variables.tf — these must be declared at THIS level too, or
   # Terraform silently drops the tfvars/TF_VAR_* values (undeclared variable
@@ -141,9 +149,11 @@ module "frontend" {
     aws.us_east_1 = aws.us_east_1
   }
 
-  environment  = var.environment
-  project_name = var.project_name
-  domain_name  = var.domain_name
+  environment       = var.environment
+  project_name      = var.project_name
+  domain_name       = local.application_domain
+  hosted_zone_name  = local.hosted_zone_name
+  include_www_alias = var.application_domain_include_www
 }
 
 # Monitoring module (CloudWatch)

--- a/infrastructure/modules/api/main.tf
+++ b/infrastructure/modules/api/main.tf
@@ -323,12 +323,15 @@ locals {
     PERENUAL_DAILY_BUDGET      = var.perenual_daily_budget
     # Bedrock embedding model for the chat RAG corpus. Empty lets the code
     # default to amazon.titan-embed-text-v2:0.
-    BEDROCK_EMBED_MODEL_ID    = var.bedrock_embed_model_id
-    SENTRY_DSN                = var.sentry_dsn
-    SENTRY_TRACES_SAMPLE_RATE = var.sentry_traces_sample_rate
-    GIT_SHA                   = var.git_sha
-    CHAT_BUDGET_INPUT_TOKENS  = var.chat_budget_input_tokens
-    CHAT_BUDGET_OUTPUT_TOKENS = var.chat_budget_output_tokens
+    BEDROCK_EMBED_MODEL_ID       = var.bedrock_embed_model_id
+    SPROUT_INTEGRATION_ENABLED   = var.sprout_integration_enabled
+    SPROUT_API_URL               = var.sprout_api_url
+    SPROUT_INTEGRATION_SECRET_ID = var.sprout_integration_secret_id
+    SENTRY_DSN                   = var.sentry_dsn
+    SENTRY_TRACES_SAMPLE_RATE    = var.sentry_traces_sample_rate
+    GIT_SHA                      = var.git_sha
+    CHAT_BUDGET_INPUT_TOKENS     = var.chat_budget_input_tokens
+    CHAT_BUDGET_OUTPUT_TOKENS    = var.chat_budget_output_tokens
     # PostHog server-side analytics. Powers confirmed conversion events from
     # the Stripe webhook (subscription_activated). Empty key = emitter no-ops,
     # so nothing leaks from environments without a configured project key.

--- a/infrastructure/modules/api/variables.tf
+++ b/infrastructure/modules/api/variables.tf
@@ -213,6 +213,24 @@ variable "bedrock_embed_model_id" {
   default     = ""
 }
 
+variable "sprout_integration_enabled" {
+  description = "Set to '1' to enable the first-party Sprout chat path."
+  type        = string
+  default     = ""
+}
+
+variable "sprout_api_url" {
+  description = "Base URL for the Sprout API."
+  type        = string
+  default     = ""
+}
+
+variable "sprout_integration_secret_id" {
+  description = "Secrets Manager id containing the Sprout HMAC secret."
+  type        = string
+  default     = ""
+}
+
 # --- Sentry / release tagging ---
 variable "sentry_dsn" {
   description = "Sentry DSN. Empty = Sentry disabled (instrument() falls through to a no-op wrapper)."

--- a/infrastructure/modules/frontend/main.tf
+++ b/infrastructure/modules/frontend/main.tf
@@ -7,6 +7,14 @@ terraform {
   }
 }
 
+locals {
+  frontend_aliases = var.domain_name == "" ? [] : concat(
+    [var.domain_name],
+    var.include_www_alias ? ["www.${var.domain_name}"] : []
+  )
+  route53_zone_name = var.hosted_zone_name != "" ? var.hosted_zone_name : var.domain_name
+}
+
 # Frontend S3 Bucket
 resource "aws_s3_bucket" "frontend" {
   bucket = "${var.project_name}-frontend-${var.environment}-${random_id.bucket_suffix.hex}"
@@ -154,7 +162,7 @@ resource "aws_s3_bucket_cors_configuration" "images" {
     # Pin CORS to that origin instead of "*" (which let any site script the
     # cross-origin upload). Falls back to "*" only in the no-domain dev
     # environment, where there is no stable site origin to pin to.
-    allowed_origins = var.domain_name == "" ? ["*"] : ["https://${var.domain_name}", "https://www.${var.domain_name}"]
+    allowed_origins = var.domain_name == "" ? ["*"] : [for alias in local.frontend_aliases : "https://${alias}"]
     max_age_seconds = 3600
   }
 }
@@ -247,7 +255,7 @@ resource "aws_cloudfront_distribution" "frontend" {
     }
   }
 
-  aliases = var.domain_name == "" ? [] : [var.domain_name, "www.${var.domain_name}"]
+  aliases = local.frontend_aliases
 
   viewer_certificate {
     cloudfront_default_certificate = var.domain_name == ""
@@ -267,11 +275,12 @@ resource "aws_cloudfront_distribution" "frontend" {
 }
 
 # Custom domain wiring (only when var.domain_name is set).
-# The hosted zone is auto-created by Route 53 when the domain is registered,
-# so we read it via a data source rather than managing it here.
+# The application hostname may be a subdomain, while Route 53 owns its parent
+# zone. Keep those concepts separate so greenhouse.chelseakr.com correctly
+# resolves inside the chelseakr.com hosted zone.
 data "aws_route53_zone" "primary" {
   count        = var.domain_name == "" ? 0 : 1
-  name         = var.domain_name
+  name         = local.route53_zone_name
   private_zone = false
 }
 
@@ -280,7 +289,7 @@ resource "aws_acm_certificate" "frontend" {
   count                     = var.domain_name == "" ? 0 : 1
   provider                  = aws.us_east_1
   domain_name               = var.domain_name
-  subject_alternative_names = ["www.${var.domain_name}"]
+  subject_alternative_names = var.include_www_alias ? ["www.${var.domain_name}"] : []
   validation_method         = "DNS"
 
   lifecycle {
@@ -331,7 +340,7 @@ resource "aws_route53_record" "apex" {
 }
 
 resource "aws_route53_record" "www" {
-  count   = var.domain_name == "" ? 0 : 1
+  count   = var.domain_name == "" || !var.include_www_alias ? 0 : 1
   zone_id = data.aws_route53_zone.primary[0].zone_id
   name    = "www.${var.domain_name}"
   type    = "A"

--- a/infrastructure/modules/frontend/variables.tf
+++ b/infrastructure/modules/frontend/variables.tf
@@ -13,3 +13,15 @@ variable "domain_name" {
   type        = string
   default     = ""
 }
+
+variable "hosted_zone_name" {
+  description = "Route 53 hosted zone containing domain_name"
+  type        = string
+  default     = ""
+}
+
+variable "include_www_alias" {
+  description = "Whether to provision www.<domain_name> as a second alias"
+  type        = bool
+  default     = true
+}

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -21,9 +21,27 @@ variable "project_name" {
 }
 
 variable "domain_name" {
-  description = "Domain name for the application (optional)"
+  description = "Email/organizational domain. Also used as the legacy application domain when application_domain is blank."
   type        = string
   default     = ""
+}
+
+variable "application_domain" {
+  description = "User-facing application hostname. May be a subdomain; defaults to domain_name for backward compatibility."
+  type        = string
+  default     = ""
+}
+
+variable "hosted_zone_name" {
+  description = "Route 53 public hosted-zone name containing application_domain. Defaults to domain_name."
+  type        = string
+  default     = ""
+}
+
+variable "application_domain_include_www" {
+  description = "Create a www alias and certificate SAN. Usually false for an application subdomain."
+  type        = bool
+  default     = true
 }
 
 variable "alert_email" {
@@ -110,6 +128,28 @@ variable "openweather_daily_budget" {
 
 variable "bedrock_embed_model_id" {
   description = "Bedrock embedding model ID for the chat RAG corpus. Blank lets the code default (amazon.titan-embed-text-v2:0) apply."
+  type        = string
+  default     = ""
+}
+
+variable "sprout_integration_enabled" {
+  description = "Set to '1' to route plant-care chat through the first-party Sprout service."
+  type        = string
+  default     = ""
+  validation {
+    condition     = contains(["", "1"], var.sprout_integration_enabled)
+    error_message = "sprout_integration_enabled must be blank or '1'."
+  }
+}
+
+variable "sprout_api_url" {
+  description = "Base URL of the hosted Sprout API."
+  type        = string
+  default     = ""
+}
+
+variable "sprout_integration_secret_id" {
+  description = "Secrets Manager id containing the shared Sprout HMAC secret."
   type        = string
   default     = ""
 }


### PR DESCRIPTION
## Summary
- route paid plant-care chat through Sprout behind a runtime feature flag
- send only minimized context, redact known nicknames/contact identifiers, and authenticate with HMAC
- persist and render Sprout citations; preserve existing Bedrock fallback and confirmed task flow
- separate application hostname from Route 53 hosted zone in Terraform
- correct the public OpenAPI task-write contract

## Verification
- npm run verify
- 1,511 tests green
- Terraform formatting and validation green

Companion API: ChelseaKR/sprout (companion PR).