### PR TITLE
docs: remove stale visibility language

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,10 +215,8 @@ jobs:
     name: SAST (Semgrep)
     runs-on: ubuntu-latest
     # Semgrep OSS is free and tokenless — kept as a fast, always-on first pass.
-    # (This comment previously claimed "CodeQL would need GitHub Advanced
-    # Security, which isn't available on this private repo's plan" — that was
-    # wrong: this repo is public, and CodeQL is free for public repos. Fixed
-    # 2026-07-05; CodeQL now runs separately in codeql.yml, see SEC-08.)
+    # CodeQL runs separately for this public repository in codeql.yml
+    # (see SEC-08).
     # Runs the community rulesets relevant to our stack and gates on
     # ERROR-severity findings only — high-confidence issues, low
     # false-positive noise. Tune the rulesets / severity as the codebase grows.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ reaches 1.0.0 (pre-1.0: minor bumps may include breaking changes — see
 
 ## [Unreleased]
 
+### Fixed
+
+- Removed superseded repository-visibility language from the CI workflow; its
+  comments now describe the active public CodeQL path directly.
+
 ## [0.23.0] - 2026-07-25
 
 ### Added


### PR DESCRIPTION
## Outcome

Removes a stale private-plan quotation from Family Greenhouse's active CI
workflow comments.

- comments now describe the separate public CodeQL path directly
- Semgrep and CodeQL behavior remains unchanged
- current public repository history remains documented in the changelog

## Validation

- live visibility-aware portfolio conformance: `stale_private_refs` passes
- workflow diff inspected
- `git diff --check`
