### PR TITLE
feat: add shared-care activation pulse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ reaches 1.0.0 (pre-1.0: minor bumps may include breaking changes — see
 
 ## [Unreleased]
 
+### Added
+
+- The dashboard now shows a bilingual Shared-care pulse until the household
+  has a plant, an active care task, a second member, and a recent task
+  completion by someone else. The ordered care-vine links directly to the
+  next missing step and can be hidden on the current device for 30 days.
+- Shared-care pulse actions emit a privacy-preserving, household-grouped
+  analytics event so the collaboration activation hypothesis can be measured
+  without sending plant, household, or member names.
+
 ## [0.19.0] - 2026-07-16
 
 ### Added

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -148,6 +148,11 @@ honest record:
   fallback without Bedrock access), surfaced as a dialog on the plant page.
   Cosmetic-grade only, never diagnostic — exactly the line the Y3 theme
   drew.
+- ✅ **Shared-care pulse** — the dashboard now derives four real collaboration
+  milestones (plant, scheduled care, teammate joined, recent care by someone
+  else), points to the next missing action, and gives solo caregivers a gentle
+  30-day device-local dismissal. This is deliberately an activation test for
+  the active-members north-star metric, not another permanent dashboard.
 
 > **Deliberately still OFF:** the beta/monetization flip. Identification
 > metering enforcement, billing enforcement beyond the existing plan caps,

--- a/frontend/src/features/dashboard/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/DashboardPage.tsx
@@ -25,6 +25,7 @@ import { useOverdueAlerts } from '@/hooks/useOverdueAlerts';
 import { useActiveHousehold } from '@/hooks/useActiveHousehold';
 import { YearInReviewCard } from './YearInReviewCard';
 import { ClimateCard } from './ClimateCard';
+import { SharedCarePulse } from './SharedCarePulse';
 import { Card, CardHeader } from '@/components/Card';
 import { Button } from '@/components/Button';
 import { PageHeader } from '@/components/PageHeader';
