### PR TITLE
Add space-grouped Care Rounds

### DIFF
--- a/docs/spaces.md
+++ b/docs/spaces.md
@@ -31,3 +31,15 @@ space belongs to the caller's active household.
 - Space setup is optional; unplaced plants continue through every care flow.
 - The consumer hierarchy stops at Inside/Outside → Space. There are no floors, shelves, or maps.
 - Household city/coordinates remain the “Local climate” setting and are not a plant space.
+
+## Care rounds
+
+The Tasks page offers two organizations over the same due-work query:
+
+- **By date** preserves the existing Overdue, Today, and Upcoming sections.
+- **Care round** joins tasks to their plants and current spaces in the client, then orders the
+  route as inside spaces, outside spaces, and unplaced plants. No task rows or schedules are
+  duplicated; completion, claiming, vacation cover, and climate-skip controls are reused.
+
+The route respects the active task filter, so “My tasks” plus “Care round” becomes a personal route
+through the household.

--- a/frontend/src/features/tasks/TasksPage.tsx
+++ b/frontend/src/features/tasks/TasksPage.tsx
@@ -1,7 +1,8 @@
 import { useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
-import { CheckIcon } from '@heroicons/react/24/outline';
+import { useTranslation } from 'react-i18next';
+import { CalendarDaysIcon, CheckIcon, MapPinIcon } from '@heroicons/react/24/outline';
 import { taskService, SnoozeReason, TaskWithCoverage } from '@/services/taskService';
 import { plantService } from '@/services/plantService';
 import { climateService } from '@/services/climateService';
@@ -27,6 +28,8 @@ import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { taskTypeLabels, taskTypeStyles } from '@/utils/taskTypeConfig';
 import { calendarDaysBetween } from '@/utils/date';
 import { useActiveHousehold } from '@/hooks/useActiveHousehold';
+import { spaceService } from '@/services/spaceService';
+import { buildCareRoundGroups } from './careRounds';
 
 type FilterType = 'all' | 'mine' | 'overdue' | 'today' | 'week';
 
@@ -68,9 +71,11 @@ function isToday(dateString: string): boolean {
 
 export function TasksPage() {
   useDocumentTitle('Tasks');
+  const { t } = useTranslation();
   const user = useAuthStore((state) => state.user);
   const { householdId, householdQuery } = useActiveHousehold();
   const [filter, setFilter] = useState<FilterType>('all');
+  const [displayMode, setDisplayMode] = useState<'schedule' | 'round'>('schedule');
 
   const {
     data: tasks,
@@ -98,6 +103,10 @@ export function TasksPage() {
   const { data: plants } = useQuery({
     queryKey: ['plants', householdId],
     queryFn: () => plantService.getPlants(),
+  });
+  const { data: spaces = [] } = useQuery({
+    queryKey: ['spaces', householdId],
+    queryFn: spaceService.getSpaces,
   });
   const tagsByPlantId = useMemo(
     () => new Map((plants ?? []).map((p) => [p.id, p.tags ?? []])),
@@ -152,6 +161,10 @@ export function TasksPage() {
   const overdueTasks = sortedTasks.filter((t) => isOverdue(t.nextDue));
   const todayTasks = sortedTasks.filter((t) => isToday(t.nextDue));
   const upcomingTasks = sortedTasks.filter((t) => !isOverdue(t.nextDue) && !isToday(t.nextDue));
+  const careRoundGroups = useMemo(
+    () => buildCareRoundGroups(sortedTasks, plants ?? [], spaces, t('spaces.unplaced')),
+    [plants, sortedTasks, spaces, t]
+  );
 
   return (
     <div className="space-y-6">
@@ -160,6 +173,41 @@ export function TasksPage() {
         title="Tasks"
         description="Manage your plant care tasks."
       />
+
+      <div
+        className="inline-flex rounded-lg border border-primary-200/70 bg-paper p-1"
+        role="group"
+        aria-label={t('careRounds.displayMode')}
+      >
+        <button
+          type="button"
+          onClick={() => setDisplayMode('schedule')}
+          aria-pressed={displayMode === 'schedule'}
+          className={clsx(
+            'inline-flex min-h-touch items-center gap-2 rounded-md px-3 py-2 text-sm font-medium',
+            displayMode === 'schedule'
+              ? 'bg-primary-100 text-primary-900'
+              : 'text-gray-600 hover:bg-primary-50'
+          )}
+        >
+          <CalendarDaysIcon className="h-5 w-5" aria-hidden="true" />
+          {t('careRounds.schedule')}
+        </button>
+        <button
+          type="button"
+          onClick={() => setDisplayMode('round')}
+          aria-pressed={displayMode === 'round'}
+          className={clsx(
+            'inline-flex min-h-touch items-center gap-2 rounded-md px-3 py-2 text-sm font-medium',
+            displayMode === 'round'
+              ? 'bg-primary-100 text-primary-900'
+              : 'text-gray-600 hover:bg-primary-50'
+          )}
+        >
+          <MapPinIcon className="h-5 w-5" aria-hidden="true" />
+          {t('careRounds.round')}
+        </button>
+      </div>
 
       {/* Filters */}
       <div className="flex flex-wrap gap-2" role="group" aria-label="Task filters">
@@ -220,6 +268,40 @@ export function TasksPage() {
             )
           }
         />
+      ) : displayMode === 'round' ? (
+        <div className="space-y-6">
+          <Card variant="paper">
+            <div className="flex items-start gap-3">
+              <span className="inline-flex h-10 w-10 flex-none items-center justify-center rounded-full bg-primary-100 text-primary-800">
+                <MapPinIcon className="h-5 w-5" aria-hidden="true" />
+              </span>
+              <div>
+                <h2 className="font-serif text-xl text-ink">{t('careRounds.title')}</h2>
+                <p className="mt-1 text-sm text-gray-600">
+                  {t('careRounds.summary', {
+                    tasks: sortedTasks.length,
+                    spaces: careRoundGroups.length,
+                  })}
+                </p>
+                <p className="mt-2 text-xs text-gray-500">
+                  {careRoundGroups.map((group) => group.name).join(' → ')}
+                </p>
+              </div>
+            </div>
+          </Card>
+          {careRoundGroups.map((group) => (
+            <TaskSection
+              key={group.id}
+              title={`${t(`spaces.${group.environment}`)} · ${group.name}`}
+              tasks={group.tasks}
+              onComplete={(id) => completeTaskMutation.mutate(id)}
+              completingTaskId={
+                completeTaskMutation.isPending ? completeTaskMutation.variables : null
+              }
+              extras={rowExtras}
+            />
+          ))}
+        </div>
       ) : (
         <div className="space-y-6">
           {overdueTasks.length > 0 && (

--- a/frontend/src/features/tasks/careRounds.test.ts
+++ b/frontend/src/features/tasks/careRounds.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import type { Plant, PlantSpace, Task } from '@/services/plantService';
+import { buildCareRoundGroups } from './careRounds';
+
+const spaces: PlantSpace[] = [
+  {
+    id: 'patio',
+    householdId: 'hh',
+    name: 'Patio',
+    environment: 'outside',
+    createdAt: '',
+    createdBy: 'u',
+    updatedAt: '',
+  },
+  {
+    id: 'kitchen',
+    householdId: 'hh',
+    name: 'Kitchen',
+    environment: 'inside',
+    createdAt: '',
+    createdBy: 'u',
+    updatedAt: '',
+  },
+];
+
+const plant = (id: string, spaceId?: string): Plant => ({
+  id,
+  householdId: 'hh',
+  name: id,
+  species: null,
+  location: null,
+  spaceId,
+  imageUrl: null,
+  notes: null,
+  createdAt: '',
+  createdBy: 'u',
+  updatedAt: '',
+});
+
+const task = (id: string, plantId: string): Task => ({
+  id,
+  plantId,
+  plantName: plantId,
+  type: 'water',
+  frequency: 7,
+  lastCompleted: null,
+  nextDue: '2026-07-15T12:00:00.000Z',
+  assignedTo: null,
+  assignedToName: null,
+  notes: null,
+  createdBy: 'u',
+  createdAt: '',
+});
+
+describe('buildCareRoundGroups', () => {
+  it('orders inside, outside, then unplaced while preserving task order', () => {
+    const result = buildCareRoundGroups(
+      [task('outside-1', 'p2'), task('inside-1', 'p1'), task('inside-2', 'p1'), task('none', 'p3')],
+      [plant('p1', 'kitchen'), plant('p2', 'patio'), plant('p3')],
+      spaces
+    );
+    expect(result.map((group) => `${group.environment}:${group.name}`)).toEqual([
+      'inside:Kitchen',
+      'outside:Patio',
+      'unplaced:Unplaced',
+    ]);
+    expect(result[0].tasks.map((item) => item.id)).toEqual(['inside-1', 'inside-2']);
+  });
+});

--- a/frontend/src/features/tasks/careRounds.ts
+++ b/frontend/src/features/tasks/careRounds.ts
@@ -1,0 +1,48 @@
+import type { Plant, PlantSpace } from '@/services/plantService';
+import type { TaskWithCoverage } from '@/services/taskService';
+
+export interface CareRoundGroup {
+  id: string;
+  name: string;
+  environment: PlantSpace['environment'] | 'unplaced';
+  tasks: TaskWithCoverage[];
+}
+
+const environmentRank: Record<CareRoundGroup['environment'], number> = {
+  inside: 0,
+  outside: 1,
+  unplaced: 2,
+};
+
+/** Build a stable physical route: inside spaces, outside spaces, then
+ * unplaced work. Tasks retain the due-date ordering supplied by the caller. */
+export function buildCareRoundGroups(
+  tasks: TaskWithCoverage[],
+  plants: Plant[],
+  spaces: PlantSpace[],
+  unplacedName = 'Unplaced'
+): CareRoundGroup[] {
+  const plantById = new Map(plants.map((plant) => [plant.id, plant]));
+  const spaceById = new Map(spaces.map((space) => [space.id, space]));
+  const groups = new Map<string, CareRoundGroup>();
+
+  for (const task of tasks) {
+    const plant = plantById.get(task.plantId);
+    const space = plant?.spaceId ? spaceById.get(plant.spaceId) : undefined;
+    const id = space?.id ?? 'unplaced';
+    const group = groups.get(id) ?? {
+      id,
+      name: space?.name ?? unplacedName,
+      environment: space?.environment ?? 'unplaced',
+      tasks: [],
+    };
+    group.tasks.push(task);
+    groups.set(id, group);
+  }
+
+  return [...groups.values()].sort(
+    (a, b) =>
+      environmentRank[a.environment] - environmentRank[b.environment] ||
+      a.name.localeCompare(b.name)
+  );
+}

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -40,6 +40,13 @@
     "deleteAction": "Delete",
     "deleteAria": "Delete {{name}}"
   },
+  "careRounds": {
+    "displayMode": "Task organization",
+    "schedule": "By date",
+    "round": "Care round",
+    "title": "Your care route",
+    "summary": "Tasks remaining: {{tasks}} · Spaces to visit: {{spaces}}"
+  },
   "nav": {
     "dashboard": "Dashboard",
     "plants": "Plants",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -42,6 +42,13 @@
     "deleteAction": "Eliminar",
     "deleteAria": "Eliminar {{name}}"
   },
+  "careRounds": {
+    "displayMode": "Organización de tareas",
+    "schedule": "Por fecha",
+    "round": "Ronda de cuidado",
+    "title": "Tu ruta de cuidado",
+    "summary": "Tareas pendientes: {{tasks}} · Espacios por visitar: {{spaces}}"
+  },
   "nav": {
     "dashboard": "Panel",
     "plants": "Plantas",


### PR DESCRIPTION
## What changed

- adds a By date / Care round organization toggle to Tasks
- builds a stable physical route through inside spaces, outside spaces, then unplaced plants
- preserves due-date ordering within each space
- reuses existing completion, claim, vacation-cover, and climate-skip controls
- respects All, My tasks, Today, This week, and Overdue filters

## Why

A space model becomes useful when it changes the care workflow. Care Rounds let a household finish everything in one room or outdoor area before moving to the next.

## Stack

Depends on #230. Review only the diff against `agent/spaces-01-browse`.

## Validation

- full pre-push `npm run verify`
- frontend: 415 tests passed
- backend: 1,211 tests passed
- i18n and hardcoded-string gates passed