### PR TITLE
Fix staging account-global resource conflicts

### DIFF
--- a/backend/tests/unit/config/commercialStatus.test.ts
+++ b/backend/tests/unit/config/commercialStatus.test.ts
@@ -46,6 +46,11 @@ describe('production IaC commercial-hold invariants', () => {
   const root = new URL('../../../../', import.meta.url);
   const apiModule = readFileSync(new URL('infrastructure/modules/api/main.tf', root), 'utf8');
   const authModule = readFileSync(new URL('infrastructure/modules/auth/main.tf', root), 'utf8');
+  const monitoringModule = readFileSync(
+    new URL('infrastructure/modules/monitoring/main.tf', root),
+    'utf8'
+  );
+  const rootModule = readFileSync(new URL('infrastructure/main.tf', root), 'utf8');
   const rootVariables = readFileSync(new URL('infrastructure/variables.tf', root), 'utf8');
   const productionVars = readFileSync(
     new URL('infrastructure/environments/production/terraform.tfvars', root),
@@ -92,6 +97,25 @@ describe('production IaC commercial-hold invariants', () => {
       /reply_to_email_address\s*=\s*var\.email_reply_to != "" \? var\.email_reply_to : \(var\.email_from_address != "" \? var\.email_from_address : null\)/
     );
     expect(authModule).not.toMatch(/reply_to_email_address\s*=\s*coalesce\(/);
+  });
+
+  it('creates the account-global Cost Explorer anomaly monitor only in production', () => {
+    expect(rootModule).toMatch(
+      /enable_cost_anomaly_monitor\s*=\s*var\.environment == "production"/
+    );
+    expect(monitoringModule).toMatch(
+      /resource "aws_ce_anomaly_monitor" "services"\s*{[\s\S]*?count\s*=\s*var\.enable_cost_anomaly_monitor \? 1 : 0/
+    );
+    expect(monitoringModule).toMatch(/to\s*=\s*aws_ce_anomaly_monitor\.services\[0\]/);
+    expect(monitoringModule).toMatch(
+      /monitor_arn_list\s*=\s*\[aws_ce_anomaly_monitor\.services\[0\]\.arn\]/
+    );
+  });
+
+  it('serializes first-time Lambda function URL policy updates', () => {
+    expect(apiModule).toMatch(
+      /resource "aws_lambda_permission" "chat_stream_url"\s*{[\s\S]*?depends_on\s*=\s*\[aws_lambda_function_url\.chat_stream\]/
+    );
   });
 
   it('deploys the registration API before exposing the public frontend form', () => {

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -167,18 +167,19 @@ module "frontend" {
 module "monitoring" {
   source = "./modules/monitoring"
 
-  environment                = var.environment
-  project_name               = var.project_name
-  api_gateway_id             = module.api.api_gateway_id
-  api_access_log_group_name  = module.api.api_access_log_group_name
-  api_lambda_log_group_name  = module.api.api_lambda_log_group_name
-  auth_lambda_log_group_name = module.api.auth_lambda_log_group_name
-  lambda_function_names      = module.api.lambda_function_names
-  alert_email                = var.alert_email
-  alert_sms_number           = var.alert_sms_number
-  dynamodb_table_name        = module.database.table_name
-  monthly_budget_usd         = var.monthly_budget_usd
-  lambda_dlq_name            = module.api.lambda_dlq_name
+  environment                 = var.environment
+  project_name                = var.project_name
+  enable_cost_anomaly_monitor = var.environment == "production"
+  api_gateway_id              = module.api.api_gateway_id
+  api_access_log_group_name   = module.api.api_access_log_group_name
+  api_lambda_log_group_name   = module.api.api_lambda_log_group_name
+  auth_lambda_log_group_name  = module.api.auth_lambda_log_group_name
+  lambda_function_names       = module.api.lambda_function_names
+  alert_email                 = var.alert_email
+  alert_sms_number            = var.alert_sms_number
+  dynamodb_table_name         = module.database.table_name
+  monthly_budget_usd          = var.monthly_budget_usd
+  lambda_dlq_name             = module.api.lambda_dlq_name
   # Wired only when the email module is provisioned (domain set). No cycle:
   # monitoring already depends on api (which depends on email), and email
   # depends on nothing here.

--- a/infrastructure/modules/api/main.tf
+++ b/infrastructure/modules/api/main.tf
@@ -610,6 +610,11 @@ resource "aws_lambda_permission" "chat_stream_url" {
   function_name          = aws_lambda_function.chat_stream.function_name
   principal              = "*"
   function_url_auth_type = "NONE"
+
+  # Function URL creation also updates the Lambda resource policy. Serialize
+  # this explicit statement so first-time stacks do not race two AddPermission
+  # calls and fail with ResourceConflictException.
+  depends_on = [aws_lambda_function_url.chat_stream]
 }
 
 # Since the October 2025 Lambda policy change, NONE-auth Function URLs reject

--- a/infrastructure/modules/monitoring/main.tf
+++ b/infrastructure/modules/monitoring/main.tf
@@ -71,18 +71,27 @@ resource "aws_budgets_budget" "monthly_cost" {
 # *shape*. Free. Cost Explorer is a us-east-1-global service (this stack's
 # region), so it lives in the default provider.
 resource "aws_ce_anomaly_monitor" "services" {
+  count = var.enable_cost_anomaly_monitor ? 1 : 0
+
   name              = "${var.project_name}-anomaly-${var.environment}"
   monitor_type      = "DIMENSIONAL"
   monitor_dimension = "SERVICE"
 }
 
+# Preserve the existing production monitor while making this account-global
+# resource optional for secondary stacks such as staging.
+moved {
+  from = aws_ce_anomaly_monitor.services
+  to   = aws_ce_anomaly_monitor.services[0]
+}
+
 resource "aws_ce_anomaly_subscription" "alerts" {
-  count = var.alert_email == "" ? 0 : 1
+  count = var.enable_cost_anomaly_monitor && var.alert_email != "" ? 1 : 0
   name  = "${var.project_name}-anomaly-sub-${var.environment}"
   # EMAIL subscribers only support DAILY/WEEKLY (IMMEDIATE needs an SNS topic).
   # DAILY = one digest email of the day's anomalies.
   frequency        = "DAILY"
-  monitor_arn_list = [aws_ce_anomaly_monitor.services.arn]
+  monitor_arn_list = [aws_ce_anomaly_monitor.services[0].arn]
 
   subscriber {
     type    = "EMAIL"

--- a/infrastructure/modules/monitoring/variables.tf
+++ b/infrastructure/modules/monitoring/variables.tf
@@ -8,6 +8,12 @@ variable "project_name" {
   type        = string
 }
 
+variable "enable_cost_anomaly_monitor" {
+  description = "Create the account-global Cost Explorer service anomaly monitor. Enable in only one stack per AWS account."
+  type        = bool
+  default     = true
+}
+
 variable "api_gateway_id" {
   description = "HTTP API Gateway ID used by CloudWatch's ApiId dimension"
   type        = string


### PR DESCRIPTION
## Summary

- create the account-global Cost Explorer service anomaly monitor only in production
- preserve the existing production monitor address with a Terraform moved block
- serialize first-time Lambda Function URL policy updates to prevent concurrent AddPermission calls
- add repository configuration regression coverage for both staging failures

## Verification

- targeted backend configuration tests: 35/35
- `terraform fmt -check`
- `git diff --check`

The staging apply persisted its partial state before exposing these two issues, so the next apply can reconcile the same isolated stack.
