### PR TITLE
ci: lean Actions per CI-CD-STANDARD §11 — CodeQL trigger scope, scorecard concurrency, prod-build cache removal

### DIFF
--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -129,10 +129,14 @@ jobs:
           ref: ${{ needs.validate.outputs.version }}
 
       - name: Setup Node.js
+        # No `cache: 'npm'` here (CICD-24 / §8c): this job builds the exact
+        # frontend+backend artifacts the downstream jobs deploy to production,
+        # so a poisoned Actions cache entry would flow straight into the prod
+        # Lambda bundles and the live site. Release/publish builds stay
+        # cache-free; only PR-triggered CI jobs may cache (ci.yml does).
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,11 @@ name: CodeQL
 # Family Greenhouse is a public repository, so CodeQL uploads findings to the
 # repository's code-scanning view without requiring GitHub Advanced Security.
 on:
-  push:
-    branches: [main]
+  # No `push: main` trigger (CI-CD-STANDARD §11e): every commit reaching main
+  # goes through a PR, so the pull_request run already analyzed it, and the
+  # weekly schedule (running on main) keeps default-branch code-scanning
+  # results fresh against new query packs. A push:main run would re-spend the
+  # multi-minute CodeQL analysis on code the PR run just covered.
   pull_request:
     branches: [main]
   schedule:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -15,6 +15,13 @@ on:
     # changes (branch protection, token permissions), not just commits.
     - cron: '30 6 * * 1'
 
+# Cancel superseded runs (CI-CD-STANDARD §11c): a rapid series of pushes to
+# main only needs the newest Scorecard analysis — earlier queued/in-flight
+# runs are stale the moment a newer commit lands.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: read-all
 
 jobs:


### PR DESCRIPTION
## Why

Part of the 2026-07-17 lean-CI sweep (CI-CD-STANDARD §11). With the account-wide Actions spending limit currently blocking runs, wasted minutes are not just cost — they are the failure mode that stops merge gating entirely. This PR trims redundant spend without weakening any gate: no SHA unpins, no permissions changes, no `continue-on-error`, no gate or trigger removed from a scanner's PR path.

## Per-workflow changes

| Workflow | Change | Standard |
|---|---|---|
| `codeql.yml` | Dropped the redundant `push: main` trigger. `pull_request` into main + weekly schedule remain, so the scanner stays armed, the required check **CodeQL analysis (javascript-typescript, actions)** still runs on every PR (verified against the branch ruleset), and the weekly run on main keeps default-branch code-scanning current. | §11e |
| `scorecard.yml` | Added top-level `concurrency` with `cancel-in-progress: true` (same group style as codeql/zizmor). Scanner triggers untouched. | §11c |
| `cd-production.yml` | Removed `cache: 'npm'` from the release **Build** job — it produces the exact artifacts the downstream jobs deploy to production, so Actions-cache poisoning would flow into the live Lambda bundles. Comment added matching the existing CICD-24 note on the smoke-tests job. | §8c / CICD-24 |

## Already compliant (no change)

| Workflow | Status |
|---|---|
| `ci.yml` | ✅ `push:[main]` + `pull_request:[main]` (§11i), concurrency-cancel (§11c), npm caching (§11f), ubuntu-only (§11b), all heavy jobs blocking — the chromium e2e-a11y job is a blocking E2E on PRs into main, allowed by §11d; Lighthouse already self-skips via an un-label-able frontend diff check |
| `cd-staging.yml` | ✅ manual `workflow_dispatch` only (deliberate — left alone), `cancel-in-progress: false` (§8b) |
| `e2e-crossbrowser.yml` | ✅ firefox/webkit matrix already on weekly schedule + dispatch (§11d) |
| `zizmor.yml` | ✅ concurrency-cancel present; triggers left alone (see Skipped) |

## Skipped (with reasons)

| Item | Reason |
|---|---|
| §11h docs-only `paths-ignore` on `ci.yml` | ci.yml contains security jobs (gitleaks **Security Scan**, semgrep **SAST**) which must scan everything — a workflow-level `paths-ignore` would filter them; and all 13 of its job contexts are required status checks, so per-job skip-twins would mean duplicating most of the workflow. Not mechanical; the Lighthouse job already implements the intent internally via a diff guard. |
| §11e-style trigger trim on `zizmor.yml` | zizmor is a seconds-long workflow audit, not heavy SAST; its `push: main` run keeps default-branch code-scanning SARIF current. Trimming it saves ~nothing. |
| §8c cache removal in `cd-staging.yml` build/e2e jobs | §8c's letter prohibits cache in jobs that deploy to **prod**, publish, generate provenance, or hold `id-token: write` — the staging build/e2e jobs do none of those. Flagging rather than changing; happy to remove there too if you want staging held to the prod bar. |
| §11g PR-matrix trim | Only matrices are Lighthouse desktop/mobile profiles (both meaningful per-PR) and the already-nightly browser matrix — no version matrix exists. N/A. |

## Verification (all local — Actions is billing-blocked account-wide, so no CI run will appear on this PR)

- `actionlint` on all three changed files: **0 new findings** (6 pre-existing info-level shellcheck notes in cd-production.yml's untouched scripts, identical on origin/main — noted, not fixed).
- `python3 -c 'yaml.safe_load(...)'` clean on each changed file.
- `node scripts/check-no-silenced-gates.mjs` (the repo's own P0-3 regression gate): clean.
- Conformance checker before → after: **17/23 → 17/23**, with `actions_sha_pinned` (75/75), `workflow_permissions` (7/7), `security_scanners_armed`, and `no_silenced_security_gate` all PASS both times.
- Required-check safety: branch ruleset queried via `gh api repos/.../rules/branches/main` — no changed workflow renames or removes a required-check job; CodeQL's required check rides the retained `pull_request` trigger.
- No overlap with open PRs #248/#228/#226/#225/#224/#223 (none touch `.github/workflows/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEt7d9aeBFmPToT46Sciqw