### PR TITLE
ci: lean actions - codeql trigger scope, scorecard concurrency, prod-build cache removal

### DIFF
--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -129,10 +129,14 @@ jobs:
           ref: ${{ needs.validate.outputs.version }}
 
       - name: Setup Node.js
+        # No `cache: 'npm'` here (CICD-24 / §8c): this job builds the exact
+        # frontend+backend artifacts the downstream jobs deploy to production,
+        # so a poisoned Actions cache entry would flow straight into the prod
+        # Lambda bundles and the live site. Release/publish builds stay
+        # cache-free; only PR-triggered CI jobs may cache (ci.yml does).
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,11 @@ name: CodeQL
 # Family Greenhouse is a public repository, so CodeQL uploads findings to the
 # repository's code-scanning view without requiring GitHub Advanced Security.
 on:
-  push:
-    branches: [main]
+  # No `push: main` trigger (CI-CD-STANDARD §11e): every commit reaching main
+  # goes through a PR, so the pull_request run already analyzed it, and the
+  # weekly schedule (running on main) keeps default-branch code-scanning
+  # results fresh against new query packs. A push:main run would re-spend the
+  # multi-minute CodeQL analysis on code the PR run just covered.
   pull_request:
     branches: [main]
   schedule:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -15,6 +15,13 @@ on:
     # changes (branch protection, token permissions), not just commits.
     - cron: '30 6 * * 1'
 
+# Cancel superseded runs (CI-CD-STANDARD §11c): a rapid series of pushes to
+# main only needs the newest Scorecard analysis — earlier queued/in-flight
+# runs are stale the moment a newer commit lands.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: read-all
 
 jobs:


### PR DESCRIPTION
Supersedes #249 — identical change set (cherry-picked from its head `4ad7ca2`), recommitted because #249's commit message fails the repo's own commitlint Lint gate (header 121 > 100 chars, non-lower-case subject) and cannot be fixed without a force-push.

## Per-workflow changes

| Workflow | Change | Standard |
|---|---|---|
| `codeql.yml` | Dropped the redundant `push: main` trigger. `pull_request` into main + weekly schedule remain, so the scanner stays armed on every PR and default-branch results refresh weekly. | CI-CD-STANDARD §11e |
| `scorecard.yml` | Added `concurrency` with `cancel-in-progress` so stacked pushes to main only spend minutes on the newest analysis. | §11c |
| `cd-production.yml` | Removed `cache: 'npm'` from the release Build job — it produces the exact artifacts deployed to production, so a poisoned Actions cache entry would flow into the live Lambda bundles. | §8c / CICD-24 |

No gate is weakened: no SHA unpins, no permissions changes, no `continue-on-error`, no gate or trigger removed from a scanner's PR path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)