### PR TITLE
chore(infrastructure): add lowercase project and environment cost tags

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -14,21 +14,47 @@ terraform {
   }
 }
 
+locals {
+  application_domain = var.application_domain != "" ? var.application_domain : var.domain_name
+  hosted_zone_name   = var.hosted_zone_name != "" ? var.hosted_zone_name : var.domain_name
+
+  # Tags stamped onto every taggable resource by BOTH aws providers below.
+  #
+  # Why two spellings of the same thing: AWS cost-allocation tag KEYS are
+  # case-sensitive, and the payer account activated the lowercase `project`
+  # key (plus `environment`) in Cost Explorer. The TitleCase Project/
+  # Environment tags this stack already applied are therefore invisible to
+  # billing — which is why family-greenhouse showed $0 of tagged spend while
+  # still running real infrastructure. The lowercase pair is what the
+  # per-project prod/staging budgets actually filter on.
+  #
+  # The TitleCase pair is deliberately KEPT rather than renamed: nothing in
+  # AWS reads a tag key case-insensitively, so dropping it would silently
+  # break any console filter, saved report or ad-hoc query built on it, and
+  # would rewrite tags on every resource in the stack for no billing gain.
+  #
+  # `environment` is var.environment ("production" | "staging", enforced by
+  # the validation in variables.tf). The two environments are separate
+  # Terraform states selected by backend key at init time (see backend.tf),
+  # each fed its own environments/<env>/terraform.tfvars, so this value is
+  # always the environment being applied and the two budgets can tell each
+  # other apart.
+  cost_allocation_tags = {
+    Project     = "family-greenhouse"
+    Environment = var.environment
+    ManagedBy   = "terraform"
+
+    project     = "family-greenhouse"
+    environment = var.environment
+  }
+}
+
 provider "aws" {
   region = var.aws_region
 
   default_tags {
-    tags = {
-      Project     = "family-greenhouse"
-      Environment = var.environment
-      ManagedBy   = "terraform"
-    }
+    tags = local.cost_allocation_tags
   }
-}
-
-locals {
-  application_domain = var.application_domain != "" ? var.application_domain : var.domain_name
-  hosted_zone_name   = var.hosted_zone_name != "" ? var.hosted_zone_name : var.domain_name
 }
 
 # Provider for CloudFront certificates (must be us-east-1)
@@ -37,11 +63,7 @@ provider "aws" {
   region = "us-east-1"
 
   default_tags {
-    tags = {
-      Project     = "family-greenhouse"
-      Environment = var.environment
-      ManagedBy   = "terraform"
-    }
+    tags = local.cost_allocation_tags
   }
 }
 


### PR DESCRIPTION
## Why

98.4% of the AWS account's July spend carries an **empty `project` cost-allocation tag**, so the per-project budgets can't see anything. `family-greenhouse` reports **$0 of tagged spend** despite running real infrastructure and having both a production and a staging budget.

The root cause is not missing tags — it's **tag key case**. This stack already applied provider-level `default_tags`, but with TitleCase keys:

```hcl
default_tags {
  tags = {
    Project     = "family-greenhouse"   # TitleCase
    Environment = var.environment       # TitleCase
    ManagedBy   = "terraform"
  }
}
```

AWS cost-allocation tag **keys are case-sensitive**, and the key activated in Cost Explorer is lowercase `project`. `Project` and `project` are two different keys, so every resource in this stack was tagged and still invisible to billing.

## What changed

