### PR TITLE
chore(infra): gate staging cloudwatch alarms and dashboard

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -23,6 +23,30 @@ keeps the SLO, route wiring, release correlation, and metric dimensions from dri
   Lambda log group because Cognito confirmation precedes login; Stripe-confirmed events land in the
   billing Lambda log group. Select all three groups for a complete funnel query.
 
+## Where alarms are created
+
+The title of this page is deliberate: alarms and the dashboard are a
+**production** capability. `enable_monitoring_alarms` and
+`enable_monitoring_dashboard` (root variables, both defaulting to `true`) gate
+every `aws_cloudwatch_metric_alarm` and the `aws_cloudwatch_dashboard` in
+`infrastructure/modules/monitoring`. Production sets neither and therefore keeps
+all 19 alarms and its dashboard; `environments/staging/terraform.tfvars` sets
+both `false`.
+
+Staging is off because its alerts SNS topic had no subscribers — `alert_email`
+is empty there, so 18 alarms plus a dashboard billed roughly $5.60/month to
+notify nobody. An alarm whose destination is empty is cost without coverage, so
+the module carries a `check "alarms_have_a_notification_destination"` block that
+warns on every plan when `enable_alarms` is true and the topic has neither an
+email nor an SMS subscription. Re-enable staging monitoring by setting
+`alert_email` (or `alert_sms_number`) first, then flipping the two flags back to
+`true`; doing it in the other order recreates the same silent bill and the check
+will say so.
+
+Metric filters, the SNS topic, the budget, and Cost Anomaly Detection are not
+gated — they are free or near-free and several are the data source the alarms
+would read on the way back up.
+
 ## Triage
 
 1. Open the `family-greenhouse-production` CloudWatch dashboard and set the incident time range.

--- a/infrastructure/environments/staging/terraform.tfvars
+++ b/infrastructure/environments/staging/terraform.tfvars
@@ -4,3 +4,16 @@ project_name                = "family-greenhouse"
 public_registration_enabled = true
 domain_name                 = ""
 alert_email                 = ""
