### PR TITLE
chore(release): prepare v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ reaches 1.0.0 (pre-1.0: minor bumps may include breaking changes — see
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-07-16
+
 ### Added
 
 - The dashboard now shows a bilingual Shared-care pulse until the household

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Family Greenhouse API — AWS Lambda + DynamoDB single-table + Cognito, with a local Express mock that mirrors the handlers.",
   "license": "Elastic-2.0",
   "private": true,

--- a/frontend/android/app/build.gradle
+++ b/frontend/android/app/build.gradle
@@ -12,10 +12,10 @@ android {
         applicationId "net.familygreenhouse.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        // Deterministic SemVer mapping: 0.18.0 -> 1800. Increment this for
+        // Deterministic SemVer mapping: 0.20.0 -> 2000. Increment this for
         // every store upload; Play never accepts a reused versionCode.
-        versionCode 1900
-        versionName "0.19.0"
+        versionCode 2000
+        versionName "0.20.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/frontend/ios/App/App.xcodeproj/project.pbxproj
+++ b/frontend/ios/App/App.xcodeproj/project.pbxproj
@@ -300,14 +300,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1900;
+				CURRENT_PROJECT_VERSION = 2000;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.19.0;
+				MARKETING_VERSION = 0.20.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = net.familygreenhouse.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -322,14 +322,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1900;
+				CURRENT_PROJECT_VERSION = 2000;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.19.0;
+				MARKETING_VERSION = 0.20.0;
 				PRODUCT_BUNDLE_IDENTIFIER = net.familygreenhouse.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Family Greenhouse web app — React + TypeScript + Vite PWA for collaborative household plant care.",
   "license": "Elastic-2.0",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "family-greenhouse",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "family-greenhouse",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "Elastic-2.0",
       "workspaces": [
         "frontend",
@@ -37,7 +37,7 @@
       }
     },
     "backend": {
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "Elastic-2.0",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.1073.0",
@@ -85,7 +85,7 @@
       }
     },
     "frontend": {
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "Elastic-2.0",
       "dependencies": {
         "@capacitor/android": "^8.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "family-greenhouse",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "license": "Elastic-2.0",
   "private": true,
   "description": "A shared plant-care journal for the whole household — per-plant schedules, reminders that find the right person across browser/email/SMS, and a care log everyone can see. React + TypeScript on AWS Lambda + DynamoDB + Cognito.",


### PR DESCRIPTION
## Release

Prepare Family Greenhouse `v0.20.0` for the shared-care activation pulse.

## Version alignment

- root, frontend, backend, and lockfile: `0.20.0`
- Android: `versionName 0.20.0`, `versionCode 2000`
- iOS: `MARKETING_VERSION 0.20.0`, `CURRENT_PROJECT_VERSION 2000`
- move the completed Shared-care pulse notes from Unreleased into the dated `0.20.0` changelog section

## Validation

- `npm run mobile:validate`
- `npm run verify` — 80 frontend files / 435 tests and 92 backend files / 1231 tests passed
- `npm run build`
- `npm run size --workspace frontend` — all budgets passed
- `git diff --check`

After merge, tag the merge commit as `v0.20.0` to trigger the production deployment workflow.
