### PR TITLE
feat: add seasonal homes for plants

### DIFF
--- a/backend/src/handlers/plants/handler.ts
+++ b/backend/src/handlers/plants/handler.ts
@@ -116,8 +116,15 @@ export const deleteSpace = createHandler(
     const id = event.pathParameters?.id;
     if (!id) throw createHttpError(400, 'Space ID is required');
     const plants = await plantService.getPlants(user.householdId!, 'all');
-    if (plants.some((plant) => plant.spaceId === id)) {
-      throw createHttpError(409, 'Move plants out of this space before deleting it');
+    if (
+      plants.some(
+        (plant) => plant.spaceId === id || plant.summerSpaceId === id || plant.winterSpaceId === id
+      )
+    ) {
+      throw createHttpError(
+        409,
+        'Remove this space from all current and seasonal plant homes before deleting it'
+      );
     }
     if (!(await spaceService.deleteSpace(user.householdId!, id))) {
       throw createHttpError(404, 'Space not found');
@@ -152,6 +159,18 @@ export const createPlant = createHandler(
       !(await spaceService.getSpace(user.householdId!, validatedBody.spaceId))
     ) {
       throw createHttpError(400, 'Space not found in this household');
+    }
+    const seasonalSpaceIds = [validatedBody.summerSpaceId, validatedBody.winterSpaceId].filter(
+      (spaceId): spaceId is string => Boolean(spaceId)
+    );
+    if (
+      (
+        await Promise.all(
+          seasonalSpaceIds.map((spaceId) => spaceService.getSpace(user.householdId!, spaceId))
+        )
+      ).some((space) => !space)
+    ) {
+      throw createHttpError(400, 'Seasonal home not found in this household');
     }
 
     // Enforce per-tier plant cap. The "free" tier limits a household to 10
@@ -245,7 +264,6 @@ export const movePlants = createHandler(
     ) {
       throw createHttpError(400, 'Space not found in this household');
     }
-
     const plants = await Promise.all(
       validatedBody.plantIds.map((plantId) => plantService.getPlant(user.householdId!, plantId))
     );
@@ -313,6 +331,18 @@ export const updatePlant = createHandler(
       !(await spaceService.getSpace(user.householdId!, validatedBody.spaceId))
     ) {
       throw createHttpError(400, 'Space not found in this household');
+    }
+    const seasonalSpaceIds = [validatedBody.summerSpaceId, validatedBody.winterSpaceId].filter(
+      (spaceId): spaceId is string => Boolean(spaceId)
+    );
+    if (
+      (
+        await Promise.all(
+          seasonalSpaceIds.map((spaceId) => spaceService.getSpace(user.householdId!, spaceId))
+        )
+      ).some((space) => !space)
+    ) {
+      throw createHttpError(400, 'Seasonal home not found in this household');
     }
 
     // Lifecycle events need the pre-write state so idempotent PUT retries do

--- a/backend/src/local-server.ts
+++ b/backend/src/local-server.ts
@@ -120,6 +120,8 @@ interface Plant {
   location: string | null;
   spaceId: string | null;
   placementNote: string | null;
+  summerSpaceId: string | null;
+  winterSpaceId: string | null;
   imageUrl: string | null;
   notes: string | null;
   status: 'active' | 'died' | 'gave_away' | 'archived';
@@ -415,6 +417,8 @@ export function resetDb(): void {
     location: 'Living Room',
     spaceId: seedSpaceId,
     placementNote: null,
+    summerSpaceId: null,
+    winterSpaceId: null,
     imageUrl: null,
     notes: 'Needs indirect light',
     status: 'active',
@@ -1543,10 +1547,16 @@ app.delete('/spaces/:id', authMiddleware, requireHousehold, (req, res) => {
   }
   if (
     [...db.plants.values()].some(
-      (plant) => plant.householdId === user.householdId && plant.spaceId === space.id
+      (plant) =>
+        plant.householdId === user.householdId &&
+        (plant.spaceId === space.id ||
+          plant.summerSpaceId === space.id ||
+          plant.winterSpaceId === space.id)
     )
   ) {
-    return res.status(409).json({ message: 'Move plants out of this space before deleting it' });
+    return res.status(409).json({
+      message: 'Remove this space from all current and seasonal plant homes before deleting it',
+    });
   }
   db.spaces.delete(space.id);
   res.status(204).send();
@@ -1582,6 +1592,8 @@ app.post(
       location,
       spaceId,
       placementNote,
+      summerSpaceId,
+      winterSpaceId,
       notes,
       tags,
       perenualSpeciesId,
@@ -1614,6 +1626,13 @@ app.post(
         return res.status(400).json({ message: 'Space not found in this household' });
       }
     }
+    for (const seasonalSpaceId of [summerSpaceId, winterSpaceId]) {
+      if (!seasonalSpaceId) continue;
+      const space = db.spaces.get(seasonalSpaceId);
+      if (!space || space.householdId !== user.householdId) {
+        return res.status(400).json({ message: 'Seasonal home not found in this household' });
+      }
+    }
 
     const plantId = uuidv4();
     const now = new Date().toISOString();
@@ -1626,6 +1645,8 @@ app.post(
       location: location || null,
       spaceId: spaceId ?? null,
       placementNote: placementNote || null,
+      summerSpaceId: summerSpaceId ?? null,
+      winterSpaceId: winterSpaceId ?? null,
       imageUrl: null,
       notes: notes || null,
       status: 'active',
@@ -1743,6 +1764,8 @@ app.post(
         location: input.location || null,
         spaceId: null,
         placementNote: null,
+        summerSpaceId: null,
+        winterSpaceId: null,
         imageUrl: null,
         notes: input.notes || null,
         status: 'active',
@@ -1856,6 +1879,16 @@ app.put(
       plant.spaceId = body.spaceId;
     }
     if (body.placementNote !== undefined) plant.placementNote = body.placementNote;
+    for (const field of ['summerSpaceId', 'winterSpaceId'] as const) {
+      if (body[field] === undefined) continue;
+      if (body[field]) {
+        const space = db.spaces.get(body[field]);
+        if (!space || space.householdId !== user.householdId) {
+          return res.status(400).json({ message: 'Seasonal home not found in this household' });
+        }
+      }
+      plant[field] = body[field];
+    }
     if (body.notes !== undefined) plant.notes = body.notes;
     if (body.tags !== undefined) {
       plant.tags = body.tags
@@ -2393,6 +2426,8 @@ app.post('/plants/shared/:code/accept', authMiddleware, requireHousehold, (req, 
     location: null,
     spaceId: null,
     placementNote: null,
+    summerSpaceId: null,
+    winterSpaceId: null,
     imageUrl: null,
     notes,
     status: 'active',

--- a/backend/src/models/schemas.ts
+++ b/backend/src/models/schemas.ts
@@ -84,6 +84,8 @@ export const createPlantSchema = z.object({
   location: z.string().max(100).optional(),
   spaceId: z.string().uuid().optional(),
   placementNote: z.string().max(120).optional(),
+  summerSpaceId: z.string().uuid().optional(),
+  winterSpaceId: z.string().uuid().optional(),
   notes: z.string().max(1000).optional(),
   perenualSpeciesId: z.number().int().positive().optional(),
   // Propagation: the same-household plant this cutting was taken from.
@@ -99,6 +101,8 @@ export const updatePlantSchema = z.object({
   location: z.string().max(100).optional().nullable(),
   spaceId: z.string().uuid().optional().nullable(),
   placementNote: z.string().max(120).optional().nullable(),
+  summerSpaceId: z.string().uuid().optional().nullable(),
+  winterSpaceId: z.string().uuid().optional().nullable(),
   notes: z.string().max(1000).optional().nullable(),
   tags: tagsSchema,
   perenualSpeciesId: z.number().int().positive().nullable().optional(),

--- a/backend/src/models/types.ts
+++ b/backend/src/models/types.ts
@@ -89,6 +89,10 @@ export interface Plant {
   spaceId?: string | null;
   /** Specific position inside a space, e.g. "east window, top shelf". */
   placementNote?: string | null;
+  /** Preferred warm-season home. Optional for legacy rows. */
+  summerSpaceId?: string | null;
+  /** Preferred cool-season home. Optional for legacy rows. */
+  winterSpaceId?: string | null;
   imageUrl: string | null;
   notes: string | null;
   /** Lifecycle status; absent on legacy rows → treated as 'active'. */

--- a/backend/src/services/plantService.ts
+++ b/backend/src/services/plantService.ts
@@ -71,6 +71,8 @@ export async function createPlant(
     location: input.location || null,
     spaceId: input.spaceId ?? null,
     placementNote: input.placementNote || null,
+    summerSpaceId: input.summerSpaceId ?? null,
+    winterSpaceId: input.winterSpaceId ?? null,
     imageUrl: null,
     notes: input.notes || null,
     status: 'active',
@@ -180,6 +182,8 @@ export async function getPlant(householdId: string, plantId: string): Promise<Pl
     location: result.Item.location as string | null,
     spaceId: (result.Item.spaceId as string | null | undefined) ?? null,
     placementNote: (result.Item.placementNote as string | null | undefined) ?? null,
+    summerSpaceId: (result.Item.summerSpaceId as string | null | undefined) ?? null,
+    winterSpaceId: (result.Item.winterSpaceId as string | null | undefined) ?? null,
     imageUrl: result.Item.imageUrl as string | null,
     notes: result.Item.notes as string | null,
     status: (result.Item.status as PlantStatus | undefined) ?? 'active',
@@ -247,6 +251,8 @@ export async function getPlants(
       location: item.location as string | null,
       spaceId: (item.spaceId as string | null | undefined) ?? null,
       placementNote: (item.placementNote as string | null | undefined) ?? null,
+      summerSpaceId: (item.summerSpaceId as string | null | undefined) ?? null,
+      winterSpaceId: (item.winterSpaceId as string | null | undefined) ?? null,
       imageUrl: item.imageUrl as string | null,
       notes: item.notes as string | null,
       status: (item.status as PlantStatus | undefined) ?? 'active',
@@ -303,6 +309,18 @@ export async function updatePlant(
     updateExpressions.push('#placementNote = :placementNote');
     expressionAttributeNames['#placementNote'] = 'placementNote';
     expressionAttributeValues[':placementNote'] = input.placementNote;
+  }
+
+  if (input.summerSpaceId !== undefined) {
+    updateExpressions.push('#summerSpaceId = :summerSpaceId');
+    expressionAttributeNames['#summerSpaceId'] = 'summerSpaceId';
+    expressionAttributeValues[':summerSpaceId'] = input.summerSpaceId;
+  }
+
+  if (input.winterSpaceId !== undefined) {
+    updateExpressions.push('#winterSpaceId = :winterSpaceId');
+    expressionAttributeNames['#winterSpaceId'] = 'winterSpaceId';
+    expressionAttributeValues[':winterSpaceId'] = input.winterSpaceId;
   }
 
   if (input.notes !== undefined) {
@@ -392,6 +410,8 @@ export async function updatePlant(
       location: result.Attributes.location as string | null,
       spaceId: (result.Attributes.spaceId as string | null | undefined) ?? null,
       placementNote: (result.Attributes.placementNote as string | null | undefined) ?? null,
+      summerSpaceId: (result.Attributes.summerSpaceId as string | null | undefined) ?? null,
+      winterSpaceId: (result.Attributes.winterSpaceId as string | null | undefined) ?? null,
       imageUrl: result.Attributes.imageUrl as string | null,
       notes: result.Attributes.notes as string | null,
       status: (result.Attributes.status as PlantStatus | undefined) ?? 'active',
@@ -614,6 +634,8 @@ export async function deletePlant(householdId: string, plantId: string): Promise
         location: (item.location as string | null | undefined) ?? null,
         spaceId: (item.spaceId as string | null | undefined) ?? null,
         placementNote: (item.placementNote as string | null | undefined) ?? null,
+        summerSpaceId: (item.summerSpaceId as string | null | undefined) ?? null,
+        winterSpaceId: (item.winterSpaceId as string | null | undefined) ?? null,
         imageUrl: (item.imageUrl as string | null | undefined) ?? null,
         notes: (item.notes as string | null | undefined) ?? null,
         status: (item.status as PlantStatus | undefined) ?? 'active',

--- a/backend/tests/integration/local-server.test.ts
+++ b/backend/tests/integration/local-server.test.ts
@@ -398,6 +398,51 @@ describe('plants routes', () => {
     expect(res.body.location).toBe('Office');
   });
 
+  it('stores and validates seasonal homes and protects referenced spaces', async () => {
+    const token = await loginAsSeed();
+    const summer = await request(app)
+      .post('/spaces')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'Summer patio', environment: 'outside' });
+    const winter = await request(app)
+      .post('/spaces')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'Winter window', environment: 'inside' });
+
+    const created = await request(app)
+      .post('/plants')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'Seasonal citrus',
+        summerSpaceId: summer.body.id,
+        winterSpaceId: winter.body.id,
+      });
+    expect(created.status).toBe(201);
+    expect(created.body).toMatchObject({
+      summerSpaceId: summer.body.id,
+      winterSpaceId: winter.body.id,
+    });
+
+    const protectedDelete = await request(app)
+      .delete(`/spaces/${summer.body.id}`)
+      .set('Authorization', `Bearer ${token}`);
+    expect(protectedDelete.status).toBe(409);
+
+    const updated = await request(app)
+      .put(`/plants/${created.body.id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ summerSpaceId: null });
+    expect(updated.status).toBe(200);
+    expect(updated.body.summerSpaceId).toBeNull();
+
+    const invalid = await request(app)
+      .put(`/plants/${created.body.id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ winterSpaceId: '00000000-0000-0000-0000-000000000000' });
+    expect(invalid.status).toBe(400);
+    expect(invalid.body.message).toMatch(/Seasonal home not found/);
+  });
+
   it('deletes a plant and cascades to its tasks', async () => {
     const token = await loginAsSeed();
     const res = await request(app)

--- a/backend/tests/unit/handlers/plants.test.ts
+++ b/backend/tests/unit/handlers/plants.test.ts
@@ -124,6 +124,29 @@ describe('plants handler', () => {
     expect(JSON.parse(res.body).message).toMatch(/Space not found/);
   });
 
+  it('refuses to create a plant with a seasonal home outside the household', async () => {
+    const spaceService = await import('../../../src/services/spaceService.js');
+    const plantService = await import('../../../src/services/plantService.js');
+    const { createPlant } = await import('../../../src/handlers/plants/handler.js');
+    vi.mocked(spaceService.getSpace).mockResolvedValueOnce(null);
+    const res = (await createPlant(
+      buildEvent({
+        httpMethod: 'POST',
+        body: JSON.stringify({
+          name: 'Pothos',
+          summerSpaceId: '550e8400-e29b-41d4-a716-446655440099',
+        }),
+        headers: { 'content-type': 'application/json' },
+      }),
+      fakeContext,
+      () => {}
+    )) as APIGatewayProxyResult;
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).message).toMatch(/Seasonal home not found/);
+    expect(plantService.createPlant).not.toHaveBeenCalled();
+  });
+
   it('moves plants only after validating the destination and every household plant', async () => {
     const plantService = await import('../../../src/services/plantService.js');
     const spaceService = await import('../../../src/services/spaceService.js');
@@ -358,6 +381,30 @@ describe('plants handler', () => {
     });
     const res = (await updatePlant(event, fakeContext, () => {})) as APIGatewayProxyResult;
     expect(res.statusCode).toBe(404);
+  });
+
+  it('validates seasonal homes before updating a plant', async () => {
+    const plantService = await import('../../../src/services/plantService.js');
+    const spaceService = await import('../../../src/services/spaceService.js');
+    const { updatePlant } = await import('../../../src/handlers/plants/handler.js');
+    vi.mocked(spaceService.getSpace).mockResolvedValueOnce(null);
+
+    const res = (await updatePlant(
+      buildEvent({
+        httpMethod: 'PUT',
+        pathParameters: { id: 'p1' },
+        body: JSON.stringify({
+          winterSpaceId: '550e8400-e29b-41d4-a716-446655440099',
+        }),
+        headers: { 'content-type': 'application/json' },
+      }),
+      fakeContext,
+      () => {}
+    )) as APIGatewayProxyResult;
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).message).toMatch(/Seasonal home not found/);
+    expect(plantService.updatePlant).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/backend/tests/unit/services/plantService.test.ts
+++ b/backend/tests/unit/services/plantService.test.ts
@@ -177,6 +177,8 @@ describe('plantService', () => {
       expect(result.species).toBeNull();
       expect(result.location).toBeNull();
       expect(result.notes).toBeNull();
+      expect(result.summerSpaceId).toBeNull();
+      expect(result.winterSpaceId).toBeNull();
     });
 
     it('maps a TransactionCanceled cap-condition failure to PlanLimitError (concurrent creates)', async () => {
@@ -303,6 +305,8 @@ describe('plantService', () => {
         parentPlantId: null,
         spaceId: null,
         placementNote: null,
+        summerSpaceId: null,
+        winterSpaceId: null,
       });
     });
 
@@ -583,6 +587,42 @@ describe('plantService', () => {
       const calls = vi.mocked(dynamodb.send).mock.calls;
       expect(calls).toHaveLength(1);
       expect((calls[0][0] as unknown as { kind: string }).kind).toBe('Update');
+    });
+
+    it('writes and returns both seasonal home IDs as ordinary plant fields', async () => {
+      const { dynamodb } = await import('../../../src/utils/dynamodb');
+      const { updatePlant } = await import('../../../src/services/plantService');
+      vi.mocked(dynamodb.send).mockResolvedValueOnce({
+        Attributes: {
+          ...plantRow('active').Item,
+          summerSpaceId: 'summer-space',
+          winterSpaceId: 'winter-space',
+        },
+      });
+
+      const result = await updatePlant(
+        'hh',
+        'p1',
+        { summerSpaceId: 'summer-space', winterSpaceId: 'winter-space' },
+        10
+      );
+
+      expect(result).toMatchObject({
+        summerSpaceId: 'summer-space',
+        winterSpaceId: 'winter-space',
+      });
+      const update = vi.mocked(dynamodb.send).mock.calls[0][0] as unknown as {
+        input: {
+          UpdateExpression: string;
+          ExpressionAttributeValues: Record<string, unknown>;
+        };
+      };
+      expect(update.input.UpdateExpression).toContain('#summerSpaceId = :summerSpaceId');
+      expect(update.input.UpdateExpression).toContain('#winterSpaceId = :winterSpaceId');
+      expect(update.input.ExpressionAttributeValues).toMatchObject({
+        ':summerSpaceId': 'summer-space',
+        ':winterSpaceId': 'winter-space',
+      });
     });
 
     it('active → died decrements plantCount in the same transaction as the status write', async () => {

--- a/docs/api-spec.yaml
+++ b/docs/api-spec.yaml
@@ -1328,6 +1328,14 @@ components:
         placementNote:
           type: string
           nullable: true
+        summerSpaceId:
+          type: string
+          format: uuid
+          nullable: true
+        winterSpaceId:
+          type: string
+          format: uuid
+          nullable: true
         imageUrl:
           type: string
           nullable: true
@@ -1377,6 +1385,12 @@ components:
         placementNote:
           type: string
           maxLength: 120
+        summerSpaceId:
+          type: string
+          format: uuid
+        winterSpaceId:
+          type: string
+          format: uuid
         notes:
           type: string
           maxLength: 1000
@@ -1402,6 +1416,14 @@ components:
         placementNote:
           type: string
           maxLength: 120
+          nullable: true
+        summerSpaceId:
+          type: string
+          format: uuid
+          nullable: true
+        winterSpaceId:
+          type: string
+          format: uuid
           nullable: true
         notes:
           type: string

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -38,6 +38,8 @@ components:
         location: { type: string, nullable: true, maxLength: 100 }
         spaceId: { type: string, format: uuid, nullable: true }
         placementNote: { type: string, nullable: true, maxLength: 120 }
+        summerSpaceId: { type: string, format: uuid, nullable: true }
+        winterSpaceId: { type: string, format: uuid, nullable: true }
         imageUrl: { type: string, nullable: true, format: uri }
         notes: { type: string, nullable: true, maxLength: 1000 }
         tags:

--- a/docs/spaces.md
+++ b/docs/spaces.md
@@ -6,10 +6,10 @@ space remain visible in the `Unplaced` group.
 
 ## Data model
 
-| Entity          | DynamoDB key                         | Important fields           |
-| --------------- | ------------------------------------ | -------------------------- |
-| Plant space     | `PK=HOUSEHOLD#{id}`, `SK=SPACE#{id}` | `name`, `environment`      |
-| Plant placement | existing `PLANT#{id}` row            | `spaceId`, `placementNote` |
+| Entity          | DynamoDB key                         | Important fields                                             |
+| --------------- | ------------------------------------ | ------------------------------------------------------------ |
+| Plant space     | `PK=HOUSEHOLD#{id}`, `SK=SPACE#{id}` | `name`, `environment`                                        |
+| Plant placement | existing `PLANT#{id}` row            | `spaceId`, `placementNote`, `summerSpaceId`, `winterSpaceId` |
 
 The legacy plant `location` string remains readable for imports, exports, and old clients. New UI
 placement writes use `spaceId`; `placementNote` stores the position within that space, such as
@@ -25,8 +25,9 @@ does not change its species traits.
 - `POST /plants/move` with one to 50 unique plant IDs, a destination `spaceId` (or `null` for
   Unplaced), and an optional placement note
 
-Plant create and update accept `spaceId` and `placementNote`. The handler verifies that a supplied
-space belongs to the caller's active household.
+Plant create and update accept `spaceId`, `placementNote`, `summerSpaceId`, and `winterSpaceId`.
+The handler verifies that every supplied space belongs to the caller's active household. A space
+cannot be deleted while any plant uses it as its current or seasonal home.
 
 ## UX rules
 
@@ -59,3 +60,10 @@ The plant detail page offers a one-step Move action, while the collection page s
 up to 50 plants and moving them together. Both use the same atomic endpoint, so a mixed-household or
 missing plant cannot leave half of a batch in the new space. A one-plant move can set a precise
 placement note; bulk moves clear old position notes that no longer describe the destination.
+
+## Seasonal homes
+
+A plant can optionally remember a preferred summer and winter space. The plant detail page uses the
+saved household latitude and a broad April–September northern warm season (inverted in the southern
+hemisphere) to suggest a move when the current space differs. Accepting the suggestion uses the same
+`POST /plants/move` operation as quick and bulk moves; it does not silently relocate plants.

--- a/frontend/src/features/plants/AddPlantPage.tsx
+++ b/frontend/src/features/plants/AddPlantPage.tsx
@@ -45,6 +45,8 @@ const makeAddPlantSchema = (t: TFunction) =>
     species: z.string().max(100, t('validation.speciesTooLong')).optional(),
     spaceId: z.string().optional(),
     placementNote: z.string().max(120, t('validation.locationTooLong')).optional(),
+    summerSpaceId: z.string().optional(),
+    winterSpaceId: z.string().optional(),
     notes: z.string().max(1000, t('validation.notesTooLong')).optional(),
     tags: z.string().max(200, t('validation.tooManyTags')).optional(),
   });
@@ -110,6 +112,8 @@ export function AddPlantPage() {
   const speciesValue = watch('species') ?? '';
   const nameValue = watch('name') ?? '';
   const spaceIdValue = watch('spaceId') ?? '';
+  const summerSpaceIdValue = watch('summerSpaceId') ?? '';
+  const winterSpaceIdValue = watch('winterSpaceId') ?? '';
   const [perenualSpeciesId, setPerenualSpeciesId] = useState<number | null>(null);
   const { data: taskTemplates = [] } = useQuery({
     queryKey: ['task-templates'],
@@ -233,6 +237,8 @@ export function AddPlantPage() {
         species: data.species || undefined,
         spaceId: data.spaceId || undefined,
         placementNote: data.placementNote || undefined,
+        summerSpaceId: data.summerSpaceId || undefined,
+        winterSpaceId: data.winterSpaceId || undefined,
         notes: data.notes || undefined,
         tags: tags.length > 0 ? tags : undefined,
         perenualSpeciesId: perenualSpeciesId ?? undefined,
@@ -525,6 +531,33 @@ export function AddPlantPage() {
             error={errors.placementNote?.message}
             {...register('placementNote')}
           />
+
+          <fieldset className="space-y-3 rounded-lg border border-primary-100/70 bg-parchment/40 p-4">
+            <legend className="px-1 text-sm font-semibold text-ink">
+              {t('seasonalHomes.title')}
+            </legend>
+            <p className="text-sm text-gray-600">{t('seasonalHomes.description')}</p>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <SpacePicker
+                id="plant-summer-space"
+                label={t('seasonalHomes.summerLabel')}
+                value={summerSpaceIdValue}
+                onChange={(spaceId) => setValue('summerSpaceId', spaceId, { shouldValidate: true })}
+                error={errors.summerSpaceId?.message}
+                allowCreate={false}
+                emptyLabel={t('seasonalHomes.notSet')}
+              />
+              <SpacePicker
+                id="plant-winter-space"
+                label={t('seasonalHomes.winterLabel')}
+                value={winterSpaceIdValue}
+                onChange={(spaceId) => setValue('winterSpaceId', spaceId, { shouldValidate: true })}
+                error={errors.winterSpaceId?.message}
+                allowCreate={false}
+                emptyLabel={t('seasonalHomes.notSet')}
+              />
+            </div>
+          </fieldset>
 
           <Input
             label="Tags"

--- a/frontend/src/features/plants/EditPlantModal.tsx
+++ b/frontend/src/features/plants/EditPlantModal.tsx
@@ -20,6 +20,8 @@ const plantSchema = z.object({
   species: z.string().max(100).optional(),
   spaceId: z.string().optional(),
   placementNote: z.string().max(120).optional(),
+  summerSpaceId: z.string().optional(),
+  winterSpaceId: z.string().optional(),
   notes: z.string().max(1000).optional(),
 });
 
@@ -50,6 +52,8 @@ export function EditPlantModal({ plant, isOpen, onClose }: EditPlantModalProps) 
       species: plant.species || '',
       spaceId: plant.spaceId || '',
       placementNote: plant.placementNote || '',
+      summerSpaceId: plant.summerSpaceId || '',
+      winterSpaceId: plant.winterSpaceId || '',
       notes: plant.notes || '',
     },
   });
@@ -59,6 +63,8 @@ export function EditPlantModal({ plant, isOpen, onClose }: EditPlantModalProps) 
   );
   const speciesValue = watch('species') ?? '';
   const spaceIdValue = watch('spaceId') ?? '';
+  const summerSpaceIdValue = watch('summerSpaceId') ?? '';
+  const winterSpaceIdValue = watch('winterSpaceId') ?? '';
 
   useEffect(() => {
     if (isOpen) {
@@ -67,6 +73,8 @@ export function EditPlantModal({ plant, isOpen, onClose }: EditPlantModalProps) 
         species: plant.species || '',
         spaceId: plant.spaceId || '',
         placementNote: plant.placementNote || '',
+        summerSpaceId: plant.summerSpaceId || '',
+        winterSpaceId: plant.winterSpaceId || '',
         notes: plant.notes || '',
       });
       setPerenualSpeciesId(plant.perenualSpeciesId ?? null);
@@ -80,6 +88,8 @@ export function EditPlantModal({ plant, isOpen, onClose }: EditPlantModalProps) 
         species: data.species || undefined,
         spaceId: data.spaceId || null,
         placementNote: data.placementNote || null,
+        summerSpaceId: data.summerSpaceId || null,
+        winterSpaceId: data.winterSpaceId || null,
         notes: data.notes || undefined,
         // Always explicit, including null — omitting it would leave the
         // backend's existing link untouched and reintroduce stale care/
@@ -180,6 +190,37 @@ export function EditPlantModal({ plant, isOpen, onClose }: EditPlantModalProps) 
                     error={errors.placementNote?.message}
                     {...register('placementNote')}
                   />
+
+                  <fieldset className="space-y-3 rounded-lg border border-primary-100/70 bg-parchment/40 p-4">
+                    <legend className="px-1 text-sm font-semibold text-ink">
+                      {t('seasonalHomes.title')}
+                    </legend>
+                    <p className="text-sm text-gray-600">{t('seasonalHomes.description')}</p>
+                    <div className="grid gap-4 sm:grid-cols-2">
+                      <SpacePicker
+                        id="plant-summer-space"
+                        label={t('seasonalHomes.summerLabel')}
+                        value={summerSpaceIdValue}
+                        onChange={(spaceId) =>
+                          setValue('summerSpaceId', spaceId, { shouldValidate: true })
+                        }
+                        error={errors.summerSpaceId?.message}
+                        allowCreate={false}
+                        emptyLabel={t('seasonalHomes.notSet')}
+                      />
+                      <SpacePicker
+                        id="plant-winter-space"
+                        label={t('seasonalHomes.winterLabel')}
+                        value={winterSpaceIdValue}
+                        onChange={(spaceId) =>
+                          setValue('winterSpaceId', spaceId, { shouldValidate: true })
+                        }
+                        error={errors.winterSpaceId?.message}
+                        allowCreate={false}
+                        emptyLabel={t('seasonalHomes.notSet')}
+                      />
+                    </div>
+                  </fieldset>
 
                   <div>
                     <label htmlFor="notes" className="label">

--- a/frontend/src/features/plants/PlantDetailPage.tsx
+++ b/frontend/src/features/plants/PlantDetailPage.tsx
@@ -50,6 +50,8 @@ import { PlantImage } from '@/components/PlantImage';
 import { spaceService } from '@/services/spaceService';
 import { plantLocationLabel, spaceMap } from '@/utils/spaces';
 import { MovePlantsDialog } from './MovePlantsDialog';
+import { householdService } from '@/services/householdService';
+import { seasonalHomeSuggestion } from './seasonalHomes';
 
 function formatDate(dateString: string | null): string {
   if (!dateString) return 'Never';
@@ -87,6 +89,11 @@ export function PlantDetailPage() {
   const { data: spaces = [] } = useQuery({
     queryKey: ['spaces', householdId],
     queryFn: spaceService.getSpaces,
+  });
+  const { data: household, isFetched: householdLoaded } = useQuery({
+    queryKey: ['household', householdId],
+    queryFn: () => householdService.getHousehold(householdId!),
+    enabled: !!householdId,
   });
 
   // Title reflects the plant once it's loaded; falls back to a generic
@@ -139,6 +146,17 @@ export function PlantDetailPage() {
     onError: (err) => toast.error(getErrorMessage(err)),
   });
 
+  const seasonalMoveMutation = useMutation({
+    mutationFn: (spaceId: string) =>
+      plantService.movePlants({ plantIds: [plantId!], spaceId, placementNote: null }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['plants', householdId] });
+      queryClient.invalidateQueries({ queryKey: ['spaces', householdId] });
+      toast.success(t('seasonalHomes.moveSuccess'));
+    },
+    onError: (err) => toast.error(getErrorMessage(err)),
+  });
+
   if (isLoading) {
     return (
       <div className="flex justify-center py-12">
@@ -161,6 +179,10 @@ export function PlantDetailPage() {
       </div>
     );
   }
+
+  const seasonalSuggestion = seasonalHomeSuggestion(plant, spaces, household?.location?.lat);
+  const hasSeasonalHomes = Boolean(plant.summerSpaceId || plant.winterSpaceId);
+  const spacesById = spaceMap(spaces);
 
   return (
     <div className="space-y-6">
@@ -283,8 +305,26 @@ export function PlantDetailPage() {
             {(plant.spaceId || plant.location) && (
               <div>
                 <dt className="text-sm font-medium text-gray-500">Space</dt>
+                <dd className="text-sm text-gray-900">{plantLocationLabel(plant, spacesById)}</dd>
+              </div>
+            )}
+            {plant.summerSpaceId && (
+              <div>
+                <dt className="text-sm font-medium text-gray-500">
+                  {t('seasonalHomes.summerDisplayLabel')}
+                </dt>
                 <dd className="text-sm text-gray-900">
-                  {plantLocationLabel(plant, spaceMap(spaces))}
+                  {spacesById.get(plant.summerSpaceId)?.name ?? t('seasonalHomes.unavailable')}
+                </dd>
+              </div>
+            )}
+            {plant.winterSpaceId && (
+              <div>
+                <dt className="text-sm font-medium text-gray-500">
+                  {t('seasonalHomes.winterDisplayLabel')}
+                </dt>
+                <dd className="text-sm text-gray-900">
+                  {spacesById.get(plant.winterSpaceId)?.name ?? t('seasonalHomes.unavailable')}
                 </dd>
               </div>
             )}
@@ -303,6 +343,38 @@ export function PlantDetailPage() {
           </dl>
         </div>
       </div>
+
+      {seasonalSuggestion && (plant.status ?? 'active') === 'active' && (
+        <Alert variant="info" title={t('seasonalHomes.suggestionTitle')}>
+          <p>
+            {t('seasonalHomes.suggestionDescription', {
+              season: t(`seasonalHomes.${seasonalSuggestion.season}`),
+              space: seasonalSuggestion.targetSpace.name,
+            })}
+          </p>
+          <Button
+            size="sm"
+            className="mt-3"
+            isLoading={seasonalMoveMutation.isPending}
+            onClick={() => seasonalMoveMutation.mutate(seasonalSuggestion.targetSpace.id)}
+            leftIcon={<ArrowsRightLeftIcon className="h-4 w-4" aria-hidden="true" />}
+          >
+            {t('seasonalHomes.moveAction', { space: seasonalSuggestion.targetSpace.name })}
+          </Button>
+        </Alert>
+      )}
+
+      {hasSeasonalHomes && householdLoaded && !household?.location && (
+        <Alert variant="info" title={t('seasonalHomes.locationTitle')}>
+          <p>{t('seasonalHomes.locationDescription')}</p>
+          <Link
+            to="/household"
+            className="mt-2 inline-flex min-h-touch items-center font-medium underline"
+          >
+            {t('seasonalHomes.locationAction')}
+          </Link>
+        </Alert>
+      )}
 
       {/* Curated care guidance — only renders if plant.species matches a known entry */}
       <CareGuidanceCard species={plant.species} />

--- a/frontend/src/features/plants/SpacePicker.tsx
+++ b/frontend/src/features/plants/SpacePicker.tsx
@@ -11,9 +11,21 @@ interface SpacePickerProps {
   value: string;
   onChange: (spaceId: string) => void;
   error?: string;
+  id?: string;
+  label?: string;
+  allowCreate?: boolean;
+  emptyLabel?: string;
 }
 
-export function SpacePicker({ value, onChange, error }: SpacePickerProps) {
+export function SpacePicker({
+  value,
+  onChange,
+  error,
+  id = 'plant-space',
+  label,
+  allowCreate = true,
+  emptyLabel,
+}: SpacePickerProps) {
   const { t } = useTranslation();
   const householdId = useActiveHouseholdId();
   const queryClient = useQueryClient();
@@ -41,16 +53,16 @@ export function SpacePicker({ value, onChange, error }: SpacePickerProps) {
 
   return (
     <div className="space-y-2">
-      <label htmlFor="plant-space" className="label">
-        {t('spaces.fieldLabel')}
+      <label htmlFor={id} className="label">
+        {label ?? t('spaces.fieldLabel')}
       </label>
       <select
-        id="plant-space"
+        id={id}
         className="input"
         value={value}
         onChange={(event) => onChange(event.target.value)}
       >
-        <option value="">{t('spaces.unplaced')}</option>
+        <option value="">{emptyLabel ?? t('spaces.unplaced')}</option>
         {inside.length > 0 && (
           <optgroup label={t('spaces.inside')}>
             {inside.map((space) => (
@@ -72,61 +84,67 @@ export function SpacePicker({ value, onChange, error }: SpacePickerProps) {
       </select>
       {error && <p className="error-message">{error}</p>}
 
-      {!creating ? (
-        <button
-          type="button"
-          className="inline-flex min-h-touch items-center gap-1 text-sm font-medium text-primary-700 hover:underline"
-          onClick={() => setCreating(true)}
-        >
-          <PlusIcon className="h-4 w-4" aria-hidden="true" />
-          {t('spaces.createAction')}
-        </button>
-      ) : (
-        <div className="rounded-lg border border-primary-100/70 bg-parchment/50 p-3 space-y-3">
-          <input
-            className="input"
-            value={name}
-            maxLength={80}
-            placeholder={t('spaces.namePlaceholder')}
-            aria-label={t('spaces.nameLabel')}
-            onChange={(event) => setName(event.target.value)}
-          />
-          <div className="flex flex-wrap gap-2" role="group" aria-label={t('spaces.environment')}>
-            {(['inside', 'outside'] as const).map((option) => (
-              <button
-                key={option}
+      {allowCreate &&
+        (!creating ? (
+          <button
+            type="button"
+            className="inline-flex min-h-touch items-center gap-1 text-sm font-medium text-primary-700 hover:underline"
+            onClick={() => setCreating(true)}
+          >
+            <PlusIcon className="h-4 w-4" aria-hidden="true" />
+            {t('spaces.createAction')}
+          </button>
+        ) : (
+          <div className="rounded-lg border border-primary-100/70 bg-parchment/50 p-3 space-y-3">
+            <input
+              className="input"
+              value={name}
+              maxLength={80}
+              placeholder={t('spaces.namePlaceholder')}
+              aria-label={t('spaces.nameLabel')}
+              onChange={(event) => setName(event.target.value)}
+            />
+            <div className="flex flex-wrap gap-2" role="group" aria-label={t('spaces.environment')}>
+              {(['inside', 'outside'] as const).map((option) => (
+                <button
+                  key={option}
+                  type="button"
+                  className={`min-h-touch rounded-full border px-3 py-1.5 text-sm ${
+                    environment === option
+                      ? 'border-primary-500 bg-primary-100 text-primary-900'
+                      : 'border-primary-200 bg-paper text-gray-700'
+                  }`}
+                  aria-pressed={environment === option}
+                  onClick={() => setEnvironment(option)}
+                >
+                  {t(`spaces.${option}`)}
+                </button>
+              ))}
+            </div>
+            {createMutation.isError && (
+              <p className="error-message">{getErrorMessage(createMutation.error)}</p>
+            )}
+            <div className="flex gap-2">
+              <Button
                 type="button"
-                className={`min-h-touch rounded-full border px-3 py-1.5 text-sm ${
-                  environment === option
-                    ? 'border-primary-500 bg-primary-100 text-primary-900'
-                    : 'border-primary-200 bg-paper text-gray-700'
-                }`}
-                aria-pressed={environment === option}
-                onClick={() => setEnvironment(option)}
+                size="sm"
+                disabled={!name.trim()}
+                isLoading={createMutation.isPending}
+                onClick={() => createMutation.mutate()}
               >
-                {t(`spaces.${option}`)}
-              </button>
-            ))}
+                {t('spaces.createAction')}
+              </Button>
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                onClick={() => setCreating(false)}
+              >
+                {t('common.cancel')}
+              </Button>
+            </div>
           </div>
-          {createMutation.isError && (
-            <p className="error-message">{getErrorMessage(createMutation.error)}</p>
-          )}
-          <div className="flex gap-2">
-            <Button
-              type="button"
-              size="sm"
-              disabled={!name.trim()}
-              isLoading={createMutation.isPending}
-              onClick={() => createMutation.mutate()}
-            >
-              {t('spaces.createAction')}
-            </Button>
-            <Button type="button" variant="secondary" size="sm" onClick={() => setCreating(false)}>
-              {t('common.cancel')}
-            </Button>
-          </div>
-        </div>
-      )}
+        ))}
     </div>
   );
 }

--- a/frontend/src/features/plants/seasonalHomes.test.ts
+++ b/frontend/src/features/plants/seasonalHomes.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import type { PlantSpace } from '@/services/plantService';
+import { seasonalHomeSuggestion, seasonForMonth } from './seasonalHomes';
+
+const spaces: PlantSpace[] = [
+  {
+    id: 'patio',
+    householdId: 'hh',
+    name: 'Patio',
+    environment: 'outside',
+    createdAt: '',
+    createdBy: '',
+    updatedAt: '',
+  },
+  {
+    id: 'sunroom',
+    householdId: 'hh',
+    name: 'Sunroom',
+    environment: 'inside',
+    createdAt: '',
+    createdBy: '',
+    updatedAt: '',
+  },
+];
+
+describe('seasonal homes', () => {
+  it('inverts warm and cool seasons across hemispheres', () => {
+    expect(seasonForMonth(45, 6)).toBe('summer');
+    expect(seasonForMonth(45, 0)).toBe('winter');
+    expect(seasonForMonth(-33, 6)).toBe('winter');
+    expect(seasonForMonth(-33, 0)).toBe('summer');
+  });
+
+  it('suggests the configured home when the plant is elsewhere', () => {
+    expect(
+      seasonalHomeSuggestion(
+        { spaceId: 'sunroom', summerSpaceId: 'patio', winterSpaceId: 'sunroom' },
+        spaces,
+        45,
+        new Date(2026, 6, 15)
+      )
+    ).toEqual({ season: 'summer', targetSpace: spaces[0] });
+  });
+
+  it('does not prompt without a latitude, valid target, or needed move', () => {
+    const plant = { spaceId: 'patio', summerSpaceId: 'patio', winterSpaceId: 'missing' };
+    expect(seasonalHomeSuggestion(plant, spaces, null, new Date(2026, 6, 15))).toBeNull();
+    expect(seasonalHomeSuggestion(plant, spaces, 45, new Date(2026, 6, 15))).toBeNull();
+    expect(seasonalHomeSuggestion(plant, spaces, 45, new Date(2026, 0, 15))).toBeNull();
+  });
+});

--- a/frontend/src/features/plants/seasonalHomes.ts
+++ b/frontend/src/features/plants/seasonalHomes.ts
@@ -1,0 +1,35 @@
+import type { Plant, PlantSpace } from '@/services/plantService';
+
+export type SeasonalHomeSeason = 'summer' | 'winter';
+
+/**
+ * Treat April–September as the northern warm season and invert it south of
+ * the equator. The broad windows make the prompt useful before temperature
+ * extremes arrive without pretending to be a weather forecast.
+ */
+export function seasonForMonth(latitude: number, month: number): SeasonalHomeSeason {
+  const northernSummer = month >= 3 && month <= 8;
+  const localSummer = latitude < 0 ? !northernSummer : northernSummer;
+  return localSummer ? 'summer' : 'winter';
+}
+
+export interface SeasonalHomeSuggestion {
+  season: SeasonalHomeSeason;
+  targetSpace: PlantSpace;
+}
+
+export function seasonalHomeSuggestion(
+  plant: Pick<Plant, 'spaceId' | 'summerSpaceId' | 'winterSpaceId'> | null | undefined,
+  spaces: PlantSpace[],
+  latitude: number | null | undefined,
+  date = new Date()
+): SeasonalHomeSuggestion | null {
+  if (!plant || latitude == null || !Number.isFinite(latitude)) return null;
+
+  const season = seasonForMonth(latitude, date.getMonth());
+  const targetSpaceId = season === 'summer' ? plant.summerSpaceId : plant.winterSpaceId;
+  if (!targetSpaceId || targetSpaceId === plant.spaceId) return null;
+
+  const targetSpace = spaces.find((space) => space.id === targetSpaceId);
+  return targetSpace ? { season, targetSpace } : null;
+}

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -56,6 +56,25 @@
     "moveSuccess_one": "Plant moved",
     "moveSuccess_other": "{{count}} plants moved"
   },
+  "seasonalHomes": {
+    "title": "Seasonal homes",
+    "description": "Choose where this plant usually lives in warm and cool seasons.",
+    "summerLabel": "Summer home (optional)",
+    "winterLabel": "Winter home (optional)",
+    "summerDisplayLabel": "Summer home",
+    "winterDisplayLabel": "Winter home",
+    "notSet": "Not set",
+    "unavailable": "Unavailable space",
+    "summer": "summer",
+    "winter": "winter",
+    "suggestionTitle": "Seasonal move suggested",
+    "suggestionDescription": "It is {{season}} in your hemisphere. Move this plant to {{space}}?",
+    "moveAction": "Move to {{space}}",
+    "moveSuccess": "Plant moved to its seasonal home",
+    "locationTitle": "Add a location for seasonal reminders",
+    "locationDescription": "Your household location tells us which season is current in your hemisphere.",
+    "locationAction": "Set household location"
+  },
   "careRounds": {
     "displayMode": "Task organization",
     "schedule": "By date",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -61,6 +61,25 @@
     "moveSuccess_other": "{{count}} plantas movidas",
     "moveSuccess_many": "{{count}} plantas movidas"
   },
+  "seasonalHomes": {
+    "title": "Hogares de temporada",
+    "description": "Elige dónde suele vivir esta planta en las temporadas cálida y fría.",
+    "summerLabel": "Hogar de verano (opcional)",
+    "winterLabel": "Hogar de invierno (opcional)",
+    "summerDisplayLabel": "Hogar de verano",
+    "winterDisplayLabel": "Hogar de invierno",
+    "notSet": "Sin configurar",
+    "unavailable": "Espacio no disponible",
+    "summer": "verano",
+    "winter": "invierno",
+    "suggestionTitle": "Se recomienda un cambio de temporada",
+    "suggestionDescription": "Es {{season}} en tu hemisferio. ¿Mover esta planta a {{space}}?",
+    "moveAction": "Mover a {{space}}",
+    "moveSuccess": "Planta movida a su hogar de temporada",
+    "locationTitle": "Añade una ubicación para recibir recordatorios de temporada",
+    "locationDescription": "La ubicación del hogar indica qué temporada es actual en tu hemisferio.",
+    "locationAction": "Configurar ubicación del hogar"
+  },
   "careRounds": {
     "displayMode": "Organización de tareas",
     "schedule": "Por fecha",

--- a/frontend/src/services/plantService.ts
+++ b/frontend/src/services/plantService.ts
@@ -26,6 +26,8 @@ export interface Plant {
   location: string | null;
   spaceId?: string | null;
   placementNote?: string | null;
+  summerSpaceId?: string | null;
+  winterSpaceId?: string | null;
   imageUrl: string | null;
   notes: string | null;
   /** Lifecycle status; legacy rows may omit it → treat as 'active'. */
@@ -46,6 +48,8 @@ export interface CreatePlantData {
   location?: string;
   spaceId?: string;
   placementNote?: string;
+  summerSpaceId?: string;
+  winterSpaceId?: string;
   notes?: string;
   tags?: string[];
   perenualSpeciesId?: number;
@@ -59,6 +63,8 @@ export interface UpdatePlantData {
   location?: string;
   spaceId?: string | null;
   placementNote?: string | null;
+  summerSpaceId?: string | null;
+  winterSpaceId?: string | null;
   notes?: string;
   tags?: string[];
   perenualSpeciesId?: number | null;


### PR DESCRIPTION
## Summary
- let households save optional summer and winter spaces on each plant from add/edit flows
- validate seasonal homes against the active household and protect referenced spaces from deletion
- suggest hemisphere-aware seasonal moves on plant detail, with explicit confirmation through the existing move endpoint
- document the migration-free data model and API fields in both OpenAPI descriptions

## Verification
- `npm run verify` (419 frontend, 1,220 backend tests)
- `npm run build --workspace frontend`
- `npm run size --workspace frontend` (350.87/360 kB aggregate; initial JS 11.83/62 kB)
- focused persistence, handler, local integration, and hemisphere tests

## Known parent-branch release state
- `npm run mobile:validate` reports the existing main-line package/native version mismatch (0.16.3 vs 0.16.2); the blocked v0.17.0 release PR updates these together

## CI note
GitHub-hosted jobs are currently prevented from starting by the repository Actions budget; local gates are green.

## Stack
- base: #235
