### PR TITLE
fix(sms): truncate SMS bodies by UTF-8 bytes, not UTF-16 units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ reaches 1.0.0 (pre-1.0: minor bumps may include breaking changes — see
 
 ### Fixed
 
+- SMS reminder bodies are now trimmed to the promised one-segment budget by
+  UTF-8 bytes rather than UTF-16 code units, so accented Spanish text or the
+  streak emoji can no longer overflow into a second billed segment or split an
+  emoji surrogate pair mid-code-point.
 - RAG answers now block unsupported quantitative care claims before they are
   persisted or delivered; streamed RAG text waits for the same grounding check.
   A later authoritative plant/task/climate result now joins historical RAG

--- a/backend/src/services/smsNotifier.ts
+++ b/backend/src/services/smsNotifier.ts
@@ -32,12 +32,38 @@ export interface SmsMessage {
  * `false` so the reminder fan-out doesn't treat an unconfigured channel as a
  * delivery and burn the day's slot.
  */
+/**
+ * Truncate `text` to at most `maxBytes` UTF-8 bytes without splitting a
+ * multi-byte code point. `String.prototype.slice` counts UTF-16 code units, so
+ * accented Spanish text or the app's own emoji can exceed the byte cap the SMS
+ * segment contract promises (and slice can even bisect an emoji surrogate pair).
+ * Iterating with `for...of` yields whole code points, so a truncated body is
+ * always valid UTF-8 and never over budget.
+ */
+export function truncateToBytes(text: string, maxBytes: number): string {
+  if (Buffer.byteLength(text, 'utf8') <= maxBytes) {
+    return text;
+  }
+  let sliceEnd = 0;
+  let bytes = 0;
+  for (const ch of text) {
+    const chBytes = Buffer.byteLength(ch, 'utf8');
+    if (bytes + chBytes > maxBytes) {
+      break;
+    }
+    bytes += chBytes;
+    sliceEnd += ch.length; // 2 for an astral code point (surrogate pair)
+  }
+  return text.slice(0, sliceEnd);
+}
+
 export async function sendSms(msg: SmsMessage): Promise<boolean> {
   if (!E164.test(msg.to)) {
     throw new Error(`Phone number must be E.164 format, got: ${msg.to}`);
   }
-  // SMS messages are billed per ~140-byte segment; trim to keep it to one.
-  const text = msg.text.slice(0, 140);
+  // SMS messages are billed per ~140-byte segment; trim to keep it to one,
+  // counting UTF-8 bytes (not UTF-16 units) and never splitting a code point.
+  const text = truncateToBytes(msg.text, 140);
 
   if (process.env.SMS_NOTIFICATIONS_ENABLED !== '1') {
     // Never log destinations or message bodies here. Verification messages

--- a/backend/tests/unit/services/smsNotifier.test.ts
+++ b/backend/tests/unit/services/smsNotifier.test.ts
@@ -59,12 +59,41 @@ describe('smsNotifier', () => {
     expect(cmd.input.MessageAttributes['AWS.SNS.SMS.SMSType'].StringValue).toBe('Transactional');
   });
 
-  it('truncates long messages to 140 bytes', async () => {
+  it('truncates long ASCII messages to 140 bytes', async () => {
     process.env = { ...ORIGINAL, SMS_NOTIFICATIONS_ENABLED: '1' };
     snsSendMock.mockResolvedValueOnce({});
     const { sendSms } = await import('../../../src/services/smsNotifier.js');
     await sendSms({ to: '+15551234567', text: 'a'.repeat(200) });
     const cmd = snsSendMock.mock.calls[0][0] as { input: { Message: string } };
-    expect(cmd.input.Message.length).toBe(140);
+    expect(Buffer.byteLength(cmd.input.Message, 'utf8')).toBe(140);
+  });
+
+  it('truncates multibyte messages by bytes without splitting a code point', async () => {
+    process.env = { ...ORIGINAL, SMS_NOTIFICATIONS_ENABLED: '1' };
+    snsSendMock.mockResolvedValueOnce({});
+    const { sendSms } = await import('../../../src/services/smsNotifier.js');
+    // The app's own streak emoji is 4 UTF-8 bytes; 100 of them is 400 bytes.
+    await sendSms({ to: '+15551234567', text: '🌱'.repeat(100) });
+    const cmd = snsSendMock.mock.calls[0][0] as { input: { Message: string } };
+    const body = cmd.input.Message;
+    // At most one 140-byte segment, and no lone/split surrogate at the boundary.
+    expect(Buffer.byteLength(body, 'utf8')).toBeLessThanOrEqual(140);
+    expect(body).toBe('🌱'.repeat(35)); // 35 * 4 bytes = 140, whole emoji only
+    expect([...body].every((ch) => ch === '🌱')).toBe(true);
+  });
+});
+
+describe('truncateToBytes', () => {
+  it('keeps a short string unchanged', async () => {
+    const { truncateToBytes } = await import('../../../src/services/smsNotifier.js');
+    expect(truncateToBytes('hello', 140)).toBe('hello');
+  });
+
+  it('never splits a multi-byte code point at the byte boundary', async () => {
+    const { truncateToBytes } = await import('../../../src/services/smsNotifier.js');
+    // 'é' is 2 UTF-8 bytes; a 3-byte cap must drop the second 'é', not split it.
+    const out = truncateToBytes('éé', 3);
+    expect(out).toBe('é');
+    expect(Buffer.byteLength(out, 'utf8')).toBe(2);
   });
 });


### PR DESCRIPTION
## What this changes

`sendSms` trimmed the body with `msg.text.slice(0, 140)`, which counts UTF-16 code units — not the 140 **bytes** the one-segment SMS contract (and the code's own comment) promises. An accented Spanish reminder or the app's `🌱` streak emoji at 140 "characters" is well over 140 bytes (two billed segments), and `.slice` can bisect an emoji surrogate pair, emitting a lone/invalid code unit.

This adds `truncateToBytes(text, maxBytes)`, which walks whole code points (`for...of`) and stops before the byte budget is exceeded, so the result is always valid UTF-8 and within one segment. The prior unit test asserted `Message.length === 140` (a character count) while its name claimed to check bytes; it now asserts `Buffer.byteLength(...) <= 140`.

## How it was tested

`npm run test -w backend -- smsNotifier` → 7 passed (updated ASCII case now checks bytes; new cases: a 100×`🌱` body truncates to exactly `🌱`×35 = 140 bytes with no split surrogate, and an `é` byte-boundary case). Also ran `npm run typecheck -w backend`, `npm run lint -w backend`, and `prettier --check` on the touched files — all clean.

## Checklist

- [x] Commits follow Conventional Commits (`fix:`)
- [x] `npm test` passes for the backend workspace (the touched one)
- [x] No secrets, credentials, or personal data added
- [x] `CHANGELOG.md` updated under Unreleased → Fixed

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fs26sUornCmNtqvt7YwKoF)_