### PR TITLE
feat: show plant locations to sitters

### DIFF
--- a/backend/src/handlers/tasks/handler.ts
+++ b/backend/src/handlers/tasks/handler.ts
@@ -541,8 +541,10 @@ export const listVacations = createHandler(
 //   - sitterService.getActiveLink enforces existence + active + within the
 //     [startsAt, expiresAt] window on EVERY call, and is generic on failure so
 //     the endpoint isn't a token-existence oracle (single 404 for any miss).
-//   - The response exposes ONLY the PII-free SitterTask projection — no member
-//     names/emails, no other households, no full plant records, no notes.
+//   - The response exposes ONLY the minimal SitterTask projection — no member
+//     names/emails, no other households, no full plant records, no private
+//     plant/task notes, and no household climate location. Current space and
+//     placement note are intentionally shared as care directions.
 
 // GET /sitter/{token}
 //
@@ -632,6 +634,10 @@ export const completeSitterTask = createHandler(
       plantName: task.plantName,
       taskType: task.customType || task.type,
       dueDate: task.nextDue,
+      // The completion response is only an acknowledgement; placements are
+      // supplied on GET and can change independently of the recurring task.
+      spaceName: null,
+      placementNote: null,
       overdue: false,
     });
   }

--- a/backend/src/local-server.ts
+++ b/backend/src/local-server.ts
@@ -2311,10 +2311,12 @@ app.get('/plants/shared/:code', (req, res) => {
 // --- Plant-sitter PUBLIC endpoints (no auth) ------------------------------
 // Mirrors handlers/tasks/handler.ts: getSitterView / completeSitterTask. The
 // 256-bit token in the path is the only credential; we validate it on every
-// call and expose ONLY the PII-free due-task projection.
+// call and expose ONLY the minimal due-task projection. Current space and
+// placement note are shared; private notes, saved climate location, and member
+// data are not.
 
-/** PII-free due/overdue tasks for a household. Mirrors taskService.getSitterTasks:
- *  due within 7 days OR overdue, active plants only, minimal fields. */
+/** Minimal due/overdue tasks for a household. Mirrors taskService.getSitterTasks:
+ *  due within 7 days OR overdue, active plants only, with sitter-safe location. */
 function sitterTasksFor(householdId: string) {
   const now = new Date();
   const cutoff = new Date(now);
@@ -2326,13 +2328,19 @@ function sitterTasksFor(householdId: string) {
     .filter((t) => (db.plants.get(t.plantId)?.status ?? 'active') === 'active')
     .filter((t) => t.nextDue <= cutoffIso)
     .sort((a, b) => new Date(a.nextDue).getTime() - new Date(b.nextDue).getTime())
-    .map((t) => ({
-      taskId: t.id,
-      plantName: t.plantName,
-      taskType: t.customType || t.type,
-      dueDate: t.nextDue,
-      overdue: t.nextDue < nowIso,
-    }));
+    .map((t) => {
+      const plant = db.plants.get(t.plantId);
+      const space = plant?.spaceId ? db.spaces.get(plant.spaceId) : undefined;
+      return {
+        taskId: t.id,
+        plantName: t.plantName,
+        taskType: t.customType || t.type,
+        dueDate: t.nextDue,
+        spaceName: space?.name ?? plant?.location ?? null,
+        placementNote: plant?.placementNote ?? null,
+        overdue: t.nextDue < nowIso,
+      };
+    });
 }
 
 // GET /sitter/:token
@@ -2397,6 +2405,8 @@ app.post('/sitter/:token/tasks/:taskId/complete', (req, res) => {
     plantName: task.plantName,
     taskType: task.customType || task.type,
     dueDate: task.nextDue,
+    spaceName: null,
+    placementNote: null,
     overdue: false,
   });
 });

--- a/backend/src/services/taskService.ts
+++ b/backend/src/services/taskService.ts
@@ -27,6 +27,7 @@ import { Task, TaskCompletion, DynamoDBItem } from '../models/types.js';
 import { CreateTaskInput, UpdateTaskInput, TaskFilters } from '../models/schemas.js';
 import { getMemberByUserId } from './householdService.js';
 import * as plantService from './plantService.js';
+import * as spaceService from './spaceService.js';
 import { recordActivity } from './activity.js';
 
 const MAX_QUERY_LIMIT = 200;
@@ -223,14 +224,20 @@ export async function getTasks(
 /**
  * The minimal, PII-free task shape a plant-sitter sees. Deliberately NOT the
  * full Task: no assignee names/ids, no createdBy, no notes (notes can contain
- * household-private context), no householdId. Just enough to do the job:
- * which plant, what to do, when it's due.
+ * household-private context), no householdId, and no household climate
+ * location. Just enough to do the job: which plant, where it is, what to do,
+ * and when it's due. Space names and placement notes are user-authored fields
+ * that the household explicitly chooses to share with active sitter links.
  */
 export interface SitterTask {
   taskId: string;
   plantName: string;
   taskType: string;
   dueDate: string;
+  /** Current structured space name, or the legacy location string. */
+  spaceName: string | null;
+  /** Short directions within that space, e.g. "east window, top shelf". */
+  placementNote: string | null;
   /** True when dueDate is in the past — drives the "overdue" badge. */
   overdue: boolean;
 }
@@ -241,7 +248,7 @@ export interface SitterTask {
  * already overdue — the sitter should see everything that needs doing during
  * their window, not just strictly-overdue items. Tasks for died/gave_away
  * plants are filtered out (getTasks already does this). The returned objects
- * expose ONLY plant common name, task type, due date, and id — see SitterTask.
+ * expose ONLY the fields documented by SitterTask.
  */
 export async function getSitterTasks(
   householdId: string,
@@ -254,19 +261,35 @@ export async function getSitterTasks(
   const nowIso = now.toISOString();
 
   // getTasks already lifecycle-filters (active plants only) and returns the
-  // denormalized plantName + customType we need — reuse it rather than
-  // re-deriving the projection.
+  // denormalized plantName + customType we need. Placements are deliberately
+  // resolved at read time so moving a plant or renaming a space is reflected
+  // immediately without rewriting recurring task rows.
   const tasks = await getTasks(householdId);
+  const [plants, spaces] = await Promise.all([
+    plantService.getPlants(householdId),
+    spaceService.getSpaces(householdId),
+  ]);
+  const plantsById = new Map(plants.map((plant) => [plant.id, plant]));
+  const spacesById = new Map(spaces.map((space) => [space.id, space]));
+
   return tasks
     .filter((t) => t.nextDue <= cutoffIso)
     .sort((a, b) => new Date(a.nextDue).getTime() - new Date(b.nextDue).getTime())
-    .map((t) => ({
-      taskId: t.id,
-      plantName: t.plantName,
-      taskType: t.customType || t.type,
-      dueDate: t.nextDue,
-      overdue: t.nextDue < nowIso,
-    }));
+    .map((t) => {
+      const plant = plantsById.get(t.plantId);
+      const spaceName = plant?.spaceId
+        ? (spacesById.get(plant.spaceId)?.name ?? plant.location ?? null)
+        : (plant?.location ?? null);
+      return {
+        taskId: t.id,
+        plantName: t.plantName,
+        taskType: t.customType || t.type,
+        dueDate: t.nextDue,
+        spaceName,
+        placementNote: plant?.placementNote ?? null,
+        overdue: t.nextDue < nowIso,
+      };
+    });
 }
 
 export async function getUpcomingTasks(householdId: string): Promise<TaskWithCoverage[]> {

--- a/backend/tests/integration/sitter-links.test.ts
+++ b/backend/tests/integration/sitter-links.test.ts
@@ -14,6 +14,7 @@ import {
   provisionLocalUserFixture,
   resetDb,
   seedHouseholdId,
+  seedPlantId,
   seedTaskId,
 } from '../../src/local-server';
 
@@ -111,7 +112,16 @@ describe('public sitter view (no auth)', () => {
     return res.body.token as string;
   }
 
-  it('returns the due task list with NO PII and no auth header', async () => {
+  it('returns sitter-safe task locations with no private household data or auth header', async () => {
+    const plant = db.plants.get(seedPlantId)!;
+    plant.placementNote = 'east window, top shelf';
+    plant.notes = 'Private propagation plan';
+    db.tasks.get(seedTaskId)!.notes = 'Use the private measuring cup';
+    db.households.get(seedHouseholdId)!.location = {
+      city: 'Private Climate City',
+      lat: 1,
+      lon: 2,
+    };
     const sitterToken = await createLink();
     const res = await request(app).get(`/sitter/${sitterToken}`); // no Authorization
     expect(res.status).toBe(200);
@@ -121,19 +131,24 @@ describe('public sitter view (no auth)', () => {
     expect(res.body.tasks.length).toBeGreaterThan(0);
 
     const task = res.body.tasks[0];
-    // Only the PII-free projection — exactly these keys, nothing more.
+    // Only the sitter-safe projection — exactly these keys, nothing more.
     expect(Object.keys(task).sort()).toEqual(
-      ['dueDate', 'overdue', 'plantName', 'taskType', 'taskId'].sort()
+      ['dueDate', 'overdue', 'placementNote', 'plantName', 'spaceName', 'taskType', 'taskId'].sort()
     );
     expect(task.plantName).toBe('Monstera');
     expect(task.taskType).toBe('water');
+    expect(task.spaceName).toBe('Living Room');
+    expect(task.placementNote).toBe('east window, top shelf');
 
     // Assert the whole payload carries no member identity / household id / notes.
     const blob = JSON.stringify(res.body);
     expect(blob).not.toContain(SEED_EMAIL);
     expect(blob).not.toContain('Test User'); // seed member name
     expect(blob).not.toContain(seedHouseholdId);
-    expect(blob).not.toMatch(/assignedTo|completedBy|createdBy|notes|email/);
+    expect(blob).not.toContain('Private Climate City');
+    expect(blob).not.toContain('Private propagation plan');
+    expect(blob).not.toContain('Use the private measuring cup');
+    expect(blob).not.toMatch(/assignedTo|completedBy|createdBy|"notes"|email/);
   });
 
   it('404s on an unknown / malformed token (no enumeration oracle)', async () => {

--- a/backend/tests/unit/handlers/sitter.test.ts
+++ b/backend/tests/unit/handlers/sitter.test.ts
@@ -72,7 +72,15 @@ describe('GET /sitter/{token} (public)', () => {
     const { getSitterTasks } = await import('../../../src/services/taskService.js');
     vi.mocked(getActiveLink).mockResolvedValueOnce(activeLink() as never);
     vi.mocked(getSitterTasks).mockResolvedValueOnce([
-      { taskId: 't1', plantName: 'Monstera', taskType: 'water', dueDate: 'now', overdue: true },
+      {
+        taskId: 't1',
+        plantName: 'Monstera',
+        taskType: 'water',
+        dueDate: 'now',
+        spaceName: 'Living Room',
+        placementNote: 'east window',
+        overdue: true,
+      },
     ] as never);
 
     const { getSitterView } = await import('../../../src/handlers/tasks/handler.js');
@@ -90,6 +98,8 @@ describe('GET /sitter/{token} (public)', () => {
       plantName: 'Monstera',
       taskType: 'water',
       dueDate: 'now',
+      spaceName: 'Living Room',
+      placementNote: 'east window',
       overdue: true,
     });
     // No member identity / household id leaked anywhere in the payload.
@@ -161,6 +171,8 @@ describe('POST /sitter/{token}/tasks/{taskId}/complete (public)', () => {
       plantName: 'Monstera',
       taskType: 'water',
       dueDate: '2999-01-02T00:00:00.000Z',
+      spaceName: null,
+      placementNote: null,
       overdue: false,
     });
 

--- a/docs/api-spec.yaml
+++ b/docs/api-spec.yaml
@@ -306,7 +306,7 @@ paths:
 
   /sitter/{token}:
     get:
-      summary: Public plant-sitter view — due/overdue tasks for a time-boxed link. No auth; token is the only credential. Returns ONLY plant common name, task type, due date, taskId (no PII).
+      summary: Public plant-sitter view — due/overdue tasks for a time-boxed link. No auth; token is the only credential. Returns only task essentials plus current space and placement note; never household climate location, private notes, or member data.
       tags: [Tasks]
       security: []
       parameters:
@@ -330,6 +330,8 @@ paths:
                         plantName: { type: string }
                         taskType: { type: string }
                         dueDate: { type: string, format: date-time }
+                        spaceName: { type: string, nullable: true }
+                        placementNote: { type: string, nullable: true }
                         overdue: { type: boolean }
         '404': { $ref: '#/components/responses/NotFound' }
 
@@ -353,6 +355,8 @@ paths:
                   plantName: { type: string }
                   taskType: { type: string }
                   dueDate: { type: string, format: date-time }
+                  spaceName: { type: string, nullable: true }
+                  placementNote: { type: string, nullable: true }
                   overdue: { type: boolean }
         '404': { $ref: '#/components/responses/NotFound' }
 

--- a/docs/audits/dpia.md
+++ b/docs/audits/dpia.md
@@ -89,7 +89,7 @@ public-access block (`infrastructure/modules/frontend/main.tf` lines 85–170).
 - Phone: empty string unless SMS opted in; changing it clears `phoneVerified`.
 - Analytics carries no PII on either rail; DNT honored in the browser.
 - Chat history auto-expires at 30 days rather than accreting.
-- Sitter view exposes due tasks only — "the token grants exactly one household's due-task view + completion, nothing else."
+- Sitter view exposes a minimal care projection: due task, plant name, current space, and placement note. It excludes saved household location, private plant/task notes, and member data — "the token grants exactly one household's sitter-safe task view + completion, nothing else."
 - Location is a feature-gated opt-in with a stated reason.
 
 ---

--- a/docs/spaces.md
+++ b/docs/spaces.md
@@ -54,6 +54,10 @@ time. This avoids denormalizing a space name onto recurring task rows, which wou
 time a plant moves or a space is renamed. Placement notes ride with the displayed space label, and
 plants without a structured space are explicitly shown as Unplaced.
 
+Active sitter links use the same read-time lookup for due tasks, sharing the current space name and
+short placement note so a sitter can find the plant. The public projection never includes the
+household's saved climate location, private plant/task notes, or member identity/contact details.
+
 ## Moving plants
 
 The plant detail page offers a one-step Move action, while the collection page supports selecting

--- a/frontend/src/features/household/SitterLinksCard.tsx
+++ b/frontend/src/features/household/SitterLinksCard.tsx
@@ -73,7 +73,7 @@ export function SitterLinksCard({ householdId }: { householdId: string }) {
     <Card>
       <CardHeader
         title="Plant-sitter links"
-        description="Going away? Share a temporary link so a neighbour or friend can see what needs care and check it off — no account needed. The link expires on its own, and you can revoke it any time."
+        description="Going away? Share a temporary link so a neighbour or friend can see due care, plant names, current spaces, and placement notes — never your saved city, private notes, or member details. The link expires on its own, and you can revoke it any time."
       />
 
       {created ? (

--- a/frontend/src/features/legal/PrivacyPage.tsx
+++ b/frontend/src/features/legal/PrivacyPage.tsx
@@ -128,8 +128,10 @@ export function PrivacyPage() {
       <h2>Sitter links</h2>
       <p>
         A household member can create a temporary sitter link without creating an account for the
-        sitter. Anyone who has that link can see the household&rsquo;s plants and due care tasks,
-        and can mark those tasks complete, during the coverage window you selected. The link is a
+        sitter. Anyone who has that link can see due care tasks, plant names, each plant&rsquo;s
+        current space, and its short placement note, and can mark those tasks complete during the
+        coverage window you selected. Sitter links do not expose your saved household location,
+        plant or task private notes, or household member identity and contact details. The link is a
         bearer credential, so only send it to someone you trust. It expires after at most 60 days
         and a household member can revoke it sooner. We do not ask for or store the sitter&rsquo;s
         identity.

--- a/frontend/src/features/plants/AddPlantPage.tsx
+++ b/frontend/src/features/plants/AddPlantPage.tsx
@@ -528,6 +528,7 @@ export function AddPlantPage() {
           <Input
             label={t('spaces.placementNoteLabel')}
             placeholder={t('spaces.placementNotePlaceholder')}
+            helperText={t('spaces.placementNoteSitterHint')}
             error={errors.placementNote?.message}
             {...register('placementNote')}
           />

--- a/frontend/src/features/plants/EditPlantModal.tsx
+++ b/frontend/src/features/plants/EditPlantModal.tsx
@@ -187,6 +187,7 @@ export function EditPlantModal({ plant, isOpen, onClose }: EditPlantModalProps) 
                   <Input
                     label={t('spaces.placementNoteLabel')}
                     placeholder={t('spaces.placementNotePlaceholder')}
+                    helperText={t('spaces.placementNoteSitterHint')}
                     error={errors.placementNote?.message}
                     {...register('placementNote')}
                   />

--- a/frontend/src/features/sitter/SitPage.tsx
+++ b/frontend/src/features/sitter/SitPage.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/Button';
 import { LoadingSpinner } from '@/components/LoadingSpinner';
 import { useMetaTags } from '@/hooks/useMetaTags';
 import { sitterService, SitterLinkInactiveError, type SitterTask } from '@/services/sitterService';
+import { MapPinIcon } from '@heroicons/react/24/outline';
 
 /**
  * Public, no-account plant-sitting page. A household member shares a
@@ -16,8 +17,9 @@ import { sitterService, SitterLinkInactiveError, type SitterTask } from '@/servi
  * Auth-free by design: it talks to the public GET /sitter/{token} +
  * POST /sitter/{token}/tasks/{taskId}/complete endpoints via the bare-fetch
  * sitterService (no axios interceptors), exactly like the pet-safe page. The
- * endpoints expose no PII — just the plant common name, task type, and due
- * date. An expired/revoked link shows a friendly message, not a raw error.
+ * endpoints expose no member identity, climate location, or private notes.
+ * The current space and short placement note are included as care directions.
+ * An expired/revoked link shows a friendly message, not a raw error.
  */
 
 /** Turn a task type + plant name into a warm, plain instruction. */
@@ -156,6 +158,7 @@ export function SitPage() {
               <ul className="space-y-3">
                 {remaining.map((task) => {
                   const isPending = pending.has(task.taskId);
+                  const location = [task.spaceName, task.placementNote].filter(Boolean).join(' · ');
                   return (
                     <li
                       key={task.taskId}
@@ -163,6 +166,12 @@ export function SitPage() {
                     >
                       <div className="min-w-0">
                         <p className="font-medium text-gray-900">{instructionFor(task)}</p>
+                        {location && (
+                          <p className="mt-1 flex items-start gap-1 text-sm text-primary-800">
+                            <MapPinIcon className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+                            <span>{location}</span>
+                          </p>
+                        )}
                         <p
                           className={
                             'mt-0.5 text-sm ' + (task.overdue ? 'text-amber-700' : 'text-gray-600')

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -42,6 +42,7 @@
     "fieldLabel": "Space (optional)",
     "placementNoteLabel": "Placement note",
     "placementNotePlaceholder": "e.g., east window, top shelf",
+    "placementNoteSitterHint": "Shared with anyone who has an active sitter link.",
     "createAction": "Create space",
     "nameLabel": "Space name",
     "namePlaceholder": "e.g., Living room or Back patio",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -43,6 +43,7 @@
     "fieldLabel": "Espacio (opcional)",
     "placementNoteLabel": "Nota de ubicación",
     "placementNotePlaceholder": "p. ej., ventana este, estante superior",
+    "placementNoteSitterHint": "Se comparte con quien tenga un enlace de cuidador activo.",
     "createAction": "Crear espacio",
     "nameLabel": "Nombre del espacio",
     "namePlaceholder": "p. ej., Sala o Patio trasero",

--- a/frontend/src/services/sitterService.ts
+++ b/frontend/src/services/sitterService.ts
@@ -9,7 +9,8 @@
  * otherwise try to refresh a (non-existent) session for an anonymous visitor.
  *
  * The 256-bit token in the path is the only credential. The endpoints expose
- * NO PII — just the plant common name, task type, due date, and id.
+ * NO member identity, private notes, or household climate location. They do
+ * include the current space and placement note as explicit care directions.
  */
 
 export interface SitterTask {
@@ -17,6 +18,8 @@ export interface SitterTask {
   plantName: string;
   taskType: string;
   dueDate: string;
+  spaceName: string | null;
+  placementNote: string | null;
   overdue: boolean;
 }
 

--- a/frontend/tests/e2e/a11y.spec.ts
+++ b/frontend/tests/e2e/a11y.spec.ts
@@ -132,6 +132,8 @@ test.describe('A11y — public routes (WCAG 2.0/2.1/2.2 AA)', () => {
               plantName: 'Monstera',
               taskType: 'water',
               dueDate: new Date(Date.now() - 1000).toISOString(),
+              spaceName: 'Living Room',
+              placementNote: 'east window, top shelf',
               overdue: true,
             },
           ],

--- a/frontend/tests/unit/features/SitPage.test.tsx
+++ b/frontend/tests/unit/features/SitPage.test.tsx
@@ -39,6 +39,8 @@ const waterTask: SitterTask = {
   plantName: 'Monstera',
   taskType: 'water',
   dueDate: new Date(Date.now() - 1000).toISOString(),
+  spaceName: 'Living Room',
+  placementNote: 'east window, top shelf',
   overdue: true,
 };
 
@@ -58,6 +60,7 @@ describe('SitPage', () => {
     renderPage();
 
     expect(await screen.findByText(/Water the Monstera/i)).toBeInTheDocument();
+    expect(screen.getByText(/Living Room · east window, top shelf/i)).toBeInTheDocument();
     expect(screen.getByText(/Overdue/i)).toBeInTheDocument();
     // Single h1 for accessibility.
     expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);


### PR DESCRIPTION
## Summary
- show each due plant's current space and placement note on the public sitter checklist
- resolve structured spaces at read time with a legacy location fallback
- disclose exactly what sitter links share while excluding climate location, private notes, and member data
- document and test the exact anonymous response projection

## Verification
- `npm run verify` (423 frontend tests, 1,223 backend tests)
- `npm run build`
- `npm run size --workspace frontend` (352.69 kB / 360 kB aggregate)

## Stack
- base: #237
- item 8 of 9

GitHub-hosted jobs may be prevented from starting by the repository Actions budget; all equivalent local gates are green.