### PR TITLE
chore(release): prepare v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,28 @@ reaches 1.0.0 (pre-1.0: minor bumps may include breaking changes — see
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-07-16
+
+### Added
+
+- Spaces can record whether outdoor plants are exposed to rain, so weather
+  guidance targets only plants whose current placement is actually affected.
+- Plants can remember preferred summer and winter spaces and receive an
+  explicit, latitude-aware move suggestion when the active season changes.
+- Placement-fit guidance can flag conservative light-level mismatches and
+  known pet-toxicity concerns using optional space conditions.
+- Active sitter links now show each due plant's current space and short
+  placement note without exposing household climate data, private notes, or
+  member identity details.
+- Spaces can name a usual caregiver. New tasks for plants in that space inherit
+  the caregiver while explicit assignments continue to win and existing tasks
+  remain unchanged.
+
+### Changed
+
+- Legacy spaces hydrate safe rain, light, pet-access, and caregiver defaults,
+  so the new placement features require no data migration or backfill.
+
 ## [0.17.0] - 2026-07-15
 
 ### Added

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Family Greenhouse API — AWS Lambda + DynamoDB single-table + Cognito, with a local Express mock that mirrors the handlers.",
   "license": "Elastic-2.0",
   "private": true,

--- a/frontend/android/app/build.gradle
+++ b/frontend/android/app/build.gradle
@@ -12,10 +12,10 @@ android {
         applicationId "net.familygreenhouse.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        // Deterministic SemVer mapping: 0.17.0 -> 1700. Increment this for
+        // Deterministic SemVer mapping: 0.18.0 -> 1800. Increment this for
         // every store upload; Play never accepts a reused versionCode.
-        versionCode 1700
-        versionName "0.17.0"
+        versionCode 1800
+        versionName "0.18.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/frontend/ios/App/App.xcodeproj/project.pbxproj
+++ b/frontend/ios/App/App.xcodeproj/project.pbxproj
@@ -300,14 +300,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1700;
+				CURRENT_PROJECT_VERSION = 1800;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.17.0;
+				MARKETING_VERSION = 0.18.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = net.familygreenhouse.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -322,14 +322,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1700;
+				CURRENT_PROJECT_VERSION = 1800;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.17.0;
+				MARKETING_VERSION = 0.18.0;
 				PRODUCT_BUNDLE_IDENTIFIER = net.familygreenhouse.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Family Greenhouse web app — React + TypeScript + Vite PWA for collaborative household plant care.",
   "license": "Elastic-2.0",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "family-greenhouse",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "family-greenhouse",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "license": "Elastic-2.0",
       "workspaces": [
         "frontend",
@@ -37,7 +37,7 @@
       }
     },
     "backend": {
-      "version": "0.17.0",
+      "version": "0.18.0",
       "license": "Elastic-2.0",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.1073.0",
@@ -85,7 +85,7 @@
       }
     },
     "frontend": {
-      "version": "0.17.0",
+      "version": "0.18.0",
       "license": "Elastic-2.0",
       "dependencies": {
         "@capacitor/android": "^8.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "family-greenhouse",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "license": "Elastic-2.0",
   "private": true,
   "description": "A shared plant-care journal for the whole household — per-plant schedules, reminders that find the right person across browser/email/SMS, and a care log everyone can see. React + TypeScript on AWS Lambda + DynamoDB + Cognito.",


### PR DESCRIPTION
## Summary

- bump root, frontend, backend, Android, and iOS release versions to 0.18.0
- add release notes for placement-aware weather guidance, seasonal homes, placement-fit checks, sitter location context, and space-default caregivers
- record that legacy spaces hydrate safe defaults and require no migration or backfill

## Validation

- make verify
- npm run mobile:validate
- git diff --check

## Deployment

After this PR is green and merged, tag the merge commit as v0.18.0. The tag-driven production workflow revalidates version and changelog consistency, rebuilds and retests the release, applies Terraform behind the production environment, deploys frontend and backend, runs production smoke tests, and automatically rolls Lambda code back if smoke tests fail.