@@ -185,6 +186,8 @@ export function DashboardPage() {
           emphasis={overdueCount && overdueCount > 0 ? 'alert' : undefined}
         />
       </dl>
+
+      <SharedCarePulse />
 
       {/* Upcoming Tasks */}
       <Card variant="paper" padding="none">

--- a/frontend/src/features/dashboard/SharedCarePulse.tsx
+++ b/frontend/src/features/dashboard/SharedCarePulse.tsx
@@ -1,0 +1,214 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { CheckIcon, XMarkIcon } from '@heroicons/react/24/outline';
+import clsx from 'clsx';
+import { Card } from '@/components/Card';
+import { SprigDivider } from '@/components/brand/SprigDivider';
+import { useActiveHousehold } from '@/hooks/useActiveHousehold';
+import { useAuthStore } from '@/store/authStore';
+import { usePrefsStore } from '@/store/prefsStore';
+import { householdService } from '@/services/householdService';
+import { plantService } from '@/services/plantService';
+import { taskService } from '@/services/taskService';
+import { track } from '@/services/analytics';
+import { deriveSharedCareMilestones, type SharedCareMilestoneKey } from './sharedCarePulseModel';
+
+const DISMISSAL_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+
+const milestoneRoutes: Record<SharedCareMilestoneKey, string> = {
+  plant: '/plants/new',
+  task: '/plants',
+  teammate: '/household',
+  sharedCare: '/tasks',
+};
+
+/**
+ * A quiet dashboard setup prompt that proves the collaboration loop with real
+ * data. React Query reuses the dashboard's plant/activity cache entries, so
+ * the only additional reads are the household roster and all active tasks.
+ */
+export function SharedCarePulse() {
+  const { t } = useTranslation();
+  const { householdId, householdQuery } = useActiveHousehold();
+  const currentUserId = useAuthStore((state) => state.user?.id ?? null);
+  const dismissedUntil = usePrefsStore((state) =>
+    householdId ? state.sharedCarePulseDismissedUntil[householdId] : undefined
+  );
+  const dismiss = usePrefsStore((state) => state.dismissSharedCarePulse);
+
+  const plantsQuery = useQuery(
+    householdQuery(
+      (hh) => ['plants', hh],
+      () => plantService.getPlants()
+    )
+  );
+  const tasksQuery = useQuery(
+    householdQuery(
+      (hh) => ['tasks', hh],
+      () => taskService.getTasks()
+    )
+  );
+  const householdQueryResult = useQuery(
+    householdQuery(
+      (hh) => ['household', hh],
+      (hh) => householdService.getHousehold(hh)
+    )
+  );
+  const activityQuery = useQuery(
+    householdQuery(
+      (hh) => ['household', hh, 'activity'],
+      (hh) => householdService.getActivity(hh, 50)
+    )
+  );
+
+  const milestones = useMemo(
+    () =>
+      deriveSharedCareMilestones({
+        plantCount: plantsQuery.data?.length ?? 0,
+        taskCount: tasksQuery.data?.length ?? 0,
+        memberUserIds: householdQueryResult.data?.members.map((member) => member.userId) ?? [],
+        activity: activityQuery.data ?? [],
+        currentUserId,
+      }),
+    [
+      activityQuery.data,
+      currentUserId,
+      householdQueryResult.data?.members,
+      plantsQuery.data?.length,
+      tasksQuery.data?.length,
+    ]
+  );
+
+  const isLoading =
+    plantsQuery.isLoading ||
+    tasksQuery.isLoading ||
+    householdQueryResult.isLoading ||
+    activityQuery.isLoading;
+  const hasError =
+    plantsQuery.isError ||
+    tasksQuery.isError ||
+    householdQueryResult.isError ||
+    activityQuery.isError;
+  const completedCount = milestones.filter((milestone) => milestone.completed).length;
+  const nextMilestone = milestones.find((milestone) => !milestone.completed);
+  const isDismissed = dismissedUntil ? Date.parse(dismissedUntil) > Date.now() : false;
+
+  // Never flash an incomplete checklist while its source queries are loading,
+  // and never turn a partial network failure into misleading product advice.
+  if (!householdId || isLoading || hasError || !nextMilestone || isDismissed) return null;
+
+  const dismissForThirtyDays = () => {
+    dismiss(householdId, new Date(Date.now() + DISMISSAL_WINDOW_MS).toISOString());
+    track('shared_care_pulse_action', { context: 'dismiss' });
+  };
+
+  const nextKey = nextMilestone.key;
+
+  return (
+    <Card
+      variant="paper"
+      className="relative overflow-hidden border-primary-200/70 bg-primary-50/70"
+    >
+      <SprigDivider className="pointer-events-none absolute -right-10 -top-3 h-28 w-72 text-primary-800/10" />
+
+      <section aria-labelledby="shared-care-pulse-title" className="relative">
+        <div className="flex items-start justify-between gap-4">
+          <div className="max-w-2xl">
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-primary-700">
+              {t('sharedCarePulse.eyebrow')}
+            </p>
+            <h2 id="shared-care-pulse-title" className="mt-1 font-serif text-xl text-ink">
+              {t('sharedCarePulse.title')}
+            </h2>
+            <p className="mt-1 text-sm text-gray-700">{t('sharedCarePulse.description')}</p>
+          </div>
+          <button
+            type="button"
+            onClick={dismissForThirtyDays}
+            className="inline-flex min-h-touch shrink-0 items-center gap-1 rounded-lg px-2 text-xs font-medium text-gray-600 transition-colors hover:bg-paper/80 hover:text-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
+            aria-label={t('sharedCarePulse.dismissAria')}
+          >
+            <XMarkIcon className="h-4 w-4" aria-hidden="true" />
+            <span className="hidden sm:inline">{t('sharedCarePulse.notNow')}</span>
+          </button>
+        </div>
+
+        <p className="mt-5 text-xs font-medium text-primary-800" aria-live="polite">
+          {t('sharedCarePulse.progress', { completed: completedCount, total: milestones.length })}
+        </p>
+
+        <div className="relative mt-3">
+          <div
+            className="absolute bottom-5 left-5 top-5 w-px bg-primary-200 sm:bottom-auto sm:left-[12.5%] sm:right-[12.5%] sm:top-5 sm:h-px sm:w-auto"
+            aria-hidden="true"
+          />
+          <ol className="relative grid gap-3 sm:grid-cols-4 sm:gap-2">
+            {milestones.map((milestone, index) => {
+              const isCurrent = milestone.key === nextKey;
+              return (
+                <li
+                  key={milestone.key}
+                  className="relative z-10 flex items-center gap-3 sm:flex-col sm:text-center"
+                  aria-current={isCurrent ? 'step' : undefined}
+                >
+                  <span
+                    className={clsx(
+                      'relative inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full border-2 text-sm font-semibold shadow-sm transition-colors',
+                      milestone.completed
+                        ? 'border-primary-700 bg-primary-700 text-white'
+                        : isCurrent
+                          ? 'border-primary-600 bg-paper text-primary-800'
+                          : 'border-primary-200 bg-paper text-gray-500'
+                    )}
+                    aria-hidden="true"
+                  >
+                    {milestone.completed ? <CheckIcon className="h-5 w-5" /> : index + 1}
+                    {milestone.completed && (
+                      <span className="absolute -right-1 -top-1 h-3 w-2 rotate-45 rounded-br-full rounded-tl-full bg-primary-400" />
+                    )}
+                  </span>
+                  <span
+                    className={clsx(
+                      'text-sm font-medium',
+                      milestone.completed || isCurrent ? 'text-ink' : 'text-gray-500'
+                    )}
+                  >
+                    {t(`sharedCarePulse.milestones.${milestone.key}.title`)}
+                    <span className="sr-only">
+                      {' — '}
+                      {milestone.completed
+                        ? t('sharedCarePulse.completeStatus')
+                        : isCurrent
+                          ? t('sharedCarePulse.currentStatus')
+                          : t('sharedCarePulse.upcomingStatus')}
+                    </span>
+                  </span>
+                </li>
+              );
+            })}
+          </ol>
+        </div>
+
+        <div className="mt-6 flex flex-col gap-3 border-l-2 border-primary-500 pl-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="text-sm font-semibold text-ink">
+              {t(`sharedCarePulse.milestones.${nextKey}.nextTitle`)}
+            </p>
+            <p className="mt-0.5 text-sm text-gray-700">
+              {t(`sharedCarePulse.milestones.${nextKey}.description`)}
+            </p>
+          </div>
+          <Link
+            to={milestoneRoutes[nextKey]}
+            onClick={() => track('shared_care_pulse_action', { context: nextKey })}
+            className="inline-flex min-h-touch shrink-0 items-center justify-center rounded-lg bg-primary-700 px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-primary-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
+          >
+            {t(`sharedCarePulse.milestones.${nextKey}.action`)}
+          </Link>
+        </div>
+      </section>
+    </Card>
+  );
+}

--- a/frontend/src/features/dashboard/sharedCarePulseModel.ts
+++ b/frontend/src/features/dashboard/sharedCarePulseModel.ts
@@ -1,0 +1,51 @@
+import type { ActivityEvent } from '@/services/householdService';
+
+const SHARED_CARE_WINDOW_MS = 14 * 24 * 60 * 60 * 1000;
+
+export type SharedCareMilestoneKey = 'plant' | 'task' | 'teammate' | 'sharedCare';
+
+export interface SharedCareMilestone {
+  key: SharedCareMilestoneKey;
+  completed: boolean;
+}
+
+interface SharedCareInputs {
+  plantCount: number;
+  taskCount: number;
+  memberUserIds: string[];
+  activity: ActivityEvent[];
+  currentUserId: string | null;
+  now?: number;
+}
+
+/**
+ * Derive the four collaboration milestones from household facts rather than
+ * storing a second, drift-prone checklist. The final milestone is deliberately
+ * time-bound: a teammate joining proves access, while a teammate completing a
+ * task recently proves that the shared-care handoff is still working.
+ */
+export function deriveSharedCareMilestones({
+  plantCount,
+  taskCount,
+  memberUserIds,
+  activity,
+  currentUserId,
+  now = Date.now(),
+}: SharedCareInputs): SharedCareMilestone[] {
+  const recentCutoff = now - SHARED_CARE_WINDOW_MS;
+  const teammateIds = new Set(memberUserIds.filter((userId) => userId !== currentUserId));
+  const teammateCompletedCare =
+    currentUserId != null &&
+    activity.some((event) => {
+      if (event.type !== 'task.completed' || !teammateIds.has(event.actorId)) return false;
+      const occurredAt = Date.parse(event.occurredAt);
+      return Number.isFinite(occurredAt) && occurredAt >= recentCutoff;
+    });
+
+  return [
+    { key: 'plant', completed: plantCount > 0 },
+    { key: 'task', completed: taskCount > 0 },
+    { key: 'teammate', completed: teammateIds.size > 0 },
+    { key: 'sharedCare', completed: teammateIds.size > 0 && teammateCompletedCare },
+  ];
+}

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -128,6 +128,43 @@
     "title": "Your care route",
     "summary": "Tasks remaining: {{tasks}} · Spaces to visit: {{spaces}}"
   },