One file, `infrastructure/main.tf`. The default-tag map is hoisted into a `local` (so the default provider and the `us_east_1` aliased provider used for CloudFront certs can't drift apart) and gains the lowercase pair:

```hcl
cost_allocation_tags = {
  Project     = "family-greenhouse"
  Environment = var.environment
  ManagedBy   = "terraform"

  project     = "family-greenhouse"
  environment = var.environment
}
```

This **merges with** the existing tags rather than replacing them. The TitleCase pair is deliberately kept: nothing in AWS matches tag keys case-insensitively, so renaming would silently break any console filter or saved report built on `Project`, and would rewrite tags across the entire stack for no billing gain.

No module files were touched, and none needed to be. `default_tags` is inherited by every resource the provider creates, and the only resource-level `tags` blocks in this repo (27 of them) set a single `Name` key — there is **no key collision**, so nothing overrides the new tags.

## Production vs. staging split

The repo does **not** use Terraform workspaces. Environments are separated two ways, and the tag rides on the existing mechanism rather than introducing a new one:

1. **Separate state, chosen at init time.** Production uses the default backend key `terraform.tfstate`; staging runs `terraform init -backend-config="key=staging/terraform.tfstate"` (`.github/workflows/cd-staging.yml`, `scripts/deploy.sh`).
2. **Separate tfvars.** `environments/production/terraform.tfvars` sets `environment = "production"`; `environments/staging/terraform.tfvars` sets `environment = "staging"`. Each is passed with `-var-file` at plan/apply.

So `var.environment` is always exactly the environment being applied, and `variables.tf` validates it to `["staging", "production"]` — it cannot silently become anything else. `environment = var.environment` therefore emits `environment=production` or `environment=staging`, matching the names the repo already uses, and the two budgets can tell each other apart.

## Verification

**`terraform fmt -check -recursive`** — clean, exit 0.

**`terraform init -backend=false && terraform validate`** (Terraform 1.5.7, the version CI pins):

```
Success! The configuration is valid, but there were some validation warnings
```

The warnings are pre-existing and unrelated to this change (deprecated `data.aws_region.name`, and `hash_key` on `aws_dynamodb_table`).

**`terraform plan` was NOT run.** It requires real credentials and access to live remote state — this config uses an S3 backend plus a DynamoDB lock table, so even `-refresh=false` cannot proceed:

```
Error: Backend initialization required, please run "terraform init"
Reason: Initial configuration of the requested backend "s3"
```

**Evidence in place of a plan.** The AWS provider schema was dumped offline (`terraform providers schema -json`, from a backend-free copy of the config — no credentials, no state, no AWS API calls) and every `aws_*` resource type declared in this repo was checked for a `tags` attribute. Of **50 declared AWS resource types, 19 are taggable** and will receive `project` + `environment` on the next apply, across **45 resource declarations** (more actual resources at runtime — `aws_lambda_function.handlers` is a `for_each` over the handler set):

| Resource type | Declarations |
| --- | --- |
| `aws_cloudwatch_metric_alarm` | 15 |
| `aws_cloudwatch_log_group` | 4 |
| `aws_iam_role` | 4 |
| `aws_cloudwatch_event_rule` | 3 |
| `aws_lambda_function` | 3 (one is a `for_each`) |
| `aws_s3_bucket` | 3 |
| `aws_sqs_queue` | 2 |
| `aws_acm_certificate`, `aws_apigatewayv2_api`, `aws_apigatewayv2_stage`, `aws_budgets_budget`, `aws_ce_anomaly_monitor`, `aws_ce_anomaly_subscription`, `aws_cloudfront_distribution`, `aws_cognito_user_pool`, `aws_dynamodb_table`, `aws_iam_openid_connect_provider`, `aws_iam_policy`, `aws_sns_topic` | 1 each |

That covers every meaningful cost driver in the stack: Lambda, DynamoDB, S3, CloudFront, API Gateway, Cognito, SQS, SNS, CloudWatch logs and alarms.

## Caveats

### Untaggable resource types (31)

These AWS resource types have no `tags` argument at all, so they stay untagged. Almost all are **sub-resources or policy attachments of a taggable parent** and generate no separate line item — the billable parent is tagged, so this is not a real attribution gap:

- **S3 bucket configuration** — `aws_s3_bucket_policy`, `aws_s3_bucket_versioning`, `aws_s3_bucket_public_access_block`, `aws_s3_bucket_lifecycle_configuration`, `aws_s3_bucket_cors_configuration`, `aws_s3_bucket_server_side_encryption_configuration` (buckets themselves are tagged)
- **IAM** — `aws_iam_role_policy`, `aws_iam_role_policy_attachment` (roles and managed policies are tagged; IAM is free anyway)
- **API Gateway v2** — `aws_apigatewayv2_authorizer`, `aws_apigatewayv2_integration`, `aws_apigatewayv2_route` (the API and stage are tagged)
- **CloudFront policies** — `aws_cloudfront_cache_policy`, `aws_cloudfront_response_headers_policy`, `aws_cloudfront_origin_access_control` (the distribution is tagged)
- **CloudWatch sub-resources** — `aws_cloudwatch_dashboard`, `aws_cloudwatch_log_metric_filter`, `aws_cloudwatch_event_target`
- **Lambda / SQS / SNS / Cognito attachments** — `aws_lambda_permission`, `aws_lambda_function_url`, `aws_sqs_queue_policy`, `aws_sns_topic_subscription`, `aws_cognito_user_pool_client`
- **Route 53 records** — `aws_route53_record` (records are never taggable; see the hosted-zone note below)
- **SES (all of SESv1 is untaggable)** — `aws_ses_domain_identity`, `aws_ses_domain_identity_verification`, `aws_ses_domain_dkim`, `aws_ses_identity_policy`, `aws_ses_receipt_rule`, `aws_ses_receipt_rule_set`, `aws_ses_active_receipt_rule_set`
- **Virtual / wait-only** — `aws_acm_certificate_validation`

The one genuine gap in this list is **SES**: outbound mail and inbound receipt-rule charges cannot be tagged by any means, so SES spend will remain unattributed.

### Managed outside Terraform — stays unattributed

- **The Route 53 hosted zone.** It is consumed as a `data "aws_route53_zone"` source (2 uses), not managed here — it was created by hand. Hosted zones are taggable and do bill (~$0.50/mo each), so this is real, attributable spend this PR does **not** capture.
- **The Terraform state backend itself.** `backend.tf` documents that the S3 state bucket and the `family-greenhouse-terraform-locks` DynamoDB table are bootstrapped by CLI before `terraform init` can run. Both are billable and neither is in state.
- **The Perenual API key SSM parameter** (`/family-greenhouse/perenual-api-key`). Per `environments/production/terraform.tfvars`, the value "was put into SSM Parameter Store via the AWS CLI and is never tracked by IAC." Terraform carries only the parameter name. Standard-tier SSM parameters are free, so the cost impact is nil, but it is an untagged out-of-band resource.
- **One Lambda resource-policy statement.** `modules/api/main.tf` documents `AllowPublicFunctionUrlInvokeFunction` on the chat-stream function as being added via `aws lambda add-permission` outside Terraform. Not billable, but untracked. (Side note for a separate PR: that comment says it is waiting on the provider-6 upgrade and that the repo pins `~> 5.0` — the root now pins `~> 6.52`, so both the comment and the CLI workaround look stale.)
- **Usage-based spend with no taggable resource.** Bedrock model invocation, cross-service data transfer and similar usage charges attach to the account rather than to a resource, so no resource tag can capture them.
- **No AWS Amplify.** Checked explicitly — there are no Amplify apps, hosting, or resources anywhere in this repo. The frontend is plain S3 + CloudFront, both tagged.

### Operational notes

- **Tags apply on the next `apply`, per environment.** This PR changes configuration only; no apply was run. Production and staging have separate state, so **each needs its own deploy** before its budget starts seeing spend.
- **Tagging is not retroactive.** Cost Explorer will not re-tag already-incurred July spend. Existing untagged spend stays untagged; attribution begins from the apply date forward, and newly activated tag keys can take up to ~24h to surface.
- **The `environment` key may need activating.** `project` is already activated as a cost-allocation key in Cost Explorer. If `environment` has not been activated too, the tag will be present on resources but unusable as a budget filter dimension. That is a Billing-console action Terraform cannot perform — worth confirming before relying on the prod/staging split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
