### PR TITLE
chore(release): prepare v0.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,26 @@ reaches 1.0.0 (pre-1.0: minor bumps may include breaking changes — see
 
 ## [Unreleased]
 
+## [0.16.2] - 2026-07-12
+
+### Added
+
+- Store-ready iPhone, iPad, and Android screenshots, app icons, Play feature artwork, localized
+  listing metadata, and deterministic validation/generation scripts for repeatable releases.
+- Public support and account-deletion pages, in-app AI response reporting, native privacy
+  disclosures, and complete account-cleanup coverage for store policy compliance.
+
+### Changed
+
+- Native networking now uses the platform HTTP stacks, mobile billing surfaces are purchase-free,
+  and release builds strip source maps before syncing into the iOS and Android shells.
+- iOS and Android release versions advance to `0.16.2` (build/version code `1602`).
+
+### Fixed
+
+- Store screenshot generation is isolated from the default Playwright suite so release-only
+  projects cannot be discovered by general CI browser profiles.
+
 ## [0.16.1] - 2026-07-12
 
 ### Fixed

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "Family Greenhouse API — AWS Lambda + DynamoDB single-table + Cognito, with a local Express mock that mirrors the handlers.",
   "license": "Elastic-2.0",
   "private": true,

--- a/frontend/android/app/build.gradle
+++ b/frontend/android/app/build.gradle
@@ -12,10 +12,10 @@ android {
         applicationId "net.familygreenhouse.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        // Deterministic SemVer mapping: 0.16.1 -> 1601. Increment this for
+        // Deterministic SemVer mapping: 0.16.2 -> 1602. Increment this for
         // every store upload; Play never accepts a reused versionCode.
-        versionCode 1601
-        versionName "0.16.1"
+        versionCode 1602
+        versionName "0.16.2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/frontend/ios/App/App.xcodeproj/project.pbxproj
+++ b/frontend/ios/App/App.xcodeproj/project.pbxproj
@@ -300,14 +300,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1601;
+				CURRENT_PROJECT_VERSION = 1602;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.16.1;
+				MARKETING_VERSION = 0.16.2;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = net.familygreenhouse.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -322,14 +322,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1601;
+				CURRENT_PROJECT_VERSION = 1602;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.16.1;
+				MARKETING_VERSION = 0.16.2;
 				PRODUCT_BUNDLE_IDENTIFIER = net.familygreenhouse.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "Family Greenhouse web app — React + TypeScript + Vite PWA for collaborative household plant care.",
   "license": "Elastic-2.0",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "family-greenhouse",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "family-greenhouse",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "license": "Elastic-2.0",
       "workspaces": [
         "frontend",
@@ -37,7 +37,7 @@
       }
     },
     "backend": {
-      "version": "0.16.1",
+      "version": "0.16.2",
       "license": "Elastic-2.0",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.1073.0",
@@ -448,7 +448,7 @@
       }
     },
     "frontend": {
-      "version": "0.16.1",
+      "version": "0.16.2",
       "license": "Elastic-2.0",
       "dependencies": {
         "@capacitor/android": "^8.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "family-greenhouse",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "license": "Elastic-2.0",
   "private": true,
   "description": "A shared plant-care journal for the whole household — per-plant schedules, reminders that find the right person across browser/email/SMS, and a care log everyone can see. React + TypeScript on AWS Lambda + DynamoDB + Cognito.",


### PR DESCRIPTION
## Summary
- advance web, backend, iOS, and Android versions to 0.16.2 / build 1602
- add the v0.16.2 changelog entry for the store-readiness release
- preserve the existing v0.16.1 tag and immutable release history

## Verification
- npm run mobile:validate
- npm run verify (pre-push hook: 398 frontend and 1,139 backend tests)

After merge, create the signed v0.16.2 tag to trigger the protected production deployment.