### PR TITLE
chore(release): v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,26 @@ reaches 1.0.0 (pre-1.0: minor bumps may include breaking changes — see
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-07-16
+
+### Added
+
+- The active Spaces view is now an operational care route, ordered inside to
+  outside to unplaced, with each stop showing plant count, overdue or due-today
+  work, next care, recorded conditions, usual caregiver, and current seasonal
+  move suggestions.
+- Every space card links to a URL-addressable scoped care round that preserves
+  the existing task filters, claiming, vacation coverage, climate advice, and
+  completion controls.
+- Focused browser coverage now verifies the complete space-to-task flow across
+  the CI browser matrix and includes a WCAG 2.2 AA scan of the populated view.
+
+### Changed
+
+- Operational space summaries are composed from existing household-scoped
+  projections only when the active Spaces view is open, adding no migration,
+  summary row, background job, or backend authorization surface.
+
 ## [0.18.0] - 2026-07-16
 
 ### Added

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Family Greenhouse API — AWS Lambda + DynamoDB single-table + Cognito, with a local Express mock that mirrors the handlers.",
   "license": "Elastic-2.0",
   "private": true,

--- a/frontend/android/app/build.gradle
+++ b/frontend/android/app/build.gradle
@@ -14,8 +14,8 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         // Deterministic SemVer mapping: 0.18.0 -> 1800. Increment this for
         // every store upload; Play never accepts a reused versionCode.
-        versionCode 1800
-        versionName "0.18.0"
+        versionCode 1900
+        versionName "0.19.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/frontend/ios/App/App.xcodeproj/project.pbxproj
+++ b/frontend/ios/App/App.xcodeproj/project.pbxproj
@@ -300,14 +300,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1800;
+				CURRENT_PROJECT_VERSION = 1900;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.18.0;
+				MARKETING_VERSION = 0.19.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = net.familygreenhouse.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -322,14 +322,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1800;
+				CURRENT_PROJECT_VERSION = 1900;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.18.0;
+				MARKETING_VERSION = 0.19.0;
 				PRODUCT_BUNDLE_IDENTIFIER = net.familygreenhouse.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Family Greenhouse web app — React + TypeScript + Vite PWA for collaborative household plant care.",
   "license": "Elastic-2.0",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "family-greenhouse",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "family-greenhouse",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "license": "Elastic-2.0",
       "workspaces": [
         "frontend",
@@ -37,7 +37,7 @@
       }
     },
     "backend": {
-      "version": "0.18.0",
+      "version": "0.19.0",
       "license": "Elastic-2.0",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.1073.0",
@@ -85,7 +85,7 @@
       }
     },
     "frontend": {
-      "version": "0.18.0",
+      "version": "0.19.0",
       "license": "Elastic-2.0",
       "dependencies": {
         "@capacitor/android": "^8.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "family-greenhouse",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "license": "Elastic-2.0",
   "private": true,
   "description": "A shared plant-care journal for the whole household — per-plant schedules, reminders that find the right person across browser/email/SMS, and a care log everyone can see. React + TypeScript on AWS Lambda + DynamoDB + Cognito.",


### PR DESCRIPTION
## Summary

- ship the operational inside/outside/unplaced care route for Spaces
- add URL-addressable, space-scoped care rounds in Tasks
- include bilingual copy, documentation, unit coverage, browser coverage, and WCAG 2.2 AA scanning
- carry the restored public-repository security posture into the release: CodeQL and zizmor code-scanning uploads, Scorecard publishing, secret scanning, push protection, and private vulnerability reporting

## Release checks

- `npm run verify`
- `npm run build`
- `npm run size --workspace frontend`
- `npm run mobile:validate`
- `actionlint .github/workflows/codeql.yml .github/workflows/zizmor.yml`
- `zizmor --persona=regular .github/workflows/codeql.yml .github/workflows/zizmor.yml`

## Deployment

The `v0.19.0` tag will trigger the production CD workflow after merge.

## Rollback

Redeploy the prior `v0.18.0` release tag if production verification fails.
