### PR TITLE
ci: restore public repository security posture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,10 +196,9 @@ jobs:
         run: npm audit --omit=dev --audit-level=high
 
       - name: Run Gitleaks (license-free CLI, blocking)
-        # The gitleaks-action@v2 wrapper needs a paid GITLEAKS_LICENSE for
-        # private repos. The gitleaks BINARY is MIT-licensed and free, so we
-        # run it directly and let a non-zero exit (leaks found) gate the
-        # build. `--redact` keeps any match out of the public log.
+        # Run the MIT-licensed binary directly so the gate stays independent
+        # of repository visibility and action-wrapper licensing. A non-zero
+        # exit blocks the build; `--redact` keeps any match out of the log.
         env:
           GITLEAKS_VERSION: 8.30.1
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,9 +1,7 @@
 name: CodeQL
 
-# This repository is private and does not have GitHub Advanced Security.
-# CodeQL still runs and preserves its SARIF as a workflow artifact; uploading
-# to the code-scanning API is intentionally disabled because GitHub rejects it
-# without GHAS. Re-enable `upload: always` if GHAS is enabled later.
+# Family Greenhouse is a public repository, so CodeQL uploads findings to the
+# repository's code-scanning view without requiring GitHub Advanced Security.
 on:
   push:
     branches: [main]
@@ -26,8 +24,11 @@ jobs:
     name: CodeQL analysis (javascript-typescript, actions)
     runs-on: ubuntu-latest
     permissions:
+      # Analyze Actions workflows alongside JavaScript/TypeScript sources.
       actions: read
       contents: read
+      # Publish SARIF findings to the public repository's code-scanning view.
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -43,14 +44,4 @@ jobs:
           build-mode: none
 
       - name: Perform CodeQL analysis
-        id: analyze
         uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
-        with:
-          upload: never
-
-      - name: Preserve CodeQL results
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        with:
-          name: codeql-sarif
-          path: ${{ steps.analyze.outputs.sarif-output }}
-          retention-days: 14

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -3,8 +3,8 @@ name: zizmor
 # Closes the "zizmor (workflow SAST)" gap declared in docs/roadmap.md's
 # metrics ledger (CICD-29): static analysis of our own GitHub Actions
 # workflows for injection risks, unpinned actions, overbroad permissions,
-# etc. The repository is private without GHAS, so findings are retained as a
-# SARIF artifact rather than uploaded to the unavailable code-scanning API.
+# etc. Results upload to the repository's code-scanning view, which is
+# available without GitHub Advanced Security because the repository is public.
 on:
   push:
     branches: [main]
@@ -26,8 +26,11 @@ jobs:
     name: zizmor workflow audit
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      # Inspect workflow metadata and checked-in workflow definitions.
       actions: read
+      contents: read
+      # Publish workflow-audit SARIF to the public code-scanning view.
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -35,22 +38,4 @@ jobs:
           persist-credentials: false
 
       - name: Run zizmor
