### PR TITLE
fix(iam): restore live account lifecycle operations

### DIFF
--- a/backend/tests/unit/config/integrationIam.test.ts
+++ b/backend/tests/unit/config/integrationIam.test.ts
@@ -20,6 +20,19 @@ describe('production integration IAM invariants', () => {
     );
   });
 
+  it('lets user lifecycle flows batch-remove records and guard transactional writes', () => {
+    const fleetPolicy = apiModule.slice(
+      apiModule.indexOf('resource "aws_iam_role_policy" "lambda"'),
+      apiModule.indexOf('resource "aws_iam_role_policy" "chat_stream"')
+    );
+
+    expect(fleetPolicy).toContain('"dynamodb:BatchWriteItem"');
+    expect(fleetPolicy).toContain('"dynamodb:ConditionCheckItem"');
+    expect(fleetPolicy).toMatch(
+      /"dynamodb:BatchWriteItem"[\s\S]*?"dynamodb:ConditionCheckItem"[\s\S]*?Resource = \[[\s\S]*?var\.dynamodb_table_arn/
+    );
+  });
+
   it('lets both chat Lambda roles read only the configured Sprout secret', () => {
     expect(apiModule).toMatch(
       /sprout_secret_arn\s*=[\s\S]*?startswith\(var\.sprout_integration_secret_id, "arn:"\)/

--- a/infrastructure/modules/api/main.tf
+++ b/infrastructure/modules/api/main.tf
@@ -140,6 +140,8 @@ resource "aws_iam_role_policy" "lambda" {
           "dynamodb:PutItem",
           "dynamodb:UpdateItem",
           "dynamodb:DeleteItem",
+          "dynamodb:BatchWriteItem",
+          "dynamodb:ConditionCheckItem",
           "dynamodb:Query",
           "dynamodb:Scan"
         ]


### PR DESCRIPTION
## Summary
- allow DynamoDB batch writes used by plant and account deletion
- allow condition checks used by transactional household admin guards
- add a focused IAM wiring regression test

## Live staging evidence
Staging run 30192189239 deployed successfully, and its real browser flow passed signup, login, onboarding, plant creation, S3 upload/confirm/render. DELETE /me then returned 500 because the shared Lambda role lacked dynamodb:BatchWriteItem. CloudWatch confirmed the AccessDeniedException; administrative fallback removed the disposable fixture.

## Verification
- full verify gate: 542 frontend + 1,405 backend tests
- Terraform fmt and validate
- lint, typecheck, i18n, observability, audit, marker and anti-silencing gates