### PR TITLE
fix: prepare exact native CORS rollout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ reaches 1.0.0 (pre-1.0: minor bumps may include breaking changes — see
 
 ## [Unreleased]
 
+## [0.16.1] - 2026-07-12
+
+### Fixed
+
+- Production deployment no longer passes the iOS `capacitor://` WebView origin to AWS-managed
+  CORS APIs, which reject custom URL schemes; AWS retains the valid web and Android origins while
+  the backend prepares exact-origin preflight handling for the complete native allowlist.
+- CORS preflight metadata now includes the implemented `PATCH` method and all four supported
+  request headers, with exact-origin tests for web, iOS, Android, and rejected callers.
+- Streaming chat now advertises only its `POST` contract, rejects other non-preflight methods,
+  and refuses wildcard CORS configuration so origin-policy drift fails closed.
+
 ## [0.16.0] - 2026-07-12
 
 ### Added

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Family Greenhouse API — AWS Lambda + DynamoDB single-table + Cognito, with a local Express mock that mirrors the handlers.",
   "license": "Elastic-2.0",
   "private": true,

--- a/backend/src/handlers/api/handler.ts
+++ b/backend/src/handlers/api/handler.ts
@@ -37,6 +37,18 @@ import { successResponse } from '../../utils/response.js';
 const apiRateLimit = () => rateLimit({ perWindowMs: 60_000, max: 120 });
 const perKeyRateLimit = () => userRateLimit({ perWindowMs: 60_000, max: 60 });
 
+// OPTIONS /{proxy+}
+// Catch-all unauthenticated preflight route. Middy's CORS `before` hook
+// short-circuits this handler with a 204 and the exact matching origin; the
+// body below is only a defensive fallback if middleware behavior changes.
+export const preflight = createHandler((): Promise<APIGatewayProxyResult> =>
+  Promise.resolve({
+    statusCode: 204,
+    headers: {},
+    body: '',
+  })
+);
+
 // GET /api/v1/me
 // Returns the household this API key is scoped to.
 export const me = createHandler((event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
@@ -252,6 +264,7 @@ export const health = createHandler(async (): Promise<APIGatewayProxyResult> => 
 
 // Lambda entrypoint: dispatch this group's routes (see middleware/router.ts).
 export const handler = createRouter({
+  'OPTIONS /{proxy+}': preflight,
   'GET /health': health,
   'GET /api/v1/me': me,
   'GET /api/v1/plants': listPlants,

--- a/backend/src/handlers/chat/streamHandler.ts
+++ b/backend/src/handlers/chat/streamHandler.ts
@@ -31,6 +31,7 @@
  * speaks the same protocol so the frontend path is exercisable offline.
  */
 import { z } from 'zod';
+import { corsHeadersForRequest } from '../../middleware/cors.js';
 import { logger } from '../../utils/logger.js';
 import { verifyCognitoIdToken } from '../../utils/jwtVerify.js';
 import { getMemberByUserId } from '../../services/householdService.js';
@@ -43,6 +44,9 @@ const sendMessageSchema = z.object({
   // completes server-side isn't re-run when the client falls back.
   turnId: z.string().uuid().optional(),
 });
+
+const STREAM_CORS_ALLOWED_HEADERS = ['Content-Type', 'Authorization', 'X-Household-Id'] as const;
+const STREAM_CORS_ALLOWED_METHODS = ['POST', 'OPTIONS'] as const;
 
 /**
  * Minimal shape of the Function URL (payload v2) event we read. Deliberately
@@ -61,7 +65,7 @@ interface StreamRequestEvent {
    * `requestContext.authorizer`: on an auth-NONE Function URL that field IS
    * caller-controlled and is never trusted here for identity (see module doc).
    */
-  requestContext?: { http?: { sourceIp?: string } };
+  requestContext?: { http?: { method?: string; sourceIp?: string } };
 }
 
 /** Writable side of awslambda's responseStream (Node Writable subset). */
@@ -98,6 +102,40 @@ class HttpishError extends Error {
   ) {
     super(message);
   }
+}
+
+function applicationCorsEnabled(): boolean {
+  return process.env.APPLICATION_CORS_ENABLED === 'true';
+}
+
+function applicationCorsHeaders(event: StreamRequestEvent): Record<string, string> {
+  return applicationCorsEnabled()
+    ? corsHeadersForRequest(event.headers, {
+        allowedHeaders: STREAM_CORS_ALLOWED_HEADERS,
+        allowedMethods: STREAM_CORS_ALLOWED_METHODS,
+      })
+    : {};
+}
+
+function requestMethod(event: StreamRequestEvent): string | undefined {
+  return event.requestContext?.http?.method?.toUpperCase();
+}
+
+function isPreflight(event: StreamRequestEvent): boolean {
+  return requestMethod(event) === 'OPTIONS';
+}
+
+function isDisallowedMethod(event: StreamRequestEvent): boolean {
+  const method = requestMethod(event);
+  return method !== undefined && method !== 'POST';
+}
+
+function methodNotAllowedHeaders(corsHeaders: Record<string, string>): Record<string, string> {
+  return {
+    'Content-Type': 'application/json',
+    Allow: STREAM_CORS_ALLOWED_METHODS.join(', '),
+    ...corsHeaders,
+  };
 }
 
 /**
@@ -251,6 +289,25 @@ export async function streamRequestToSse(
   responseStream: ResponseStreamLike
 ): Promise<void> {
   const httpResponseStream = (globalThis as StreamifyCapableGlobal).awslambda?.HttpResponseStream;
+  const corsHeaders = applicationCorsHeaders(event);
+  if (applicationCorsEnabled() && isPreflight(event)) {
+    const out = httpResponseStream
+      ? httpResponseStream.from(responseStream, { statusCode: 204, headers: corsHeaders })
+      : responseStream;
+    out.end();
+    return;
+  }
+  if (isDisallowedMethod(event)) {
+    const out = httpResponseStream
+      ? httpResponseStream.from(responseStream, {
+          statusCode: 405,
+          headers: methodNotAllowedHeaders(corsHeaders),
+        })
+      : responseStream;
+    out.write(JSON.stringify({ message: 'Method Not Allowed' }));
+    out.end();
+    return;
+  }
   let user: { userId: string; householdId: string };
   let body: { message: string; conversationId?: string; turnId?: string };
   try {
@@ -265,7 +322,7 @@ export async function streamRequestToSse(
     const out = httpResponseStream
       ? httpResponseStream.from(responseStream, {
           statusCode,
-          headers: { 'Content-Type': 'application/json' },
+          headers: { 'Content-Type': 'application/json', ...corsHeaders },
         })
       : responseStream;
     out.write(JSON.stringify({ message: (err as Error).message || 'Chat request failed' }));
@@ -276,7 +333,11 @@ export async function streamRequestToSse(
   const out = httpResponseStream
     ? httpResponseStream.from(responseStream, {
         statusCode: 200,
-        headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-store' },
+        headers: {
+          'Content-Type': 'text/event-stream',
+          'Cache-Control': 'no-store',
+          ...corsHeaders,
+        },
       })
     : responseStream;
   try {
@@ -319,13 +380,24 @@ const streamify = (globalThis as StreamifyCapableGlobal).awslambda?.streamifyRes
 async function bufferedHandler(
   event: StreamRequestEvent
 ): Promise<{ statusCode: number; headers: Record<string, string>; body: string }> {
+  const corsHeaders = applicationCorsHeaders(event);
+  if (applicationCorsEnabled() && isPreflight(event)) {
+    return { statusCode: 204, headers: corsHeaders, body: '' };
+  }
+  if (isDisallowedMethod(event)) {
+    return {
+      statusCode: 405,
+      headers: methodNotAllowedHeaders(corsHeaders),
+      body: JSON.stringify({ message: 'Method Not Allowed' }),
+    };
+  }
   try {
     const { userId, householdId } = await resolveUser(event);
     const { message, conversationId, turnId } = parseBody(event);
     const result = await runChatTurn({ userId, householdId, conversationId, message, turnId });
     return {
       statusCode: 200,
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...corsHeaders },
       body: JSON.stringify(result),
     };
   } catch (err) {
@@ -335,7 +407,7 @@ async function bufferedHandler(
         : ((err as { statusCode?: number }).statusCode ?? 500);
     return {
       statusCode,
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...corsHeaders },
       body: JSON.stringify({ message: (err as Error).message || 'Chat request failed' }),
     };
   }

--- a/backend/src/local-server.ts
+++ b/backend/src/local-server.ts
@@ -53,6 +53,10 @@ if (process.env.NODE_ENV === 'production') {
 export const app = express();
 const PORT = process.env.PORT || 4000;
 
+// Mirror API Gateway's unauthenticated OPTIONS /{proxy+} route. The general
+// CORS middleware below also answers preflights, but registering the route
+// explicitly keeps the mock and production route surfaces in lockstep.
+app.options('/*proxy', cors());
 app.use(cors());
 app.use(express.json());
 

--- a/backend/src/middleware/cors.ts
+++ b/backend/src/middleware/cors.ts
@@ -1,0 +1,83 @@
+/**
+ * Shared exact-origin CORS policy.
+ *
+ * ALLOWED_ORIGIN is ordered: the public web origin first (also used for link
+ * building), followed by the Capacitor shell origins. Custom WebView schemes
+ * such as capacitor:// are valid browser origins but are rejected by AWS's
+ * managed API Gateway / Function URL CORS APIs, so the application layer is
+ * the eventual source of truth for the complete list.
+ */
+
+export const CORS_ALLOWED_HEADERS = [
+  'Content-Type',
+  'Authorization',
+  'X-Household-Id',
+  'X-Cognito-Access-Token',
+] as const;
+
+export const CORS_ALLOWED_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'] as const;
+
+export const CORS_MAX_AGE_SECONDS = 300;
+
+interface CorsResponsePolicy {
+  allowedHeaders?: readonly string[];
+  allowedMethods?: readonly string[];
+  maxAgeSeconds?: number;
+}
+
+export function resolveCorsOrigins(): string[] {
+  const allowed = process.env.ALLOWED_ORIGIN;
+  if (allowed && allowed.length > 0) {
+    const origins = allowed
+      .split(',')
+      .map((origin) => origin.trim())
+      .filter((origin) => origin.length > 0);
+    if (origins.length === 0) {
+      throw new Error('ALLOWED_ORIGIN must contain at least one exact origin');
+    }
+    if (origins.some((origin) => origin.includes('*'))) {
+      throw new Error('ALLOWED_ORIGIN wildcards are not permitted');
+    }
+    return origins;
+  }
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error('ALLOWED_ORIGIN must be set in production');
+  }
+  return ['http://localhost:3000'];
+}
+
+/** The user-facing web origin (the first allowlist entry), for link building. */
+export function firstAllowedOrigin(): string | undefined {
+  return resolveCorsOrigins()[0];
+}
+
+function requestOrigin(headers?: Record<string, string | undefined>): string | undefined {
+  return headers?.origin ?? headers?.Origin;
+}
+
+/**
+ * Headers for responses that cannot use Middy's normal CORS middleware (the
+ * outer router's 404 and the streaming Function URL). Unknown origins never
+ * receive Access-Control-Allow-Origin; exact matching is deliberate.
+ */
+export function corsHeadersForRequest(
+  headers?: Record<string, string | undefined>,
+  policy: CorsResponsePolicy = {}
+): Record<string, string> {
+  const origin = requestOrigin(headers);
+  const responseHeaders: Record<string, string> = { Vary: 'Origin' };
+  if (!origin || !resolveCorsOrigins().includes(origin)) return responseHeaders;
+
+  const allowedHeaders = policy.allowedHeaders ?? CORS_ALLOWED_HEADERS;
+  const allowedMethods = policy.allowedMethods ?? CORS_ALLOWED_METHODS;
+  const maxAgeSeconds = policy.maxAgeSeconds ?? CORS_MAX_AGE_SECONDS;
+
+  return {
+    ...responseHeaders,
+    'Access-Control-Allow-Origin': origin,
+    'Access-Control-Allow-Credentials': 'true',
+    'Access-Control-Allow-Headers': allowedHeaders.join(', '),
+    'Access-Control-Allow-Methods': allowedMethods.join(', '),
+    'Access-Control-Max-Age': String(maxAgeSeconds),
+  };
+}

--- a/backend/src/middleware/handler.ts
+++ b/backend/src/middleware/handler.ts
@@ -16,6 +16,12 @@ import httpCors from '@middy/http-cors';
 import httpJsonBodyParser from '@middy/http-json-body-parser';
 import { Handler } from 'aws-lambda';
 import { bodySizeGuard } from './bodySize.js';
+import {
+  CORS_ALLOWED_HEADERS,
+  CORS_ALLOWED_METHODS,
+  CORS_MAX_AGE_SECONDS,
+  resolveCorsOrigins,
+} from './cors.js';
 import { loggingMiddleware } from './logging.js';
 import { securityHeaders } from './securityHeaders.js';
 
@@ -66,34 +72,20 @@ function jsonErrorHandler(): middy.MiddlewareObj<unknown, unknown> {
   return { onError };
 }
 
-/**
- * ALLOWED_ORIGIN is a comma-separated list: the web origin first, then the
- * Capacitor shell origins (`capacitor://localhost` on iOS, `https://localhost`
- * on Android — the schemes the native WebViews serve the bundled app from).
- * middy's http-cors echoes whichever listed origin the request presented,
- * which is required with credentials:true (a literal list in the header is
- * not valid CORS). Link-building code that falls back to ALLOWED_ORIGIN must
- * take the FIRST entry (the web origin) — see firstAllowedOrigin.
- */
-function resolveCorsOrigins(): string[] {
-  const allowed = process.env.ALLOWED_ORIGIN;
-  if (allowed && allowed.length > 0) {
-    return allowed
-      .split(',')
-      .map((o) => o.trim())
-      .filter((o) => o.length > 0);
-  }
-  // Wildcard with credentials:true is rejected by browsers and unsafe; only
-  // permit a wildcard in local development where ALLOWED_ORIGIN is unset.
-  if (process.env.NODE_ENV === 'production') {
-    throw new Error('ALLOWED_ORIGIN must be set in production');
-  }
-  return ['http://localhost:3000'];
-}
+export { firstAllowedOrigin } from './cors.js';
 
-/** The user-facing WEB origin (first ALLOWED_ORIGIN entry), for link building. */
-export function firstAllowedOrigin(): string | undefined {
-  return resolveCorsOrigins()[0];
+function corsOptions() {
+  return {
+    origins: resolveCorsOrigins(),
+    credentials: true,
+    disableBeforePreflightResponse: false,
+    headers: CORS_ALLOWED_HEADERS.join(', '),
+    methods: CORS_ALLOWED_METHODS.join(', '),
+    maxAge: CORS_MAX_AGE_SECONDS,
+    cacheControl: `public, max-age=${CORS_MAX_AGE_SECONDS}`,
+    requestHeaders: CORS_ALLOWED_HEADERS.map((header) => header.toLowerCase()),
+    requestMethods: [...CORS_ALLOWED_METHODS],
+  };
 }
 
 export function createHandler<TEvent, TResult>(
@@ -107,12 +99,7 @@ export function createHandler<TEvent, TResult>(
       .use(securityHeaders())
       .use(bodySizeGuard(opts?.maxBodyBytes))
       .use(httpJsonBodyParser({ disableContentTypeError: true }))
-      .use(
-        httpCors({
-          origins: resolveCorsOrigins(),
-          credentials: true,
-        })
-      )
+      .use(httpCors(corsOptions()))
       .use(loggingMiddleware())
       .use(jsonErrorHandler())
   );
@@ -131,12 +118,7 @@ export function createRawBodyHandler<TEvent, TResult>(handler: Handler<TEvent, T
   return middy(handler)
     .use(securityHeaders())
     .use(bodySizeGuard())
-    .use(
-      httpCors({
-        origins: resolveCorsOrigins(),
-        credentials: true,
-      })
-    )
+    .use(httpCors(corsOptions()))
     .use(loggingMiddleware())
     .use(jsonErrorHandler());
 }

--- a/backend/src/middleware/router.ts
+++ b/backend/src/middleware/router.ts
@@ -19,36 +19,24 @@
  */
 import type { APIGatewayProxyResult, Context } from 'aws-lambda';
 import { instrument } from '../utils/sentry.js';
+import { corsHeadersForRequest } from './cors.js';
 import { _securityHeaders } from './securityHeaders.js';
 
 /**
  * The inline 404 below never passes through the per-route middy stack, so it
  * misses the `securityHeaders` and `httpCors` middleware every real response
  * gets. Without CORS headers the browser surfaces an opaque CORS error
- * instead of the 404 body. Mirror `resolveCorsOrigins` in handler.ts (not
- * exported there); unlike the cold-start check there we don't throw on a
- * missing ALLOWED_ORIGIN — a 404 without a CORS header beats failing the
- * whole dispatch.
+ * instead of the 404 body. The shared policy fails closed on a missing or
+ * wildcard production allowlist and never authorizes an unknown request
+ * origin.
  */
-function notFoundHeaders(requestOrigin: string | undefined): Record<string, string> {
-  // ALLOWED_ORIGIN is a comma-separated list — web origin first, then the
-  // Capacitor shell origins (see resolveCorsOrigins in handler.ts). Echo the
-  // request's origin when it's on the list; otherwise fall back to the first
-  // (web) entry so the header stays a single valid origin.
-  const allowed = (process.env.ALLOWED_ORIGIN ?? '')
-    .split(',')
-    .map((o) => o.trim())
-    .filter((o) => o.length > 0);
-  const origin =
-    requestOrigin && allowed.includes(requestOrigin)
-      ? requestOrigin
-      : (allowed[0] ?? 'http://localhost:3000');
+function notFoundHeaders(
+  requestHeaders: Record<string, string | undefined> | undefined
+): Record<string, string> {
   return {
     'Content-Type': 'application/json',
     ..._securityHeaders,
-    'Access-Control-Allow-Origin': origin,
-    'Access-Control-Allow-Credentials': 'true',
-    Vary: 'Origin',
+    ...corsHeadersForRequest(requestHeaders),
   };
 }
 
@@ -80,10 +68,9 @@ export function createRouter(routes: Record<string, RouteHandler>): RouterHandle
     const route = routes[key];
     if (!route) {
       const headers = ((event ?? {}) as { headers?: Record<string, string | undefined> }).headers;
-      const requestOrigin = headers?.origin ?? headers?.Origin;
       return Promise.resolve({
         statusCode: 404,
-        headers: notFoundHeaders(requestOrigin),
+        headers: notFoundHeaders(headers),
         body: JSON.stringify({ message: `No route handler for ${key}` }),
       });
     }

--- a/backend/tests/integration/route-parity.test.ts
+++ b/backend/tests/integration/route-parity.test.ts
@@ -50,7 +50,7 @@ const GROUPS: Record<string, { handler: { routes: string[] } }> = {
 
 /** API Gateway routeKey ("GET /plants/{id}") → Express form ("GET /plants/:id"). */
 function toExpressKey(routeKey: string): string {
-  return routeKey.replace(/\{([^}]+)\}/g, ':$1');
+  return routeKey.replace(/\{([^}]+)\+\}/g, '*$1').replace(/\{([^}]+)\}/g, ':$1');
 }
 
 /** Every "METHOD /path" the mock Express app has registered. */

--- a/backend/tests/integration/route-terraform-parity.test.ts
+++ b/backend/tests/integration/route-terraform-parity.test.ts
@@ -59,7 +59,7 @@ const GROUPS: Array<{ handler: { routes: string[] } }> = [
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const MAIN_TF = resolve(__dirname, '../../../infrastructure/modules/api/main.tf');
 
-const ROUTE_KEY = /^"((?:GET|POST|PUT|DELETE|PATCH) \/[^"]*)"\s*=/;
+const ROUTE_KEY = /^"((?:GET|POST|PUT|DELETE|PATCH|OPTIONS) \/[^"]*)"\s*=/;
 
 /**
  * Parse the `route_key` strings out of the `local.routes` map in main.tf.

--- a/backend/tests/unit/handlers/chatStreamHandler.test.ts
+++ b/backend/tests/unit/handlers/chatStreamHandler.test.ts
@@ -53,9 +53,13 @@ function makeStream() {
  * drive `streamRequestToSse` directly.
  */
 const metadataCalls: Array<{ statusCode?: number; headers?: Record<string, string> }> = [];
+const originalAllowedOrigin = process.env.ALLOWED_ORIGIN;
+const originalApplicationCorsEnabled = process.env.APPLICATION_CORS_ENABLED;
 beforeAll(() => {
   process.env.COGNITO_USER_POOL_ID = 'us-east-1_TestPool';
   process.env.COGNITO_CLIENT_ID = 'test-client-id';
+  process.env.ALLOWED_ORIGIN =
+    'https://familygreenhouse.net,capacitor://localhost,https://localhost';
   (globalThis as Record<string, unknown>).awslambda = {
     HttpResponseStream: {
       from: (stream: unknown, metadata: (typeof metadataCalls)[number]) => {
@@ -67,6 +71,10 @@ beforeAll(() => {
 });
 afterAll(() => {
   delete (globalThis as Record<string, unknown>).awslambda;
+  if (originalAllowedOrigin === undefined) delete process.env.ALLOWED_ORIGIN;
+  else process.env.ALLOWED_ORIGIN = originalAllowedOrigin;
+  if (originalApplicationCorsEnabled === undefined) delete process.env.APPLICATION_CORS_ENABLED;
+  else process.env.APPLICATION_CORS_ENABLED = originalApplicationCorsEnabled;
 });
 
 beforeEach(() => {
@@ -75,6 +83,7 @@ beforeEach(() => {
   // Rate-limit buckets are module-level and per-warm-container; reset them so
   // one test's requests don't count against the next.
   __resetChatStreamRateLimitForTests();
+  delete process.env.APPLICATION_CORS_ENABLED;
 });
 
 const validClaims = {
@@ -100,6 +109,111 @@ async function* fakeTurn() {
 }
 
 describe('streamHandler auth (in-handler JWT verification)', () => {
+  it('answers an allowed iOS preflight before auth when application CORS is enabled', async () => {
+    process.env.APPLICATION_CORS_ENABLED = 'true';
+    const stream = makeStream();
+    await streamRequestToSse(
+      makeEvent({
+        headers: { origin: 'capacitor://localhost' },
+        requestContext: { http: { method: 'OPTIONS', sourceIp: '203.0.113.8' } },
+      }),
+      stream
+    );
+
+    expect(metadataCalls[0]).toMatchObject({
+      statusCode: 204,
+      headers: {
+        'Access-Control-Allow-Origin': 'capacitor://localhost',
+        'Access-Control-Allow-Credentials': 'true',
+        'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-Household-Id',
+        'Access-Control-Allow-Methods': 'POST, OPTIONS',
+        Vary: 'Origin',
+      },
+    });
+    expect(mockVerify).not.toHaveBeenCalled();
+    expect(streamChatTurn).not.toHaveBeenCalled();
+    expect(stream.end).toHaveBeenCalled();
+  });
+
+  it('does not authorize an unknown stream preflight origin', async () => {
+    process.env.APPLICATION_CORS_ENABLED = 'true';
+    const stream = makeStream();
+    await streamRequestToSse(
+      makeEvent({
+        headers: { origin: 'https://attacker.example' },
+        requestContext: { http: { method: 'OPTIONS', sourceIp: '203.0.113.9' } },
+      }),
+      stream
+    );
+
+    expect(metadataCalls[0]?.statusCode).toBe(204);
+    expect(metadataCalls[0]?.headers?.['Access-Control-Allow-Origin']).toBeUndefined();
+    expect(metadataCalls[0]?.headers?.Vary).toBe('Origin');
+  });
+
+  it('adds exact CORS headers to an allowed POST error response', async () => {
+    process.env.APPLICATION_CORS_ENABLED = 'true';
+    const stream = makeStream();
+    await streamRequestToSse(
+      makeEvent({
+        headers: { origin: 'capacitor://localhost' },
+        requestContext: { http: { method: 'POST', sourceIp: '203.0.113.11' } },
+      }),
+      stream
+    );
+
+    expect(metadataCalls[0]).toMatchObject({
+      statusCode: 401,
+      headers: {
+        'Access-Control-Allow-Origin': 'capacitor://localhost',
+        'Access-Control-Allow-Methods': 'POST, OPTIONS',
+        Vary: 'Origin',
+      },
+    });
+  });
+
+  it('does not add an allow-origin header to an unknown-origin POST error', async () => {
+    process.env.APPLICATION_CORS_ENABLED = 'true';
+    const stream = makeStream();
+    await streamRequestToSse(
+      makeEvent({
+        headers: { origin: 'https://attacker.example' },
+        requestContext: { http: { method: 'POST', sourceIp: '203.0.113.12' } },
+      }),
+      stream
+    );
+
+    expect(metadataCalls[0]?.statusCode).toBe(401);
+    expect(metadataCalls[0]?.headers?.['Access-Control-Allow-Origin']).toBeUndefined();
+    expect(metadataCalls[0]?.headers?.Vary).toBe('Origin');
+  });
+
+  it('rejects non-POST methods before auth or a chat turn', async () => {
+    process.env.APPLICATION_CORS_ENABLED = 'true';
+    const stream = makeStream();
+    await streamRequestToSse(
+      makeEvent({
+        headers: {
+          authorization: 'Bearer some.jwt.token',
+          origin: 'capacitor://localhost',
+        },
+        requestContext: { http: { method: 'PATCH', sourceIp: '203.0.113.10' } },
+      }),
+      stream
+    );
+
+    expect(metadataCalls[0]).toMatchObject({
+      statusCode: 405,
+      headers: {
+        Allow: 'POST, OPTIONS',
+        'Access-Control-Allow-Origin': 'capacitor://localhost',
+      },
+    });
+    expect(JSON.parse(stream.chunks.join(''))).toEqual({ message: 'Method Not Allowed' });
+    expect(mockVerify).not.toHaveBeenCalled();
+    expect(streamChatTurn).not.toHaveBeenCalled();
+  });
+
   it('401s when no Authorization header is present, without verifying or streaming', async () => {
     const stream = makeStream();
     await streamRequestToSse(makeEvent({ headers: {} }), stream);
@@ -171,6 +285,7 @@ describe('streamHandler auth (in-handler JWT verification)', () => {
   });
 
   it('streams SSE events for a verified member (status 200, text/event-stream)', async () => {
+    process.env.APPLICATION_CORS_ENABLED = 'true';
     mockVerify.mockResolvedValue(validClaims);
     vi.mocked(getMemberByUserId).mockResolvedValue({
       userId: 'user-1',
@@ -178,10 +293,22 @@ describe('streamHandler auth (in-handler JWT verification)', () => {
     } as Awaited<ReturnType<typeof getMemberByUserId>>);
     vi.mocked(streamChatTurn).mockImplementation(fakeTurn as unknown as typeof streamChatTurn);
     const stream = makeStream();
-    await streamRequestToSse(makeEvent(), stream);
+    await streamRequestToSse(
+      makeEvent({
+        headers: {
+          authorization: 'Bearer some.jwt.token',
+          origin: 'capacitor://localhost',
+        },
+        requestContext: { http: { method: 'POST', sourceIp: '203.0.113.13' } },
+      }),
+      stream
+    );
 
     expect(metadataCalls[0]?.statusCode).toBe(200);
     expect(metadataCalls[0]?.headers?.['Content-Type']).toBe('text/event-stream');
+    expect(metadataCalls[0]?.headers?.['Access-Control-Allow-Origin']).toBe(
+      'capacitor://localhost'
+    );
     expect(streamChatTurn).toHaveBeenCalledWith({
       userId: 'user-1',
       householdId: 'hh-claim',
@@ -232,5 +359,19 @@ describe('streamHandler auth (in-handler JWT verification)', () => {
     };
     expect(result.statusCode).toBe(401);
     expect(JSON.parse(result.body)).toEqual({ message: 'Unauthorized' });
+  });
+
+  it('buffered fallback handler rejects non-POST methods', async () => {
+    const result = (await (handler as (e: unknown) => Promise<unknown>)(
+      makeEvent({ requestContext: { http: { method: 'DELETE' } } })
+    )) as {
+      statusCode: number;
+      headers: Record<string, string>;
+      body: string;
+    };
+    expect(result.statusCode).toBe(405);
+    expect(result.headers.Allow).toBe('POST, OPTIONS');
+    expect(JSON.parse(result.body)).toEqual({ message: 'Method Not Allowed' });
+    expect(mockVerify).not.toHaveBeenCalled();
   });
 });

--- a/backend/tests/unit/middleware/cors.test.ts
+++ b/backend/tests/unit/middleware/cors.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { APIGatewayProxyEventV2, APIGatewayProxyResultV2, Context } from 'aws-lambda';
+import { createHandler } from '../../../src/middleware/handler.js';
+import { resolveCorsOrigins } from '../../../src/middleware/cors.js';
+
+const ctx = {} as Context;
+const originalAllowedOrigin = process.env.ALLOWED_ORIGIN;
+
+function preflightEvent(origin: string): APIGatewayProxyEventV2 {
+  return {
+    version: '2.0',
+    routeKey: 'OPTIONS /{proxy+}',
+    rawPath: '/plants',
+    rawQueryString: '',
+    headers: {
+      origin,
+      'access-control-request-method': 'PATCH',
+      'access-control-request-headers':
+        'authorization, content-type, x-household-id, x-cognito-access-token',
+    },
+    requestContext: {
+      accountId: 'test',
+      apiId: 'test',
+      domainName: 'test.execute-api.us-east-1.amazonaws.com',
+      domainPrefix: 'test',
+      http: {
+        method: 'OPTIONS',
+        path: '/plants',
+        protocol: 'HTTP/1.1',
+        sourceIp: '127.0.0.1',
+        userAgent: 'vitest',
+      },
+      requestId: 'request-1',
+      routeKey: 'OPTIONS /{proxy+}',
+      stage: 'production',
+      time: '12/Jul/2026:20:00:00 +0000',
+      timeEpoch: 0,
+    },
+    isBase64Encoded: false,
+  };
+}
+
+async function invoke(origin: string) {
+  const base = vi.fn(async () => ({ statusCode: 500, body: 'should not run' }));
+  const handler = createHandler(base);
+  const response = (await handler(
+    preflightEvent(origin),
+    ctx,
+    () => undefined
+  )) as APIGatewayProxyResultV2;
+  return { base, response: response as { statusCode: number; headers: Record<string, string> } };
+}
+
+beforeEach(() => {
+  process.env.ALLOWED_ORIGIN =
+    'https://familygreenhouse.net,capacitor://localhost,https://localhost';
+});
+
+afterEach(() => {
+  if (originalAllowedOrigin === undefined) delete process.env.ALLOWED_ORIGIN;
+  else process.env.ALLOWED_ORIGIN = originalAllowedOrigin;
+});
+
+describe('application CORS preflight', () => {
+  for (const origin of [
+    'https://familygreenhouse.net',
+    'capacitor://localhost',
+    'https://localhost',
+  ]) {
+    it(`returns an exact-origin 204 for ${origin}`, async () => {
+      const { base, response } = await invoke(origin);
+
+      expect(base).not.toHaveBeenCalled();
+      expect(response.statusCode).toBe(204);
+      expect(response.headers['Access-Control-Allow-Origin']).toBe(origin);
+      expect(response.headers['Access-Control-Allow-Credentials']).toBe('true');
+      expect(response.headers['Access-Control-Allow-Methods']).toContain('PATCH');
+      expect(response.headers['Access-Control-Allow-Headers']).toContain('X-Household-Id');
+      expect(response.headers.Vary).toContain('Origin');
+    });
+  }
+
+  it('does not authorize an unknown origin', async () => {
+    const { base, response } = await invoke('https://attacker.example');
+
+    expect(base).not.toHaveBeenCalled();
+    expect(response.statusCode).toBe(204);
+    expect(response.headers['Access-Control-Allow-Origin']).toBeUndefined();
+  });
+
+  it('rejects wildcard configuration instead of reflecting arbitrary origins', () => {
+    process.env.ALLOWED_ORIGIN = '*';
+    expect(() => resolveCorsOrigins()).toThrow('ALLOWED_ORIGIN wildcards are not permitted');
+  });
+});

--- a/backend/tests/unit/middleware/router.test.ts
+++ b/backend/tests/unit/middleware/router.test.ts
@@ -50,7 +50,13 @@ describe('createRouter', () => {
     // Without these the browser reports an opaque CORS failure instead of
     // surfacing the 404 to the frontend.
     const handler = createRouter(routes);
-    const res = await handler({ routeKey: 'DELETE /plants/{id}' }, ctx);
+    const res = await handler(
+      {
+        routeKey: 'DELETE /plants/{id}',
+        headers: { origin: 'http://localhost:3000' },
+      },
+      ctx
+    );
     expect(res.headers).toMatchObject({
       'Content-Type': 'application/json',
       'Strict-Transport-Security': 'max-age=63072000; includeSubDomains; preload',
@@ -61,6 +67,19 @@ describe('createRouter', () => {
     });
     expect(typeof res.headers?.['Access-Control-Allow-Origin']).toBe('string');
     expect(res.headers?.['Access-Control-Allow-Origin']).not.toBe('');
+  });
+
+  it('does not authorize an unknown origin on an inline 404', async () => {
+    const handler = createRouter(routes);
+    const res = await handler(
+      {
+        routeKey: 'DELETE /plants/{id}',
+        headers: { origin: 'https://attacker.example' },
+      },
+      ctx
+    );
+    expect(res.headers?.['Access-Control-Allow-Origin']).toBeUndefined();
+    expect(res.headers?.Vary).toBe('Origin');
   });
 
   it('exposes its route keys', () => {
@@ -94,7 +113,7 @@ const GROUPS: Record<string, { handler: { routes: string[] } }> = {
 // Previously this regex missed JSDoc-style route docs (e.g. notifications/
 // run-reminders) — and was the reason a couple unregistered routes shipped
 // to production. Code review 2026-06-01.
-const ROUTE_COMMENT = /^(?:\/\/|\*)\s*(GET|POST|PUT|PATCH|DELETE)\s+(\/\S+)/;
+const ROUTE_COMMENT = /^(?:\/\/|\*)\s*(GET|POST|PUT|PATCH|DELETE|OPTIONS)\s+(\/\S+)/;
 
 function canonical(raw: string): string {
   return raw.split('?')[0].replace(/:([A-Za-z0-9_]+)/g, '{$1}');

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Family Greenhouse web app — React + TypeScript + Vite PWA for collaborative household plant care.",
   "license": "Elastic-2.0",
   "type": "module",

--- a/infrastructure/modules/api/main.tf
+++ b/infrastructure/modules/api/main.tf
@@ -6,6 +6,14 @@ locals {
   # the comma-joined ALLOWED_ORIGIN env (middleware/handler.ts
   # firstAllowedOrigin), so order matters here.
   allowed_origins = concat([var.allowed_origin], var.native_app_origins)
+  # AWS managed CORS accepts only HTTP(S) origins. Keep the full exact list in
+  # ALLOWED_ORIGIN for application-managed CORS, but filter custom WebView
+  # schemes (notably capacitor:// on iOS) out of API Gateway / Function URL
+  # configuration during the first phase of the ownership migration.
+  managed_cors_origins = [
+    for origin in local.allowed_origins : origin
+    if can(regex("^https?://", origin))
+  ]
 }
 
 # API Gateway
@@ -14,8 +22,8 @@ resource "aws_apigatewayv2_api" "main" {
   protocol_type = "HTTP"
 
   cors_configuration {
-    allow_origins = local.allowed_origins
-    allow_methods = ["GET", "POST", "PUT", "DELETE", "OPTIONS"]
+    allow_origins = local.managed_cors_origins
+    allow_methods = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]
     # X-Household-Id pins a non-default household per request (see
     # docs/multi-household.md). X-Cognito-Access-Token carries the Cognito
     # access token alongside the ID token for Cognito-direct calls (see
@@ -254,8 +262,7 @@ locals {
 # Environment shared by EVERY backend Lambda — the for_each fleet below AND
 # the standalone chat_stream function (which must see the exact same config:
 # it runs the same chat service code, plus the Cognito vars its in-handler
-# JWT verification depends on). Single source of truth: add new variables
-# HERE, never inline in one function's environment block.
+# JWT verification depends on). Function-specific switches are merged below.
 locals {
   lambda_environment = {
     NODE_ENV             = var.environment
@@ -338,6 +345,15 @@ locals {
     POSTHOG_KEY  = var.posthog_key
     POSTHOG_HOST = var.posthog_host
   }
+
+  # Phase-one safety switch for the standalone streaming function. The API
+  # fleet can emit application CORS behind API Gateway managed CORS, whose
+  # response headers take precedence. Function URL CORS can instead duplicate
+  # handler headers, so keep them disabled until the follow-up release removes
+  # the managed block and flips this switch true.
+  chat_stream_environment = merge(local.lambda_environment, {
+    APPLICATION_CORS_ENABLED = tostring(var.application_cors_enabled)
+  })
 }
 
 resource "aws_lambda_function" "handlers" {
@@ -530,7 +546,7 @@ resource "aws_lambda_function" "chat_stream" {
   source_code_hash = filebase64sha256("${path.module}/placeholder.zip")
 
   environment {
-    variables = local.lambda_environment
+    variables = local.chat_stream_environment
   }
 
   tracing_config {
@@ -573,9 +589,9 @@ resource "aws_lambda_function_url" "chat_stream" {
   invoke_mode        = "RESPONSE_STREAM"
 
   cors {
-    allow_origins = local.allowed_origins
+    allow_origins = local.managed_cors_origins
     allow_methods = ["POST"]
-    allow_headers = ["Content-Type", "Authorization", "X-Household-Id"]
+    allow_headers = ["content-type", "authorization", "x-household-id"]
     max_age       = 300
   }
 }
@@ -647,6 +663,11 @@ resource "aws_apigatewayv2_integration" "handlers" {
 # fails closed (401/locked), never open.
 locals {
   routes = {
+    # Catch-all unauthenticated preflight. While API Gateway managed CORS is
+    # present it answers before routing; this route prepares the application
+    # to take ownership without an API-wide preflight outage.
+    "OPTIONS /{proxy+}" = { group = "api", auth = "none" }
+
     # --- auth (public except authenticated profile/password) ---
     "POST /auth/signup"          = { group = "auth", auth = "none" }
     "POST /auth/resend-code"     = { group = "auth", auth = "none" }

--- a/infrastructure/modules/api/variables.tf
+++ b/infrastructure/modules/api/variables.tf
@@ -56,6 +56,12 @@ variable "native_app_origins" {
   default     = ["capacitor://localhost", "https://localhost"]
 }
 
+variable "application_cors_enabled" {
+  description = "Whether Lambda responses own CORS (enable only after AWS managed CORS blocks are removed)"
+  type        = bool
+  default     = false
+}
+
 variable "bedrock_chat_model_id" {
   description = "Bedrock model ID or inference profile for the chat Lambda. Defaults to '' which lets the Lambda code fall back to Haiku 4.5."
   type        = string

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "family-greenhouse",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "family-greenhouse",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "license": "Elastic-2.0",
       "workspaces": [
         "frontend",
@@ -37,7 +37,7 @@
       }
     },
     "backend": {
-      "version": "0.16.0",
+      "version": "0.16.1",
       "license": "Elastic-2.0",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.1073.0",
@@ -448,7 +448,7 @@
       }
     },
     "frontend": {
-      "version": "0.16.0",
+      "version": "0.16.1",
       "license": "Elastic-2.0",
       "dependencies": {
         "@capacitor/android": "^8.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "family-greenhouse",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "license": "Elastic-2.0",
   "private": true,
   "description": "A shared plant-care journal for the whole household — per-plant schedules, reminders that find the right person across browser/email/SMS, and a care log everyone can see. React + TypeScript on AWS Lambda + DynamoDB + Cognito.",


### PR DESCRIPTION
## Summary

- filter custom iOS origins out of AWS-managed CORS so production Terraform accepts the release
- install exact-origin application preflight handling for web, iOS, and Android
- constrain streaming chat to POST/OPTIONS and reject wildcard origin policy
- add local/prod route parity and CORS regression coverage
- bump release metadata to v0.16.1

## Rollout

This is phase 1 of the CORS ownership migration. AWS-managed CORS stays enabled while the new Lambda preflight code deploys. A separate v0.16.2 release will remove managed CORS and enable application CORS for the streaming Function URL only after this release is healthy.

## Verification

- npm run verify
- npm run build
- terraform validate
- refreshed production plan: 3 add, 3 in-place change, 0 destroy
- 391 frontend tests and 1,133 backend tests pass

Unrelated local persistence edits and the regenerated mail-forwarder ZIP are excluded.