-        env:
-          GH_TOKEN: ${{ github.token }}
-          ZIZMOR_IMAGE: ghcr.io/zizmorcore/zizmor:latest@sha256:d1117e5dbd9ee4970644067b534ab6ab50371f3c6f7f4d05446eb603a6e78f48
-        run: |
-          docker run --rm \
-            --volume "$GITHUB_WORKSPACE:/workspace:ro" \
-            --workdir /workspace \
-            --env GH_TOKEN \
-            "$ZIZMOR_IMAGE" \
-            --persona=regular \
-            --format=sarif \
-            -- . > zizmor.sarif
-
-      - name: Preserve zizmor results
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        with:
-          name: zizmor-sarif
-          path: zizmor.sarif
-          retention-days: 14
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ reaches 1.0.0 (pre-1.0: minor bumps may include breaking changes — see
 
 ## [Unreleased]
 
+### Security
+
+- Public repository visibility is restored after a clean full-history Gitleaks
+  scan and separate inspection of archived Lambda bundles. GitHub secret
+  scanning, push protection, and private vulnerability reporting are active
+  with no open secret alerts.
+- CodeQL and zizmor again publish findings to the public repository's code
+  scanning view, and OpenSSF Scorecard public publishing resumes. The
+  commercial hold and every runtime signup/payment control remain unchanged.
+
 ## [0.18.0] - 2026-07-16
 
 ### Added

--- a/docs/COMMERCIAL-STATUS.md
+++ b/docs/COMMERCIAL-STATUS.md
@@ -8,6 +8,22 @@ software-development artifact. Nothing in this repository or its demo is a
 current paid offer, launch campaign, customer solicitation, statement of paid
 adoption, or representation that revenue is being earned.
 
+## Repository visibility
+
+The source repository and its Git history are public portfolio artifacts.
+Historical commits and retained design documents may contain superseded
+pricing, launch, or customer-acquisition hypotheses; they are not current
+offers and must be read with this dated status record. Repository visibility
+does not change production authorization, expose household data, or relax any
+commercial-hold control.
+
+Before restoring public visibility on July 16, 2026, the complete Git history
+was scanned for secrets, archived Lambda bundles were inspected separately,
+and GitHub secret scanning plus push protection were verified active. Public
+browser configuration such as the API endpoint and Cognito client identifiers
+remains intentionally reproducible; credentials and customer data do not
+belong in this repository.
+
 ## Controls currently in place
 
 - [`commercial-status.json`](../commercial-status.json) is the single shared

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -187,9 +187,9 @@ Per `STANDARDS/CI-CD-STANDARD.md` CICD-29, this ledger declares the optional CI 
 | 6: build                                         | Applies (core) | Green, required                                                                                                                                   |
 | 7: Lighthouse (perf + a11y)                      | Applies        | Green, required — now runs automatically whenever `frontend/**` changes (the `skip-lighthouse` label bypass was closed 2026-07-05; see CHANGELOG) |
 | 8: bundle-size, e2e+a11y (Playwright)            | Applies        | Green, required                                                                                                                                   |
-| zizmor (workflow SAST)                           | Applies        | Shipped — `.github/workflows/zizmor.yml`, results upload to code scanning                                                                         |
-| CodeQL                                           | Applies        | Shipped (2026-07-05, PR #177) — `.github/workflows/codeql.yml`; repo is public so this is free                                                    |
-| OpenSSF Scorecard                                | Applies        | Shipped — `.github/workflows/scorecard.yml`, publishes to the public Scorecard API + code scanning                                                |
+| zizmor (workflow SAST)                           | Applies        | Shipped — `.github/workflows/zizmor.yml`, public-repository results upload to code scanning                                                       |
+| CodeQL                                           | Applies        | Shipped (2026-07-05, PR #177) — public-repository uploads restored 2026-07-16 after the temporary private hold                                    |
+| OpenSSF Scorecard                                | Applies        | Shipped — `.github/workflows/scorecard.yml`, public Scorecard publishing resumed with public visibility                                           |
 
 ```
 AI-Evaluation-Standard: APPLIES (tiers: tool-use + RAG, citation/grounding guard, model-card)


### PR DESCRIPTION
## Summary
- restore public-repository CodeQL and zizmor uploads to GitHub code scanning
- keep the license-independent full-history Gitleaks gate
- document public Git history as a portfolio artifact while preserving the commercial hold
- record the public-readiness audit and resumed OpenSSF Scorecard publishing

## Repository settings verified
- visibility: public and anonymously reachable
- secret scanning: enabled, zero open alerts
- push protection: enabled
- Dependabot security updates: enabled
- private vulnerability reporting: enabled

## Verification
- full-history Gitleaks: 309 commits / 10.44 MB, no leaks
- archived Lambda ZIP inspection: no credential signatures
- npm run verify: 430 frontend + 1,231 backend tests, all gates passed
- actionlint on changed workflows
- zizmor regular persona on changed workflows: no findings
- git diff --check

## Runtime impact
None. Authentication, household data, registration, billing, and the commercial hold are unchanged.