### PR TITLE
Harden production rollback snapshots

### DIFF
--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -411,10 +411,12 @@ jobs:
           name: backend-dist-${{ needs.validate.outputs.version }}
           path: dist
 
-      - name: Capture previous Lambda versions for rollback
+      - name: Capture previous Lambda versions and packages for rollback
         id: prev
         run: |
           set -euo pipefail
+          rollback_dir=$(mktemp -d)
+          trap 'rm -rf "$rollback_dir"' EXIT
           versions=""
           # Keep this list in sync with the deploy loop below (and with
           # esbuild's dist/*.js bundles + the terraform function names).
@@ -429,6 +431,48 @@ jobs:
             ver=$(aws lambda list-versions-by-function --function-name "$FUNCTION_NAME" \
               --query 'max_by(Versions[?Version!=`$LATEST`], &to_number(Version)).Version' \
               --output text)
+            if [ -z "$ver" ] || [ "$ver" = "None" ]; then
+              echo "::error::${FUNCTION_NAME}: no published version is available for rollback"
+              exit 1
+            fi
+
+            # Materialize the captured package before mutating any function.
+            # A version number alone is insufficient: versions published by a
+            # prior rollback might not yet have a matching artifact in our S3
+            # archive. Lambda's immutable version remains the source of truth.
+            code_location=$(aws lambda get-function \
+              --function-name "$FUNCTION_NAME" \
+              --qualifier "$ver" \
+              --query 'Code.Location' \
+              --output text)
+            if [ -z "$code_location" ] || [ "$code_location" = "None" ]; then
+              echo "::error::${FUNCTION_NAME}: version ${ver} has no downloadable code package"
+              exit 1
+            fi
+
+            snapshot_file="${rollback_dir}/${handler}-v${ver}.zip"
+            curl --fail --silent --show-error --location \
+              --retry 3 --retry-all-errors \
+              "$code_location" \
+              --output "$snapshot_file"
+            test -s "$snapshot_file" || {
+              echo "::error::${FUNCTION_NAME}: downloaded rollback package is empty"
+              exit 1
+            }
+            snapshot_key="lambda-versions/${handler}-v${ver}.zip"
+            aws s3 cp "$snapshot_file" \
+              "s3://${ARTIFACT_BUCKET}/${snapshot_key}" \
+              --only-show-errors
+            snapshot_size=$(aws s3api head-object \
+              --bucket "$ARTIFACT_BUCKET" \
+              --key "$snapshot_key" \
+              --query 'ContentLength' \
+              --output text)
+            if ! [[ "$snapshot_size" =~ ^[1-9][0-9]*$ ]]; then
+              echo "::error::${FUNCTION_NAME}: rollback package was not stored correctly"
+              exit 1
+            fi
+            echo "  ✓ ${FUNCTION_NAME} rollback package v${ver} (${snapshot_size} bytes)"
             versions="${versions}${handler}=${ver}\n"
           done
           printf '%b' "$versions" > prev-versions.txt

--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -348,10 +348,12 @@ jobs:
           aws s3api head-object \
             --bucket "$ARTIFACT_BUCKET" \
             --key "${FRONTEND_SNAPSHOT_PREFIX}/index.html" > /dev/null
+          SNAPSHOT_MARKER="${RUNNER_TEMP}/snapshot-complete"
+          : > "$SNAPSHOT_MARKER"
           aws s3api put-object \
             --bucket "$ARTIFACT_BUCKET" \
             --key "${FRONTEND_SNAPSHOT_PREFIX}/snapshot-complete" \
-            --body /dev/null > /dev/null
+            --body "$SNAPSHOT_MARKER" > /dev/null
           echo "ready=true" >> "$GITHUB_OUTPUT"
 
       - name: Sync to S3

--- a/backend/tests/unit/config/commercialStatus.test.ts
+++ b/backend/tests/unit/config/commercialStatus.test.ts
@@ -167,6 +167,9 @@ describe('production IaC commercial-hold invariants', () => {
     expect(productionWorkflow).not.toMatch(/FRONTEND_SNAPSHOT_PREFIX:.*run_attempt/);
     expect(deployFrontend).toMatch(/Snapshot current frontend for rollback/);
     expect(deployFrontend).toMatch(/snapshot-complete/);
+    expect(deployFrontend).toMatch(/SNAPSHOT_MARKER="\$\{RUNNER_TEMP\}\/snapshot-complete"/);
+    expect(deployFrontend).toMatch(/--body "\$SNAPSHOT_MARKER"/);
+    expect(deployFrontend).not.toMatch(/--body \/dev\/null/);
     expect(deployFrontend).toMatch(/cloudfront wait invalidation-completed/);
     expect(deployBackend).toMatch(/lambda wait function-updated-v2/);
     expect(deployBackend).toMatch(/API_URL:\s*\$\{\{ needs\.terraform\.outputs\.api_url }}/);

--- a/backend/tests/unit/config/commercialStatus.test.ts
+++ b/backend/tests/unit/config/commercialStatus.test.ts
@@ -171,6 +171,13 @@ describe('production IaC commercial-hold invariants', () => {
     expect(deployFrontend).toMatch(/--body "\$SNAPSHOT_MARKER"/);
     expect(deployFrontend).not.toMatch(/--body \/dev\/null/);
     expect(deployFrontend).toMatch(/cloudfront wait invalidation-completed/);
+    expect(deployBackend.indexOf('Capture previous Lambda versions and packages')).toBeLessThan(
+      deployBackend.indexOf('Mark Lambda rollback snapshot ready')
+    );
+    expect(deployBackend).toMatch(/aws lambda get-function[\s\S]*?--qualifier "\$ver"/);
+    expect(deployBackend).toMatch(/Code\.Location/);
+    expect(deployBackend).toMatch(/snapshot_size=.*aws s3api head-object/);
+    expect(deployBackend).toMatch(/rollback package was not stored correctly/);
     expect(deployBackend).toMatch(/lambda wait function-updated-v2/);
     expect(deployBackend).toMatch(/API_URL:\s*\$\{\{ needs\.terraform\.outputs\.api_url }}/);
     expect(deployBackend).toMatch(/url="\$\{API_URL\}\/health"/);


### PR DESCRIPTION
## Summary

- write the frontend rollback completion marker from a real empty runner-temp file instead of `/dev/null`
- materialize and verify every captured Lambda rollback package before mutating any production function
- use Lambda's immutable published versions as the rollback source of truth, closing historical S3 archive gaps
- pin both recovery contracts with repository configuration tests

## Verification

- targeted backend configuration tests: 35/35
- `actionlint .github/workflows/cd-production.yml`
- `git diff --check`

The first v0.22.0 run stopped before frontend sync. Cognito and 14 Lambdas rolled back automatically; the remaining species Lambda was manually restored from its checksum-verified immutable v43 package. Once this merges, a manual main-branch dispatch can safely retry the immutable v0.22.0 tag using the corrected workflow definition.