+  "sharedCarePulse": {
+    "eyebrow": "Shared-care setup",
+    "title": "Make care something the household shares",
+    "description": "A quick check that reminders have become a routine another person can actually pick up.",
+    "progress": "{{completed}} of {{total}} steps ready",
+    "notNow": "Not now",
+    "dismissAria": "Hide shared-care setup for 30 days",
+    "completeStatus": "Complete",
+    "currentStatus": "Next step",
+    "upcomingStatus": "Upcoming",
+    "milestones": {
+      "plant": {
+        "title": "Add a plant",
+        "nextTitle": "Start with one plant",
+        "description": "Give the household something real to care for. You can add its schedule next.",
+        "action": "Add a plant"
+      },
+      "task": {
+        "title": "Plan the care",
+        "nextTitle": "Add a care schedule",
+        "description": "Open a plant and add a recurring task so the right work appears at the right time.",
+        "action": "Choose a plant"
+      },
+      "teammate": {
+        "title": "Invite someone",
+        "nextTitle": "Bring in another caregiver",
+        "description": "Share an invite with someone you trust. Plant care still works perfectly well solo, too.",
+        "action": "Invite someone"
+      },
+      "sharedCare": {
+        "title": "Share the handoff",
+        "nextTitle": "Let your teammate take one",
+        "description": "When another member completes a task, everyone can see that the care handoff works.",
+        "action": "Open care tasks"
+      }
+    }
+  },
   "nav": {
     "dashboard": "Dashboard",
     "plants": "Plants",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -137,6 +137,43 @@
     "title": "Tu ruta de cuidado",
     "summary": "Tareas pendientes: {{tasks}} · Espacios por visitar: {{spaces}}"
   },
