### PR TITLE
fix(sms): truncate sms bodies by utf-8 bytes, not utf-16 units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ reaches 1.0.0 (pre-1.0: minor bumps may include breaking changes — see
 
 ## [Unreleased]
 
+### Fixed
+
+- SMS reminder bodies are now trimmed to the promised 140-byte budget by
+  UTF-8 bytes rather than UTF-16 code units, so accented Spanish text or the
+  streak emoji can no longer blow past the byte budget or split an emoji
+  surrogate pair mid-code-point.
+
 ## [0.21.0] - 2026-07-16
 
 ### Added

--- a/backend/src/services/smsNotifier.ts
+++ b/backend/src/services/smsNotifier.ts
@@ -32,12 +32,38 @@ export interface SmsMessage {
  * `false` so the reminder fan-out doesn't treat an unconfigured channel as a
  * delivery and burn the day's slot.
  */
+/**
+ * Truncate `text` to at most `maxBytes` UTF-8 bytes without splitting a
+ * multi-byte code point. `String.prototype.slice` counts UTF-16 code units, so
+ * accented Spanish text or the app's own emoji can exceed the byte cap the SMS
+ * segment contract promises (and slice can even bisect an emoji surrogate pair).
+ * Iterating with `for...of` yields whole code points, so a truncated body is
+ * always valid UTF-8 and never over budget.
+ */
+export function truncateToBytes(text: string, maxBytes: number): string {
+  if (Buffer.byteLength(text, 'utf8') <= maxBytes) {
+    return text;
+  }
+  let sliceEnd = 0;
+  let bytes = 0;
+  for (const ch of text) {
+    const chBytes = Buffer.byteLength(ch, 'utf8');
+    if (bytes + chBytes > maxBytes) {
+      break;
+    }
+    bytes += chBytes;
+    sliceEnd += ch.length; // 2 for an astral code point (surrogate pair)
+  }
+  return text.slice(0, sliceEnd);
+}
+
 export async function sendSms(msg: SmsMessage): Promise<boolean> {
   if (!E164.test(msg.to)) {
     throw new Error(`Phone number must be E.164 format, got: ${msg.to}`);
   }
-  // SMS messages are billed per ~140-byte segment; trim to keep it to one.
-  const text = msg.text.slice(0, 140);
+  // SMS messages are billed per ~140-byte segment; trim to keep it to one,
+  // counting UTF-8 bytes (not UTF-16 units) and never splitting a code point.
+  const text = truncateToBytes(msg.text, 140);
 
   if (process.env.SMS_NOTIFICATIONS_ENABLED !== '1') {
     // Never log destinations or message bodies here. Verification messages

--- a/backend/tests/unit/services/smsNotifier.test.ts
+++ b/backend/tests/unit/services/smsNotifier.test.ts
@@ -59,12 +59,41 @@ describe('smsNotifier', () => {
     expect(cmd.input.MessageAttributes['AWS.SNS.SMS.SMSType'].StringValue).toBe('Transactional');
   });
 
-  it('truncates long messages to 140 bytes', async () => {
+  it('truncates long ASCII messages to 140 bytes', async () => {
     process.env = { ...ORIGINAL, SMS_NOTIFICATIONS_ENABLED: '1' };
     snsSendMock.mockResolvedValueOnce({});
     const { sendSms } = await import('../../../src/services/smsNotifier.js');
     await sendSms({ to: '+15551234567', text: 'a'.repeat(200) });
     const cmd = snsSendMock.mock.calls[0][0] as { input: { Message: string } };
-    expect(cmd.input.Message.length).toBe(140);
+    expect(Buffer.byteLength(cmd.input.Message, 'utf8')).toBe(140);
+  });
+
+  it('truncates multibyte messages by bytes without splitting a code point', async () => {
+    process.env = { ...ORIGINAL, SMS_NOTIFICATIONS_ENABLED: '1' };
+    snsSendMock.mockResolvedValueOnce({});
+    const { sendSms } = await import('../../../src/services/smsNotifier.js');
+    // The app's own streak emoji is 4 UTF-8 bytes; 100 of them is 400 bytes.
+    await sendSms({ to: '+15551234567', text: '🌱'.repeat(100) });
+    const cmd = snsSendMock.mock.calls[0][0] as { input: { Message: string } };
+    const body = cmd.input.Message;
+    // At most one 140-byte segment, and no lone/split surrogate at the boundary.
+    expect(Buffer.byteLength(body, 'utf8')).toBeLessThanOrEqual(140);
+    expect(body).toBe('🌱'.repeat(35)); // 35 * 4 bytes = 140, whole emoji only
+    expect([...body].every((ch) => ch === '🌱')).toBe(true);
+  });
+});
+
+describe('truncateToBytes', () => {
+  it('keeps a short string unchanged', async () => {
+    const { truncateToBytes } = await import('../../../src/services/smsNotifier.js');
+    expect(truncateToBytes('hello', 140)).toBe('hello');
+  });
+
+  it('never splits a multi-byte code point at the byte boundary', async () => {
+    const { truncateToBytes } = await import('../../../src/services/smsNotifier.js');
+    // 'é' is 2 UTF-8 bytes; a 3-byte cap must drop the second 'é', not split it.
+    const out = truncateToBytes('éé', 3);
+    expect(out).toBe('é');
+    expect(Buffer.byteLength(out, 'utf8')).toBe(2);
   });
 });


### PR DESCRIPTION
Supersedes #228 — identical code change (cherry-picked from its head `f7371ff`), recommitted because that branch's commit subject fails the repo's commitlint `subject-case: lower-case` Lint gate (its CI predates the Actions billing fix, so the gate never got to run) and cannot be amended without a force-push.

## What this changes

`sendSms` trimmed the body with `msg.text.slice(0, 140)`, which counts UTF-16 code units — not the 140 **bytes** the one-segment comment promises. Accented Spanish text or the app's 🌱 streak emoji at 140 "characters" is well over 140 bytes, and `.slice` can bisect an emoji surrogate pair, emitting an invalid lone code unit.

Adds `truncateToBytes(text, maxBytes)`: walks whole code points (`for...of`) and stops before the byte budget is exceeded, so the result is always valid UTF-8 and within the documented 140-byte budget.

## Beyond #228

- CHANGELOG entry placed under `[Unreleased]` — on #228's branch it drifted into the already-tagged `0.16.3` section as main moved on, which would misattribute the fix to a shipped release.
- CHANGELOG wording tightened to claim exactly what the code guarantees (the 140-byte budget) rather than one-segment billing in all cases (mixed GSM-7/UCS-2 segmentation rules make the general billing claim not strictly provable from a byte cap).

## Tests

- ASCII truncation asserted in bytes (`Buffer.byteLength`), not `.length`.
- Emoji-only body: ≤140 bytes, whole code points only, no split surrogate.
- 2-byte boundary case (`éé` at a 3-byte cap → `é`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)