### PR TITLE
ci: pin every codeql-action step to v4.37.4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -65,6 +65,15 @@ updates:
     labels:
       - dependencies
       - ci
+    # One PR for the whole CodeQL action set: init, analyze, autobuild and
+    # upload-sarif must always run the same version. Since CodeQL Action
+    # 3.30.4 the non-init steps hard-error when they load a configuration
+    # file written by a different version, so a half-applied bump breaks the
+    # scan rather than merely warning.
+    groups:
+      codeql-action:
+        patterns:
+          - github/codeql-action*
 
   # --- Terraform providers/modules ---
   - package-ecosystem: terraform

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,10 +41,10 @@ jobs:
       - name: Initialize CodeQL
         # javascript-typescript and actions are both interpreted languages
         # (no compile step) — build-mode: none covers both in one run.
-        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           languages: javascript-typescript, actions
           build-mode: none
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -45,6 +45,6 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF results to code scanning
-        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           sarif_file: results.sarif

--- a/renovate.json
+++ b/renovate.json
@@ -10,5 +10,14 @@
       "depNameTemplate": "ChelseaKR/portfolio-standards",
       "datasourceTemplate": "github-releases"
     }
+  ],
+  "packageRules": [
+    {
+      "description": "Move every github/codeql-action/* step in one PR. init, analyze, autobuild and upload-sarif must run the same version: since CodeQL Action 3.30.4 the non-init steps hard-error when they load a configuration file written by a different version.",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["github/codeql-action**"],
+      "groupName": "codeql-action",
+      "minimumReleaseAge": "72 hours"
+    }
   ]
 }


### PR DESCRIPTION
## What was wrong

Nothing was broken: `codeql.yml` (`init`, `analyze`) and `scorecard.yml`
(`upload-sarif`) were all on `7188fc36`, correctly commented `# v4.37.1`.
Three patches behind, and one of ten distinct `codeql-action` versions across
the account.

## What changed

Repin all three steps to `f205ea1c3313d32999d8d6a48b4f6530d4437b38` (`# v4.37.4`).

Add a `codeql-action` group to `.github/dependabot.yml` and `renovate.json`.

## Verifying the target pin

`f205ea1c3313d32999d8d6a48b4f6530d4437b38` is the **commit** that `github/codeql-action`'s
`v4.37.4` tag dereferences to. The tag is annotated, so the tag object
(`ea14db8afdef5d462e69d78c4ca45002d4522418`) is not the same object as the
commit — the commit is `f205ea1c…`, and the moving `v4` tag currently points
at it too. v4.37.4 ships CodeQL bundle 2.26.2.

## Why every file has to carry the same SHA

Since CodeQL Action 3.30.4, the non-`init` steps **hard-error** when they load
a configuration file generated by a different version of the action ("Loaded a
configuration file for version X, but running version Y"), and `init` warns
when a workflow mixes versions. Dependabot and Renovate bump `uses:` lines one
dependency at a time, so `init` can move while `analyze` stays behind — that is
how the skew gets manufactured in the first place. The grouping rule added here
makes every `github/codeql-action/*` step move in a single PR.

Not merged and not readied by me — review at your leisure.