+
+# Staging monitoring is off. Its alarms routed to the family-greenhouse-alerts-
+# staging SNS topic, and alert_email above is empty, so the topic has zero
+# subscribers — 18 alarms plus a dashboard were billing ~$5.60/month to notify
+# nobody. They were deleted from the account; these flags stop the next apply
+# from recreating them.
+#
+# To re-enable: set alert_email (or alert_sms_number) so the topic actually has
+# a destination, then flip these back to true. Leaving them true with no
+# subscriber trips the alarms_have_a_notification_destination check in
+# modules/monitoring and rebuys the same silent bill.
+enable_monitoring_alarms    = false
+enable_monitoring_dashboard = false

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -212,6 +212,8 @@ module "monitoring" {
   environment                 = var.environment
   project_name                = var.project_name
   enable_cost_anomaly_monitor = var.environment == "production"
+  enable_alarms               = var.enable_monitoring_alarms
+  enable_dashboard            = var.enable_monitoring_dashboard
   api_gateway_id              = module.api.api_gateway_id
   api_access_log_group_name   = module.api.api_access_log_group_name
   api_lambda_log_group_name   = module.api.api_lambda_log_group_name

--- a/infrastructure/modules/monitoring/main.tf
+++ b/infrastructure/modules/monitoring/main.tf
@@ -114,6 +114,8 @@ resource "aws_ce_anomaly_subscription" "alerts" {
 # request/error panels deliberately exclude GET /health so the 30-second
 # synthetic probe cannot swamp the two real users' traffic or error rate.
 resource "aws_cloudwatch_dashboard" "main" {
+  count = var.enable_dashboard ? 1 : 0
+
   dashboard_name = "${var.project_name}-${var.environment}"
 
   dashboard_body = jsonencode({
@@ -275,6 +277,14 @@ resource "aws_cloudwatch_dashboard" "main" {
   })
 }
 
+# Keep the existing (production) dashboard in place now that the resource is
+# counted — without this, adding `count` would move the state address from
+# .main to .main[0] and Terraform would destroy and recreate the dashboard.
+moved {
+  from = aws_cloudwatch_dashboard.main
+  to   = aws_cloudwatch_dashboard.main[0]
+}
+
 data "aws_region" "current" {}
 
 # Health-excluded RED metrics derived from the structured access log. These
@@ -355,6 +365,8 @@ locals {
 # Any Lambda error anywhere in the account/region. Coarse by design — the
 # dashboard's per-function Errors widget gives the attribution.
 resource "aws_cloudwatch_metric_alarm" "lambda_errors_aggregate" {
+  count = var.enable_alarms ? 1 : 0
+
   alarm_name          = "${var.project_name}-lambda-errors-aggregate-${var.environment}"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 2
@@ -381,6 +393,8 @@ resource "aws_cloudwatch_metric_alarm" "lambda_errors_aggregate" {
 # below cover latency for the two functions where it matters, and the
 # dashboard's p95 widget covers the rest.
 resource "aws_cloudwatch_metric_alarm" "lambda_throttles_aggregate" {
+  count = var.enable_alarms ? 1 : 0
+
   alarm_name          = "${var.project_name}-lambda-throttles-aggregate-${var.environment}"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 1
@@ -401,7 +415,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_throttles_aggregate" {
 
 # Per-function alarms for the critical pair only (see strategy note above).
 resource "aws_cloudwatch_metric_alarm" "lambda_errors" {
-  for_each = toset(local.critical_lambda_names)
+  for_each = toset(var.enable_alarms ? local.critical_lambda_names : [])
 
   alarm_name          = "${each.value}-errors"
   comparison_operator = "GreaterThanThreshold"
@@ -429,7 +443,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_errors" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "lambda_duration" {
-  for_each = toset(local.critical_lambda_names)
+  for_each = toset(var.enable_alarms ? local.critical_lambda_names : [])
 
   alarm_name          = "${each.value}-duration"
   comparison_operator = "GreaterThanThreshold"
@@ -456,7 +470,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_duration" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "dynamodb_throttle" {
-  count = var.dynamodb_table_name == "" ? 0 : 1
+  count = var.enable_alarms && var.dynamodb_table_name != "" ? 1 : 0
 
   alarm_name          = "${var.project_name}-ddb-throttle-${var.environment}"
   comparison_operator = "GreaterThanThreshold"
@@ -482,7 +496,7 @@ resource "aws_cloudwatch_metric_alarm" "dynamodb_throttle" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "dynamodb_write_throttle" {
-  count = var.dynamodb_table_name == "" ? 0 : 1
+  count = var.enable_alarms && var.dynamodb_table_name != "" ? 1 : 0
 
   alarm_name          = "${var.project_name}-ddb-write-throttle-${var.environment}"
   comparison_operator = "GreaterThanThreshold"
@@ -507,6 +521,8 @@ resource "aws_cloudwatch_metric_alarm" "dynamodb_write_throttle" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "api_5xx" {
+  count = var.enable_alarms ? 1 : 0
+
   alarm_name          = "${var.project_name}-api-5xx-${var.environment}"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 2
@@ -534,6 +550,8 @@ resource "aws_cloudwatch_metric_alarm" "api_5xx" {
 # current traffic level and must page even when Lambda itself returns a shaped
 # 5xx response (which does not increment the Lambda Errors metric).
 resource "aws_cloudwatch_metric_alarm" "application_5xx" {
+  count = var.enable_alarms ? 1 : 0
+
   alarm_name          = "${var.project_name}-application-5xx-${var.environment}"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 1
@@ -549,6 +567,8 @@ resource "aws_cloudwatch_metric_alarm" "application_5xx" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "application_latency_p95" {
+  count = var.enable_alarms ? 1 : 0
+
   alarm_name          = "${var.project_name}-application-latency-p95-${var.environment}"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 3
@@ -569,6 +589,8 @@ resource "aws_cloudwatch_metric_alarm" "application_latency_p95" {
 # burn (3% errors) sustained across most of six hours. Both use the same
 # health-excluded application request/error metrics as the dashboard.
 resource "aws_cloudwatch_metric_alarm" "availability_fast_burn" {
+  count = var.enable_alarms ? 1 : 0
+
   alarm_name          = "${var.project_name}-availability-fast-burn-${var.environment}"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 12
@@ -610,6 +632,8 @@ resource "aws_cloudwatch_metric_alarm" "availability_fast_burn" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "availability_slow_burn" {
+  count = var.enable_alarms ? 1 : 0
+
   alarm_name          = "${var.project_name}-availability-slow-burn-${var.environment}"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 12
@@ -651,6 +675,8 @@ resource "aws_cloudwatch_metric_alarm" "availability_slow_burn" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "frontend_errors" {
+  count = var.enable_alarms ? 1 : 0
+
   alarm_name          = "${var.project_name}-frontend-errors-${var.environment}"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 1
@@ -670,7 +696,7 @@ resource "aws_cloudwatch_metric_alarm" "frontend_errors" {
 # data loss we want to know about immediately. treat_missing_data=notBreaching
 # so a normally-empty queue (no metric emitted) doesn't false-alarm.
 resource "aws_cloudwatch_metric_alarm" "lambda_dlq_depth" {
-  count = var.lambda_dlq_name == "" ? 0 : 1
+  count = var.enable_alarms && var.lambda_dlq_name != "" ? 1 : 0
 
   alarm_name          = "${var.project_name}-lambda-dlq-not-empty-${var.environment}"
   comparison_operator = "GreaterThanThreshold"
@@ -700,7 +726,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_dlq_depth" {
 # created when a domain is configured. treat_missing_data = notBreaching so a
 # normally-empty queue doesn't false-alarm.
 resource "aws_cloudwatch_metric_alarm" "email_forwarder_dlq_depth" {
-  count = var.email_forwarder_dlq_name == "" ? 0 : 1
+  count = var.enable_alarms && var.email_forwarder_dlq_name != "" ? 1 : 0
 
   alarm_name          = "${var.project_name}-mail-forwarder-dlq-not-empty-${var.environment}"
   comparison_operator = "GreaterThanThreshold"
@@ -742,6 +768,8 @@ resource "aws_cloudwatch_log_metric_filter" "auth_login_failure" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "auth_login_failure_spike" {
+  count = var.enable_alarms ? 1 : 0
+
   alarm_name          = "${var.project_name}-auth-login-failure-spike-${var.environment}"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 1
@@ -756,5 +784,79 @@ resource "aws_cloudwatch_metric_alarm" "auth_login_failure_spike" {
 
   tags = {
     Name = "${var.project_name}-auth-login-failure-alarm-${var.environment}"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# State moves for the alarm gate
+#
+# Adding `count` to a resource that never had one moves its state address from
+# `.name` to `.name[0]`. Without these blocks Terraform would read that as
+# "destroy the old alarm, create a new one" on the next production apply. Each
+# alarm below is a no-op address rewrite; the alarm's own configuration is
+# untouched, so production keeps every alarm it has today.
+# ---------------------------------------------------------------------------
+moved {
+  from = aws_cloudwatch_metric_alarm.lambda_errors_aggregate
+  to   = aws_cloudwatch_metric_alarm.lambda_errors_aggregate[0]
+}
+
+moved {
+  from = aws_cloudwatch_metric_alarm.lambda_throttles_aggregate
+  to   = aws_cloudwatch_metric_alarm.lambda_throttles_aggregate[0]
+}
+
+moved {
+  from = aws_cloudwatch_metric_alarm.api_5xx
+  to   = aws_cloudwatch_metric_alarm.api_5xx[0]
+}
+
+moved {
+  from = aws_cloudwatch_metric_alarm.application_5xx
+  to   = aws_cloudwatch_metric_alarm.application_5xx[0]
+}
+
+moved {
+  from = aws_cloudwatch_metric_alarm.application_latency_p95
+  to   = aws_cloudwatch_metric_alarm.application_latency_p95[0]
+}
+
+moved {
+  from = aws_cloudwatch_metric_alarm.availability_fast_burn
+  to   = aws_cloudwatch_metric_alarm.availability_fast_burn[0]
+}
+
+moved {
+  from = aws_cloudwatch_metric_alarm.availability_slow_burn
+  to   = aws_cloudwatch_metric_alarm.availability_slow_burn[0]
+}
+
+moved {
+  from = aws_cloudwatch_metric_alarm.frontend_errors
+  to   = aws_cloudwatch_metric_alarm.frontend_errors[0]
+}
+
+moved {
+  from = aws_cloudwatch_metric_alarm.auth_login_failure_spike
+  to   = aws_cloudwatch_metric_alarm.auth_login_failure_spike[0]
+}
+
+# An alarm nobody receives is cost without coverage. Every alarm above routes
+# its alarm_actions to aws_sns_topic.alerts, but that topic only gets a
+# subscriber when alert_email or alert_sms_number is set — so a stack can bill
+# ~$0.10/alarm/month to notify a topic with zero destinations and look
+# monitored while being silent. Staging did exactly that (18 alarms plus a
+# dashboard, no subscribers, ~$5.60/mo) before enable_alarms existed.
+#
+# This is a `check`, not a lifecycle precondition, on purpose: it warns on
+# every plan/apply instead of hard-failing, so standing alarms up before the
+# destination is wired stays possible while the gap is impossible to miss.
+check "alarms_have_a_notification_destination" {
+  assert {
+    condition = (
+      !var.enable_alarms ||
+      length(aws_sns_topic_subscription.email) + length(aws_sns_topic_subscription.sms) > 0
+    )
+    error_message = "enable_alarms is true but the ${var.environment} alerts topic has no subscribers: alert_email and alert_sms_number are both empty, so every alarm here notifies nobody while still billing ~$0.10/month. Set alert_email (and/or alert_sms_number) in this environment's tfvars, or set enable_alarms = false."
   }
 }

--- a/infrastructure/modules/monitoring/outputs.tf
+++ b/infrastructure/modules/monitoring/outputs.tf
@@ -4,6 +4,6 @@ output "sns_topic_arn" {
 }
 
 output "dashboard_name" {
-  description = "CloudWatch dashboard name"
-  value       = aws_cloudwatch_dashboard.main.dashboard_name
+  description = "CloudWatch dashboard name, or null when enable_dashboard is false"
+  value       = one(aws_cloudwatch_dashboard.main[*].dashboard_name)
 }

--- a/infrastructure/modules/monitoring/variables.tf
+++ b/infrastructure/modules/monitoring/variables.tf
@@ -8,6 +8,18 @@ variable "project_name" {
   type        = string
 }
 
+variable "enable_alarms" {
+  description = "Create the CloudWatch metric alarms. Each standard alarm bills ~$0.10/mo, so a stack whose alerts topic has no subscribers (see the check block in main.tf) is paying for notifications nobody receives. Production keeps this true; disable only for stacks nobody is on call for."
+  type        = bool
+  default     = true
+}
+
+variable "enable_dashboard" {
+  description = "Create the CloudWatch dashboard. The first three dashboards per account are free, so a second stack's dashboard bills ~$3/mo. Production keeps this true."
+  type        = bool
+  default     = true
+}
+
 variable "enable_cost_anomaly_monitor" {
   description = "Create the account-global Cost Explorer service anomaly monitor. Enable in only one stack per AWS account."
   type        = bool

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -68,6 +68,18 @@ variable "monthly_budget_usd" {
   default     = "50"
 }
 
+variable "enable_monitoring_alarms" {
+  description = "Create the CloudWatch metric alarms (~$0.10/alarm/month). Defaults true so production is unaffected; staging sets it false because its alerts topic has no subscribers, so the alarms notified nobody."
+  type        = bool
+  default     = true
+}
+
+variable "enable_monitoring_dashboard" {
+  description = "Create the CloudWatch dashboard (~$3/month beyond the account's first three). Defaults true so production is unaffected; staging sets it false."
+  type        = bool
+  default     = true
+}
+
 variable "email_from_address" {
   description = "Friendly From header for Cognito mail (signup confirmations, password resets). E.g. 'Family Greenhouse <hello@familygreenhouse.net>'. Required when domain_name is set."
   type        = string


### PR DESCRIPTION
## Why

24 CloudWatch alarms and 1 dashboard were deleted from the live account (~$5.60/month): 18 `family-greenhouse-*-staging` alarms plus the `family-greenhouse-staging` dashboard. They all routed to the `family-greenhouse-alerts-staging` SNS topic, and `environments/staging/terraform.tfvars` sets `alert_email = ""`, so that topic has **zero subscribers** — every one of those alarms fired into nothing.

The deletion was not durable. `infrastructure/modules/monitoring/main.tf` declared the alarms and the dashboard unconditionally, so the next staging `terraform apply` would have recreated all of them and the bill with them. This PR makes it durable.

## What's gated

Two new module variables, `enable_alarms` and `enable_dashboard`, **both defaulting to `true`**, wired through the root variables `enable_monitoring_alarms` / `enable_monitoring_dashboard`. Staging tfvars sets both to `false`; production sets neither and so takes the `true` default.

Gated by `enable_alarms` — all 15 `aws_cloudwatch_metric_alarm` resources in the module:

| Resource | How |
| --- | --- |
| `lambda_errors_aggregate`, `lambda_throttles_aggregate`, `api_5xx`, `application_5xx`, `application_latency_p95`, `availability_fast_burn`, `availability_slow_burn`, `frontend_errors`, `auth_login_failure_spike` | new `count = var.enable_alarms ? 1 : 0` (+ `moved` block, see below) |
| `lambda_errors`, `lambda_duration` (per critical function) | `for_each = toset(var.enable_alarms ? local.critical_lambda_names : [])` — instance keys unchanged when enabled |
| `dynamodb_throttle`, `dynamodb_write_throttle`, `lambda_dlq_depth`, `email_forwarder_dlq_depth` | `enable_alarms` folded into the existing `count` condition; index stays `[0]` |

Gated by `enable_dashboard`: `aws_cloudwatch_dashboard.main`. Its output becomes `one(...)` (null when disabled).

**Not gated**, deliberately: the SNS topic and subscriptions, the four log metric filters, the budget, and Cost Anomaly Detection. They are free or near-free, and the metric filters are the data source the alarms read on the way back up — dropping them would delete SLO history rather than save money.

## Proof production is unaffected

Real `terraform plan` runs against live production state, `-lock=false` (read-only; **no apply was run**). Baseline = `origin/main` in a separate worktree, same state, same tfvars:

```
origin/main   -var-file=environments/production/terraform.tfvars → Plan: 0 to add, 76 to change, 0 to destroy
this branch   -var-file=environments/production/terraform.tfvars → Plan: 0 to add, 76 to change, 0 to destroy
```

Machine-diffing the two plan JSONs (normalising the `[0]` suffix the gate introduces):

```
baseline addresses: 274   new addresses: 274
only in baseline: []
only in new:      []
action differences: {}
baseline production alarms: 19
this branch production alarms: 19
```

Identical plans. All **19 production alarms** are present on both sides, and the dashboard plans as a `no-op` with `previous_address = module.monitoring.aws_cloudwatch_dashboard.main`, confirming the `moved` block rewrote the address instead of destroying it. The 76 `update`s are pre-existing drift on `main` — a `default_tags` change adding lowercase `environment` / `project` tags — identical before and after this PR; the only field differing on any alarm is `tags_all`.

The `moved` blocks matter: adding `count` to a resource that never had one moves its state address from `.name` to `.name[0]`, which Terraform would otherwise read as destroy-and-recreate. There is one `moved` block per newly-counted resource (9 alarms + the dashboard), following the pattern already used for `aws_ce_anomaly_monitor.services`.

## Proof the $5.60/month stays gone

Against live staging state (`key=staging/terraform.tfstate`), same read-only plans:

```
origin/main   -var-file=environments/staging/terraform.tfvars → Plan: 19 to add, 46 to change, 0 to destroy
this branch   -var-file=environments/staging/terraform.tfvars → Plan:  0 to add, 46 to change, 0 to destroy
```

Those 19 creations on `main` are exactly the deleted resources — 18 alarms plus `aws_cloudwatch_dashboard.main` — i.e. confirmation that the next staging apply really would have rebought them. On this branch staging creates 0, destroys 0, and has 0 alarm/dashboard instances left in the plan.

## The deeper problem: alarms with no delivery path

The cost was the symptom; the real defect is that a stack could declare 18 alarms pointing at a topic nobody was subscribed to and look monitored while being silent. The module now carries:

```hcl
check "alarms_have_a_notification_destination" {
  assert {
    condition = (
      !var.enable_alarms ||
      length(aws_sns_topic_subscription.email) + length(aws_sns_topic_subscription.sms) > 0
    )
    ...
  }
}
```

A `check`, not a `lifecycle` precondition, on purpose: it warns on every plan/apply rather than hard-failing, so standing alarms up before their destination is wired stays possible while the gap is impossible to miss. Verified live — planning staging with `-var enable_monitoring_alarms=true` emits:

```
Warning: Check block assertion failed
  on modules/monitoring/main.tf line 856, in check "alarms_have_a_notification_destination":
    │ aws_sns_topic_subscription.email is empty tuple
    │ aws_sns_topic_subscription.sms is empty tuple
    │ var.enable_alarms is true
```

Production passes the check (it has `alert_email = support@familygreenhouse.net`), so no warning there.

## Re-enabling staging monitoring

Set `alert_email` (or `alert_sms_number`) in `environments/staging/terraform.tfvars` **first**, then flip `enable_monitoring_alarms` / `enable_monitoring_dashboard` back to `true`. In that order the alarms are actually useful; in the other order you rebuy the same silent bill, and the check block will say so on every plan. Both the tfvars comment and `docs/observability.md` spell this out.

## Verification

- `terraform fmt -check -recursive` — clean
- `terraform validate` — success (only the deprecation warnings already present on `main`)
- `terraform plan` — four real plans as above; **`terraform apply` was never run and no AWS resource was mutated**
- `npm run verify` (full repo gate: format, lint, typecheck, tests, i18n, `observability:check` 21/21, audit, marker/gate greps) — passed via the pre-push hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)