+  "sharedCarePulse": {
+    "eyebrow": "Configuración del cuidado compartido",
+    "title": "Haz que el cuidado sea cosa de todo el hogar",
+    "description": "Una comprobación rápida de que los recordatorios ya forman una rutina que otra persona puede asumir.",
+    "progress": "{{completed}} de {{total}} pasos listos",
+    "notNow": "Ahora no",
+    "dismissAria": "Ocultar la configuración del cuidado compartido durante 30 días",
+    "completeStatus": "Completado",
+    "currentStatus": "Siguiente paso",
+    "upcomingStatus": "Próximamente",
+    "milestones": {
+      "plant": {
+        "title": "Añade una planta",
+        "nextTitle": "Empieza con una planta",
+        "description": "Dale al hogar algo real que cuidar. Después podrás añadir su calendario.",
+        "action": "Añadir una planta"
+      },
+      "task": {
+        "title": "Planifica el cuidado",
+        "nextTitle": "Añade un calendario de cuidado",
+        "description": "Abre una planta y añade una tarea periódica para que el trabajo adecuado aparezca en el momento adecuado.",
+        "action": "Elegir una planta"
+      },
+      "teammate": {
+        "title": "Invita a alguien",
+        "nextTitle": "Suma a otra persona cuidadora",
+        "description": "Comparte una invitación con alguien de confianza. El cuidado también funciona perfectamente en solitario.",
+        "action": "Invitar a alguien"
+      },
+      "sharedCare": {
+        "title": "Comparte el relevo",
+        "nextTitle": "Deja una tarea a tu compañero o compañera",
+        "description": "Cuando otra persona completa una tarea, todo el hogar puede ver que el relevo funciona.",
+        "action": "Abrir tareas de cuidado"
+      }
+    }
+  },
   "nav": {
     "dashboard": "Panel",
     "plants": "Plantas",

--- a/frontend/src/services/analytics.ts
+++ b/frontend/src/services/analytics.ts
@@ -110,6 +110,7 @@ export type EventName =
   | 'plant_share_accepted' // A shared cutting card was copied into a household.
   | 'cutting_graft_started' // Visitor tapped the graft CTA on a public cutting card.
   | 'household_switched' // User changed active household via the switcher.
+  | 'shared_care_pulse_action' // Dashboard setup action or 30-day dismissal; `context` names the step.
   | 'climate_location_set'
   | 'experiment_viewed'; // A bucketed A/B variant was rendered to the visitor.
 

--- a/frontend/src/store/prefsStore.ts
+++ b/frontend/src/store/prefsStore.ts
@@ -30,10 +30,16 @@ interface PrefsState {
    *  timezone. Empty strings mean "no quiet hours." */
   dndStart: string;
   dndEnd: string;
+  /** Per-household snooze for the dashboard shared-care setup prompt. The
+   *  prompt is intentionally gentle for people who care for plants solo; a
+   *  dismissal hides it on this device for 30 days without changing any
+   *  household data or another member's experience. */
+  sharedCarePulseDismissedUntil: Record<string, string>;
   setDensity: (d: Density) => void;
   setLanguage: (l: LangCode) => void;
   setWelcomeSeen: (v: boolean) => void;
   setDnd: (start: string, end: string) => void;
+  dismissSharedCarePulse: (householdId: string, until: string) => void;
 }
 
 export const usePrefsStore = create<PrefsState>()(
@@ -46,6 +52,7 @@ export const usePrefsStore = create<PrefsState>()(
       welcomeSeen: false,
       dndStart: '',
       dndEnd: '',
+      sharedCarePulseDismissedUntil: {},
       setDensity: (density) => set({ density }),
       setLanguage: (language) => {
         i18n.changeLanguage(language);
@@ -53,6 +60,13 @@ export const usePrefsStore = create<PrefsState>()(
       },
       setWelcomeSeen: (welcomeSeen) => set({ welcomeSeen }),
       setDnd: (dndStart, dndEnd) => set({ dndStart, dndEnd }),
+      dismissSharedCarePulse: (householdId, until) =>
+        set((state) => ({
+          sharedCarePulseDismissedUntil: {
+            ...state.sharedCarePulseDismissedUntil,
+            [householdId]: until,
+          },
+        })),
     }),
     {
       name: 'fg.prefs',

--- a/frontend/tests/e2e/shared-care-pulse.spec.ts
+++ b/frontend/tests/e2e/shared-care-pulse.spec.ts
@@ -1,0 +1,44 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+import { provisionAccount, uiLogin, type ProvisionedAccount } from './helpers';
+
+let account: ProvisionedAccount;
+
+test.beforeAll(async () => {
+  account = await provisionAccount({
+    emailPrefix: 'shared-care-pulse',
+    householdName: 'Shared Care Household',
+    plant: { name: 'Kitchen Pothos', species: 'Epipremnum aureum' },
+    waterTask: { frequency: 7 },
+  });
+});
+
+test('guides a solo caregiver toward a shared routine and remembers dismissal', async ({
+  page,
+}) => {
+  await uiLogin(page, account.email, account.password);
+
+  const pulse = page.getByRole('region', {
+    name: /make care something the household shares/i,
+  });
+  await expect(pulse).toBeVisible();
+  await expect(pulse.getByText('2 of 4 steps ready')).toBeVisible();
+  await expect(pulse.getByRole('listitem')).toHaveCount(4);
+  await expect(pulse.getByRole('link', { name: 'Invite someone' })).toHaveAttribute(
+    'href',
+    '/household'
+  );
+
+  const accessibility = await new AxeBuilder({ page })
+    .include('section[aria-labelledby="shared-care-pulse-title"]')
+    .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22aa'])
+    .analyze();
+  expect(accessibility.violations).toEqual([]);
+
+  await pulse.getByRole('button', { name: /hide shared-care setup for 30 days/i }).click();
+  await expect(pulse).toHaveCount(0);
+
+  await page.reload();
+  await expect(page).toHaveURL(/\/dashboard/);
+  await expect(pulse).toHaveCount(0);
+});

--- a/frontend/tests/integration/dashboard.flow.test.tsx
+++ b/frontend/tests/integration/dashboard.flow.test.tsx
@@ -90,7 +90,28 @@ describe('Dashboard integration', () => {
           frequency: 7,
         });
       }),
+      http.get(`${API}/tasks`, () =>
+        HttpResponse.json([
+          {
+            id: 't1',
+            plantId: 'p1',
+            plantName: 'Monstera',
+            type: 'water',
+            nextDue: new Date().toISOString(),
+            frequency: 7,
+          },
+        ])
+      ),
       http.get(`${API}/plants`, () => HttpResponse.json([])),
+      http.get(`${API}/households/hh-1`, () =>
+        HttpResponse.json({
+          id: 'hh-1',
+          name: 'Home',
+          createdAt: '',
+          createdBy: 'u1',
+          members: [{ userId: 'u1', name: 'Chelsea', role: 'admin', joinedAt: '' }],
+        })
+      ),
       http.get(`${API}/households/hh-1/activity`, () => HttpResponse.json([])),
       http.get(`${API}/households/hh-1/climate`, () =>
         HttpResponse.json({ status: 'no_location' })

--- a/frontend/tests/unit/features/SharedCarePulse.test.tsx
+++ b/frontend/tests/unit/features/SharedCarePulse.test.tsx
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse } from 'msw';
+import { SharedCarePulse } from '@/features/dashboard/SharedCarePulse';
+import { deriveSharedCareMilestones } from '@/features/dashboard/sharedCarePulseModel';
+import type { ActivityEvent } from '@/services/householdService';
+import { useAuthStore } from '@/store/authStore';
+import { usePrefsStore } from '@/store/prefsStore';
+import { server } from '../../msw/server';
+
+const API = 'http://localhost:4000';
+const NOW = Date.parse('2026-07-16T12:00:00.000Z');
+
+function completion(actorId: string, occurredAt: string): ActivityEvent {
+  return {
+    id: `event-${actorId}`,
+    type: 'task.completed',
+    householdId: 'hh-1',
+    actorId,
+    actorName: actorId,
+    occurredAt,
+    payload: {},
+  };
+}
+
+function renderPulse() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <SharedCarePulse />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+function usePulseHandlers({
+  members = [{ userId: 'u1', name: 'Chelsea', role: 'admin', joinedAt: '' }],
+  activity = [],
+}: {
+  members?: Array<{ userId: string; name: string; role: 'admin' | 'member'; joinedAt: string }>;
+  activity?: ActivityEvent[];
+} = {}) {
+  server.use(
+    http.get(`${API}/plants`, () =>
+      HttpResponse.json([
+        {
+          id: 'p1',
+          householdId: 'hh-1',
+          name: 'Monstera',
+          species: null,
+          location: null,
+          imageUrl: null,
+          notes: null,
+          createdAt: '',
+          createdBy: 'u1',
+          updatedAt: '',
+        },
+      ])
+    ),
+    http.get(`${API}/tasks`, () =>
+      HttpResponse.json([
+        {
+          id: 't1',
+          plantId: 'p1',
+          plantName: 'Monstera',
+          type: 'water',
+          frequency: 7,
+          nextDue: '2026-07-17T12:00:00.000Z',
+        },
+      ])
+    ),
+    http.get(`${API}/households/hh-1`, () =>
+      HttpResponse.json({
+        id: 'hh-1',
+        name: 'Home',
+        createdAt: '',
+        createdBy: 'u1',
+        members,
+      })
+    ),
+    http.get(`${API}/households/hh-1/activity`, () => HttpResponse.json(activity))
+  );
+}
+
+beforeEach(() => {
+  useAuthStore.setState({
+    user: {
+      id: 'u1',
+      email: 'chelsea@example.com',
+      name: 'Chelsea',
+      householdId: 'hh-1',
+      householdRole: 'admin',
+    },
+    isAuthenticated: true,
+    isLoading: false,
+  } as never);
+  usePrefsStore.setState({ sharedCarePulseDismissedUntil: {} });
+});
+
+describe('deriveSharedCareMilestones', () => {
+  it('requires recent care from a different household member for the handoff milestone', () => {
+    const milestones = deriveSharedCareMilestones({
+      plantCount: 1,
+      taskCount: 1,
+      memberUserIds: ['u1', 'u2'],
+      currentUserId: 'u1',
+      now: NOW,
+      activity: [
+        completion('u1', '2026-07-16T10:00:00.000Z'),
+        completion('u2', '2026-07-01T10:00:00.000Z'),
+      ],
+    });
+
+    expect(milestones.map(({ key, completed }) => [key, completed])).toEqual([
+      ['plant', true],
+      ['task', true],
+      ['teammate', true],
+      ['sharedCare', false],
+    ]);
+  });
+
+  it('completes the full loop when a teammate logged care within 14 days', () => {
+    const milestones = deriveSharedCareMilestones({
+      plantCount: 1,
+      taskCount: 1,
+      memberUserIds: ['u1', 'u2'],
+      currentUserId: 'u1',
+      now: NOW,
+      activity: [completion('u2', '2026-07-10T10:00:00.000Z')],
+    });
+
+    expect(milestones.every((milestone) => milestone.completed)).toBe(true);
+  });
+
+  it('does not mistake an external plant sitter for a joined household teammate', () => {
+    const milestones = deriveSharedCareMilestones({
+      plantCount: 1,
+      taskCount: 1,
+      memberUserIds: ['u1', 'u2'],
+      currentUserId: 'u1',
+      now: NOW,
+      activity: [completion('sitter:share-1', '2026-07-16T10:00:00.000Z')],
+    });
+
+    expect(milestones.find((milestone) => milestone.key === 'sharedCare')?.completed).toBe(false);
+  });
+});
+
+describe('SharedCarePulse', () => {
+  it('shows the first incomplete collaboration step and its direct action', async () => {
+    usePulseHandlers();
+    renderPulse();
+
+    expect(
+      await screen.findByRole('heading', { name: 'Make care something the household shares' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('2 of 4 steps ready')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Invite someone' })).toHaveAttribute(
+      'href',
+      '/household'
+    );
+  });
+
+  it('lets a solo caregiver hide the prompt for 30 days on this device', async () => {
+    usePulseHandlers();
+    const user = userEvent.setup();
+    renderPulse();
+
+    const dismissButton = await screen.findByRole('button', {
+      name: 'Hide shared-care setup for 30 days',
+    });
+    await user.click(dismissButton);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('heading', { name: 'Make care something the household shares' })
+      ).not.toBeInTheDocument();
+    });
+    expect(
+      Date.parse(usePrefsStore.getState().sharedCarePulseDismissedUntil['hh-1'])
+    ).toBeGreaterThan(Date.now());
+  });
+});


### PR DESCRIPTION
## What changed

- add a dashboard Shared-care pulse derived from four real household milestones
- link directly to the first missing collaboration step and allow a 30-day device-local dismissal
- add English and Spanish copy plus privacy-preserving action analytics
- cover milestone semantics, dashboard integration, responsive browser behavior, persistence, and WCAG checks

## Why

The product tracks active members per household and care-task completion, but the dashboard did not help a solo caregiver turn an existing plant schedule into a routine another household member could actually pick up. This is a focused activation experiment that disappears once shared care is working.

The final milestone only counts recent task completions by a user in the current household roster. Plant-sitter activity does not satisfy it.

## Validation

- `npm run verify` — 80 frontend files / 435 tests and 92 backend files / 1231 tests passed
- `npx playwright test tests/e2e/shared-care-pulse.spec.ts --project=chromium --project='Mobile Chrome'` — 2 passed
- scoped Axe scan for WCAG 2 A/AA, 2.1 A/AA, and 2.2 AA — no violations
- `npm run build`
- `npm run size --workspace frontend` — all budgets passed
- `npm run mobile:validate`
