### PR TITLE
Show plant placement on task rows

### DIFF
--- a/docs/spaces.md
+++ b/docs/spaces.md
@@ -43,3 +43,10 @@ The Tasks page offers two organizations over the same due-work query:
 
 The route respects the active task filter, so “My tasks” plus “Care round” becomes a personal route
 through the household.
+
+## Task location visibility
+
+The dashboard and both Tasks organizations resolve each task's plant to its current space at read
+time. This avoids denormalizing a space name onto recurring task rows, which would become stale every
+time a plant moves or a space is renamed. Placement notes ride with the displayed space label, and
+plants without a structured space are explicitly shown as Unplaced.

--- a/frontend/src/components/TaskLocation.tsx
+++ b/frontend/src/components/TaskLocation.tsx
@@ -1,0 +1,10 @@
+import { MapPinIcon } from '@heroicons/react/24/outline';
+
+export function TaskLocation({ label }: { label: string }) {
+  return (
+    <p className="mt-1 flex items-center gap-1 text-xs text-gray-600">
+      <MapPinIcon className="h-3.5 w-3.5 flex-none" aria-hidden="true" />
+      <span className="truncate">{label}</span>
+    </p>
+  );
+}

--- a/frontend/src/features/dashboard/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/DashboardPage.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { CheckIcon } from '@heroicons/react/24/outline';
 import { useAuthStore } from '@/store/authStore';
 import { taskService, SnoozeReason, TaskWithCoverage } from '@/services/taskService';
@@ -36,6 +37,7 @@ import { DashboardHeaderArt } from '@/components/headers/DashboardHeaderArt';
 import { PlantImage } from '@/components/PlantImage';
 import { spaceService } from '@/services/spaceService';
 import { plantLocationLabel, spaceMap } from '@/utils/spaces';
+import { TaskLocation } from '@/components/TaskLocation';
 import { getErrorMessage } from '@/services/api';
 import clsx from 'clsx';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
@@ -72,6 +74,7 @@ function filterActivity(
 
 export function DashboardPage() {
   useDocumentTitle('Dashboard');
+  const { t } = useTranslation();
   const user = useAuthStore((state) => state.user);
   const { householdId, householdQuery } = useActiveHousehold();
 
@@ -140,6 +143,7 @@ export function DashboardPage() {
     () => new Map((plants ?? []).map((p) => [p.id, p.tags ?? []])),
     [plants]
   );
+  const plantsById = useMemo(() => new Map((plants ?? []).map((p) => [p.id, p])), [plants]);
 
   const claimMutation = useClaimTaskMutation(householdId);
   const unclaimMutation = useUnclaimTaskMutation(householdId);
@@ -222,6 +226,11 @@ export function DashboardPage() {
               <TaskItem
                 key={task.id}
                 task={task}
+                locationLabel={
+                  plantsById.has(task.plantId)
+                    ? plantLocationLabel(plantsById.get(task.plantId)!, spacesById)
+                    : t('spaces.unplaced')
+                }
                 onComplete={handleCompleteTask}
                 isCompleting={
                   completeTaskMutation.isPending && completeTaskMutation.variables === task.id
@@ -505,6 +514,7 @@ function ActivityRow({ event }: ActivityRowProps) {
 
 interface TaskItemProps {
   task: TaskWithCoverage;
+  locationLabel: string;
   onComplete: (taskId: string) => void;
   isCompleting: boolean;
   skipReason: Extract<SnoozeReason, 'rain' | 'frost'> | null;
@@ -517,6 +527,7 @@ interface TaskItemProps {
 
 function TaskItem({
   task,
+  locationLabel,
   onComplete,
   isCompleting,
   skipReason,
@@ -557,6 +568,7 @@ function TaskItem({
             </span>
             {task.assignedToName && ` • ${task.assignedToName}`}
           </p>
+          <TaskLocation label={locationLabel} />
           {(!task.assignedTo || task.coveringFor || skipReason) && (
             <div className="mt-1 flex flex-wrap items-center gap-1.5">
               {!task.assignedTo && <UpForGrabsBadge />}

--- a/frontend/src/features/tasks/TasksPage.tsx
+++ b/frontend/src/features/tasks/TasksPage.tsx
@@ -30,6 +30,8 @@ import { calendarDaysBetween } from '@/utils/date';
 import { useActiveHousehold } from '@/hooks/useActiveHousehold';
 import { spaceService } from '@/services/spaceService';
 import { buildCareRoundGroups } from './careRounds';
+import { TaskLocation } from '@/components/TaskLocation';
+import { plantLocationLabel, spaceMap } from '@/utils/spaces';
 
 type FilterType = 'all' | 'mine' | 'overdue' | 'today' | 'week';
 
@@ -112,6 +114,8 @@ export function TasksPage() {
     () => new Map((plants ?? []).map((p) => [p.id, p.tags ?? []])),
     [plants]
   );
+  const plantsById = useMemo(() => new Map((plants ?? []).map((p) => [p.id, p])), [plants]);
+  const spacesById = useMemo(() => spaceMap(spaces), [spaces]);
 
   const completeTaskMutation = useCompleteTaskMutation(householdId);
 
@@ -124,6 +128,10 @@ export function TasksPage() {
 
   const rowExtras: TaskRowExtras = {
     skipReasonFor,
+    locationFor: (task) =>
+      plantsById.has(task.plantId)
+        ? plantLocationLabel(plantsById.get(task.plantId)!, spacesById, t('spaces.unplaced'))
+        : t('spaces.unplaced'),
     onClaim: (id) => claimMutation.mutate(id),
     onUnclaim: (id) => unclaimMutation.mutate(id),
     onSkip: (task, reason) => skipMutation.mutate({ task, reason }),
@@ -349,6 +357,7 @@ export function TasksPage() {
 /** Claim / vacation / climate-skip plumbing shared by every section row. */
 interface TaskRowExtras {
   skipReasonFor: (task: TaskWithCoverage) => Extract<SnoozeReason, 'rain' | 'frost'> | null;
+  locationFor: (task: TaskWithCoverage) => string;
   onClaim: (taskId: string) => void;
   onUnclaim: (taskId: string) => void;
   onSkip: (task: TaskWithCoverage, reason: SnoozeReason) => void;
@@ -432,6 +441,7 @@ function TaskSection({
                     </span>
                     {task.assignedToName && ` • Assigned to ${task.assignedToName}`}
                   </p>
+                  <TaskLocation label={extras.locationFor(task)} />
                   {(!task.assignedTo || task.coveringFor || skipReason) && (
                     <div className="mt-1 flex flex-wrap items-center gap-1.5">
                       {!task.assignedTo && <UpForGrabsBadge />}


### PR DESCRIPTION
## Summary
- show each plant’s inside/outside space directly on task rows
- include placement context on both the Tasks page and dashboard
- keep unplaced plants explicit so care routes remain actionable

## Dependency
Stacked on #231.

## Validation
- npm run verify
- 415 frontend tests
- 1,211 backend tests