### PR TITLE
Fix staging Cognito email fallback

### DIFF
--- a/backend/tests/unit/config/commercialStatus.test.ts
+++ b/backend/tests/unit/config/commercialStatus.test.ts
@@ -87,6 +87,13 @@ describe('production IaC commercial-hold invariants', () => {
     expect(productionVars).toMatch(/^public_registration_enabled\s*=\s*true\s*$/m);
   });
 
+  it('keeps Cognito default email configuration valid when SES addresses are blank', () => {
+    expect(authModule).toMatch(
+      /reply_to_email_address\s*=\s*var\.email_reply_to != "" \? var\.email_reply_to : \(var\.email_from_address != "" \? var\.email_from_address : null\)/
+    );
+    expect(authModule).not.toMatch(/reply_to_email_address\s*=\s*coalesce\(/);
+  });
+
   it('deploys the registration API before exposing the public frontend form', () => {
     const deployFrontend = productionWorkflow.slice(
       productionWorkflow.indexOf('  deploy-frontend:'),

--- a/infrastructure/modules/auth/main.tf
+++ b/infrastructure/modules/auth/main.tf
@@ -61,7 +61,7 @@ resource "aws_cognito_user_pool" "main" {
     email_sending_account  = var.email_identity_arn == "" ? "COGNITO_DEFAULT" : "DEVELOPER"
     source_arn             = var.email_identity_arn == "" ? null : var.email_identity_arn
     from_email_address     = var.email_from_address == "" ? null : var.email_from_address
-    reply_to_email_address = coalesce(var.email_reply_to, var.email_from_address, "") == "" ? null : coalesce(var.email_reply_to, var.email_from_address)
+    reply_to_email_address = var.email_reply_to != "" ? var.email_reply_to : (var.email_from_address != "" ? var.email_from_address : null)
   }
 
   verification_message_template {


### PR DESCRIPTION
## Summary

- make Cognito `reply_to_email_address` resolve to `null` when staging has no SES addresses
- preserve the production preference order of explicit reply-to, then from-address
- pin the blank-address behavior with a repository configuration regression test

## Verification

- targeted backend configuration tests: 33/33
- `terraform fmt -check`
- `git diff --check`

The first staging attempt stopped during Terraform plan before applying any resources. This fixes that plan-time failure.
