### PR TITLE
Prepare v0.17.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,31 @@ reaches 1.0.0 (pre-1.0: minor bumps may include breaking changes — see
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-07-15
+
+### Added
+
+- Households can define named indoor and outdoor spaces, browse plants by
+  placement, and see unplaced plants without relying on free-form tags.
+- Care Rounds group due work by space so a caregiver can finish one physical
+  area at a time and track progress through the round.
+- Task rows now show each plant's current space and indoor/outdoor context.
+- Quick-move and bulk-move workflows let caregivers relocate plants between
+  spaces while recording the placement change consistently.
+
+### Changed
+
+- The new move workflow remains a lazy-loaded chunk; the aggregate bundle
+  budget is recalibrated with tight headroom while initial JS, vendor, and CSS
+  budgets remain unchanged.
+
+### Fixed
+
+- CodeQL and zizmor now retain SARIF artifacts on private repositories without
+  requiring the unavailable GitHub Advanced Security upload endpoint.
+- Production UI browser assertions now match the commercial-hold pricing and
+  billing headings.
+
 ## [0.16.3] - 2026-07-14
 
 ### Security

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.16.3",
+  "version": "0.17.0",
   "description": "Family Greenhouse API — AWS Lambda + DynamoDB single-table + Cognito, with a local Express mock that mirrors the handlers.",
   "license": "Elastic-2.0",
   "private": true,

--- a/frontend/android/app/build.gradle
+++ b/frontend/android/app/build.gradle
@@ -12,10 +12,10 @@ android {
         applicationId "net.familygreenhouse.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        // Deterministic SemVer mapping: 0.16.2 -> 1602. Increment this for
+        // Deterministic SemVer mapping: 0.17.0 -> 1700. Increment this for
         // every store upload; Play never accepts a reused versionCode.
-        versionCode 1602
-        versionName "0.16.2"
+        versionCode 1700
+        versionName "0.17.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/frontend/ios/App/App.xcodeproj/project.pbxproj
+++ b/frontend/ios/App/App.xcodeproj/project.pbxproj
@@ -300,14 +300,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1602;
+				CURRENT_PROJECT_VERSION = 1700;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.16.2;
+				MARKETING_VERSION = 0.17.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = net.familygreenhouse.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -322,14 +322,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1602;
+				CURRENT_PROJECT_VERSION = 1700;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.16.2;
+				MARKETING_VERSION = 0.17.0;
 				PRODUCT_BUNDLE_IDENTIFIER = net.familygreenhouse.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.16.3",
+  "version": "0.17.0",
   "description": "Family Greenhouse web app — React + TypeScript + Vite PWA for collaborative household plant care.",
   "license": "Elastic-2.0",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "family-greenhouse",
-  "version": "0.16.3",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "family-greenhouse",
-      "version": "0.16.3",
+      "version": "0.17.0",
       "license": "Elastic-2.0",
       "workspaces": [
         "frontend",
@@ -37,7 +37,7 @@
       }
     },
     "backend": {
-      "version": "0.16.3",
+      "version": "0.17.0",
       "license": "Elastic-2.0",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.1073.0",
@@ -85,7 +85,7 @@
       }
     },
     "frontend": {
-      "version": "0.16.3",
+      "version": "0.17.0",
       "license": "Elastic-2.0",
       "dependencies": {
         "@capacitor/android": "^8.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "family-greenhouse",
-  "version": "0.16.3",
+  "version": "0.17.0",
   "license": "Elastic-2.0",
   "private": true,
   "description": "A shared plant-care journal for the whole household — per-plant schedules, reminders that find the right person across browser/email/SMS, and a care log everyone can see. React + TypeScript on AWS Lambda + DynamoDB + Cognito.",


### PR DESCRIPTION
## Summary
- bump root, frontend, backend, Android, and iOS versions to 0.17.0 (build 1700)
- document household spaces, Care Rounds, task locations, and quick/bulk moves
- include the private-repository CI repairs in the release notes

## Verification
- npm run verify
- npm run mobile:validate
- PRs #230, #231, #232, and #233 passed the full hosted check suite before merge