### PR TITLE
fix: harden activity, grounding, and usage meters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,15 @@ reaches 1.0.0 (pre-1.0: minor bumps may include breaking changes — see
 
 ## [Unreleased]
 
+## [0.23.1] - 2026-08-09
+
 ### Changed
 
+- RAG grounding now recognizes care quantities that carry volume, mass,
+  dilution, repetition, and fertilizer-ratio units, verifies unit-aware dose
+  evidence (including `per` and `/` denominators), and records content-free pass
+  telemetry with checked-claim and source counts. Zero-claim passes are now
+  observable instead of looking identical to a substantive verification.
 - Frontend coverage floors ratcheted from lines 65 / statements 64 / branches
   59 / functions 57 to lines 76 / statements 75 / branches 65 / functions 66
   (`frontend/vitest.config.ts`), backed by new unit coverage for the chat SSE
@@ -39,6 +46,17 @@ reaches 1.0.0 (pre-1.0: minor bumps may include breaking changes — see
 
 ### Fixed
 
+- Household activity now gives every emitted event type a descriptive row,
+  includes imports in the Plants filter, and labels demo leaf-health results
+  as canned rather than durable real assessments. The event renderer and
+  filter exhaustively cover the frontend's declared event union while retaining
+  a safe fallback for older clients that receive a newer event type.
+- Billing usage counters now preserve genuine zeroes while reporting missing
+  or unreadable household counters as unavailable through the additive
+  `usageDetail` response. The legacy `usage` object remains numeric-only and is
+  omitted when incomplete, keeping cached clients safe; current plan meters no
+  longer show unknown usage as `0`, and a known over-limit count still surfaces
+  the post-downgrade warning when the other count is unavailable.
 - README's Code Quality conformance row claimed the backend "clears 80% on
   all four coverage metrics" — untrue for branches, which measured 73.77% at
   the 2026-07-05 rung this claim was written against and 76.01% today. The

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "Family Greenhouse API — AWS Lambda + DynamoDB single-table + Cognito, with a local Express mock that mirrors the handlers.",
   "license": "Elastic-2.0",
   "private": true,

--- a/backend/src/handlers/billing/handler.ts
+++ b/backend/src/handlers/billing/handler.ts
@@ -69,10 +69,11 @@ export const listPlans = createHandler((): Promise<APIGatewayProxyResult> => {
 });
 
 // GET /billing/me
-// Returns the subscription plus current usage against the plan's caps
-// ({plantCount, maxPlants, memberCount, maxMembers}) so the UI can render
-// usage meters and an over-limit notice after a downgrade. Counters missing
-// from legacy METADATA rows read as 0 (see services/householdUsage.ts).
+// Returns the subscription plus current usage against the plan's caps so the
+// UI can render meters and an over-limit notice after a downgrade. The legacy
+// `usage` object remains numeric-only for rolling-deploy/PWA compatibility and
+// is omitted if either counter is unknown. `usageDetail` is the additive,
+// nullable source of truth for current clients.
 export const getCurrentSubscription = createHandler(
   async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
     const { user } = event as AuthenticatedEvent;
@@ -81,14 +82,25 @@ export const getCurrentSubscription = createHandler(
       getHouseholdCounters(user.householdId!),
     ]);
     const plan = getPlan(sub.planId);
+    const usageDetail = {
+      plantCount: counters.plantCount,
+      maxPlants: plan.maxPlants,
+      memberCount: counters.memberCount,
+      maxMembers: plan.maxMembers,
+    };
+    const usage =
+      counters.plantCount !== null && counters.memberCount !== null
+        ? {
+            plantCount: counters.plantCount,
+            maxPlants: plan.maxPlants,
+            memberCount: counters.memberCount,
+            maxMembers: plan.maxMembers,
+          }
+        : undefined;
     return successResponse({
       ...sub,
-      usage: {
-        plantCount: counters.plantCount,
-        maxPlants: plan.maxPlants,
-        memberCount: counters.memberCount,
-        maxMembers: plan.maxMembers,
-      },
+      ...(usage ? { usage } : {}),
+      usageDetail,
     });
   }
 )

--- a/backend/src/handlers/plants/handler.ts
+++ b/backend/src/handlers/plants/handler.ts
@@ -251,28 +251,34 @@ export const createPlant = createHandler(
     // A create WITH a parent records the more specific 'plant.propagated'
     // (instead of, not in addition to, 'plant.created' — one feed row per
     // create) so the feed can tell the propagation story.
-    activity
-      .recordActivity({
-        type: parentPlant ? 'plant.propagated' : 'plant.created',
-        householdId: user.householdId!,
-        actorId: user.userId,
-        actorName: await resolveActorName(user.householdId!, user.userId),
-        payload: parentPlant
-          ? {
-              plantId: plant.id,
-              plantName: plant.name,
-              parentPlantId: parentPlant.id,
-              parentPlantName: parentPlant.name,
-            }
-          : { plantId: plant.id, plantName: plant.name },
-      })
-      .catch((err) => {
-        // Activity-stream rows are advisory, not load-bearing — losing one
-        // doesn't affect correctness of the underlying mutation. Surfacing
-        // the failure as a warn keeps "DDB is degrading" visible in
-        // CloudWatch before the next mutation also fails.
-        logger.warn({ err }, 'activity_record_failed');
-      });
+    const actorName = await resolveActorName(user.householdId!, user.userId);
+    const activityInput: activity.RecordActivityInput = parentPlant
+      ? {
+          type: 'plant.propagated',
+          householdId: user.householdId!,
+          actorId: user.userId,
+          actorName,
+          payload: {
+            plantId: plant.id,
+            plantName: plant.name,
+            parentPlantId: parentPlant.id,
+            parentPlantName: parentPlant.name,
+          },
+        }
+      : {
+          type: 'plant.created',
+          householdId: user.householdId!,
+          actorId: user.userId,
+          actorName,
+          payload: { plantId: plant.id, plantName: plant.name },
+        };
+    activity.recordActivity(activityInput).catch((err) => {
+      // Activity-stream rows are advisory, not load-bearing — losing one
+      // doesn't affect correctness of the underlying mutation. Surfacing
+      // the failure as a warn keeps "DDB is degrading" visible in
+      // CloudWatch before the next mutation also fails.
+      logger.warn({ err }, 'activity_record_failed');
+    });
 
     return createdResponse(plant);
   }
@@ -460,27 +466,29 @@ export const updatePlant = createHandler(
     // restore are operational events; died/gave-away additionally feed the
     // survival metric. Best-effort, same as plant.created.
     if (validatedBody.status && lifecycleBefore?.status !== plant.status) {
-      const lifecycleType = {
-        active: 'plant.restored',
-        archived: 'plant.archived',
-        died: 'plant.died',
-        gave_away: 'plant.gave_away',
-      }[validatedBody.status] as activity.ActivityType;
-      activity
-        .recordActivity({
-          type: lifecycleType,
-          householdId: user.householdId!,
-          actorId: user.userId,
-          actorName: await resolveActorName(user.householdId!, user.userId),
-          payload: {
-            plantId: plant.id,
-            plantName: plant.name,
-            previousStatus: lifecycleBefore?.status,
-          },
-        })
-        .catch((err) => {
-          logger.warn({ err }, 'activity_record_failed');
-        });
+      const actorName = await resolveActorName(user.householdId!, user.userId);
+      const eventBase = {
+        householdId: user.householdId!,
+        actorId: user.userId,
+        actorName,
+        payload: {
+          plantId: plant.id,
+          plantName: plant.name,
+          previousStatus: lifecycleBefore?.status,
+        },
+      };
+      const lifecycleActivityByStatus = {
+        active: { ...eventBase, type: 'plant.restored' },
+        archived: { ...eventBase, type: 'plant.archived' },
+        died: { ...eventBase, type: 'plant.died' },
+        gave_away: { ...eventBase, type: 'plant.gave_away' },
+      } satisfies Record<
+        'active' | 'died' | 'gave_away' | 'archived',
+        activity.RecordActivityInput
+      >;
+      activity.recordActivity(lifecycleActivityByStatus[validatedBody.status]).catch((err) => {
+        logger.warn({ err }, 'activity_record_failed');
+      });
     }
 
     return successResponse(plant);

--- a/backend/src/handlers/plants/health.ts
+++ b/backend/src/handlers/plants/health.ts
@@ -119,7 +119,12 @@ export const checkPlantHealth = createHandler(
         householdId: user.householdId!,
         actorId: user.userId,
         actorName,
-        payload: { plantId: plant.id, plantName: plant.name, overall: assessment.overall },
+        payload: {
+          plantId: plant.id,
+          plantName: plant.name,
+          overall: assessment.overall,
+          demo: assessment.demo === true,
+        },
       })
       .catch((err) => {
         logger.warn({ err }, 'activity_record_failed');

--- a/backend/src/local-server.ts
+++ b/backend/src/local-server.ts
@@ -47,6 +47,7 @@ import { TEMPLATES } from './models/taskTemplates.js';
 import { PLANS, planSummary } from './models/plans.js';
 import { lookupToxicity } from './models/petToxicity.js';
 import { frontendTelemetrySchema, productTelemetrySchema } from './models/telemetry.js';
+import type { ActivityEvent, RecordActivityInput } from './services/activity.js';
 import { isAllowedPushEndpoint } from './services/pushEndpoint.js';
 import {
   COMMERCIAL_HOLD_ACTIVE,
@@ -271,32 +272,6 @@ interface VacationWindow {
   endDate: string;
   createdBy: string;
   createdAt: string;
-}
-
-interface ActivityEvent {
-  id: string;
-  type:
-    | 'task.completed'
-    | 'task.snoozed'
-    | 'task.claimed'
-    | 'task.unclaimed'
-    | 'plant.created'
-    | 'plants.imported'
-    | 'plant.deleted'
-    | 'plant.died'
-    | 'plant.gave_away'
-    | 'plant.archived'
-    | 'plant.restored'
-    | 'plant.propagated'
-    | 'plant.shared_accepted'
-    | 'photo.uploaded'
-    | 'member.joined'
-    | 'member.left';
-  householdId: string;
-  actorId: string;
-  actorName: string;
-  occurredAt: string;
-  payload: Record<string, unknown>;
 }
 
 interface ApiKey {
@@ -663,13 +638,7 @@ function membersOf(householdId: string) {
 }
 
 // Helper for emitting activity events. Mirrors `services/activity.ts`.
-function recordActivity(input: {
-  type: ActivityEvent['type'];
-  householdId: string;
-  actorId: string;
-  actorName: string;
-  payload: Record<string, unknown>;
-}): void {
+function recordActivity(input: RecordActivityInput): void {
   const id = uuidv4();
   db.activity.set(id, {
     id,
@@ -2174,7 +2143,7 @@ app.put(
         archived: 'plant.archived',
         died: 'plant.died',
         gave_away: 'plant.gave_away',
-      }[body.status] as ActivityEvent['type'];
+      }[body.status];
       recordActivity({
         type: lifecycleType,
         householdId: user.householdId,
@@ -2324,9 +2293,9 @@ app.post(
     if (!plant || plant.householdId !== user.householdId) {
       return res.status(404).json({ message: 'Plant not found' });
     }
-    res.json({
+    const assessment = {
       demo: true,
-      overall: 'monitor',
+      overall: 'monitor' as const,
       observations: [
         {
           sign: 'demo mode',
@@ -2338,7 +2307,20 @@ app.post(
         'Keep an eye on the leaf over the next week and compare against a new photo. (Demo response — no analysis was performed.)',
       disclaimer:
         'This is a cosmetic visual check from a single photo, not a plant-health diagnosis.',
+    };
+    recordActivity({
+      type: 'plant.health_checked',
+      householdId: user.householdId,
+      actorId: user.userId,
+      actorName: db.users.get(user.userId)?.name ?? user.email.split('@')[0],
+      payload: {
+        plantId: plant.id,
+        plantName: plant.name,
+        overall: assessment.overall,
+        demo: assessment.demo,
+      },
     });
+    res.json(assessment);
   }
 );
 
@@ -3464,17 +3446,21 @@ app.get('/billing/me', authMiddleware, requireHousehold, (req, res) => {
     (p) => p.householdId === user.householdId && (p.status ?? 'active') === 'active'
   ).length;
   const memberCount = membersOf(user.householdId).length;
+  const usage = {
+    plantCount,
+    maxPlants: plan.maxPlants,
+    memberCount,
+    maxMembers: plan.maxMembers,
+  };
   res.json({
     planId,
     stripeCustomerId: h?.stripeCustomerId,
     stripeSubscriptionId: h?.stripeSubscriptionId,
     status: h?.subscriptionStatus,
-    usage: {
-      plantCount,
-      maxPlants: plan.maxPlants,
-      memberCount,
-      maxMembers: plan.maxMembers,
-    },
+    // Local counts are always available, so expose both the legacy numeric
+    // shape and the additive nullable-capable shape with identical values.
+    usage,
+    usageDetail: usage,
   });
 });
 

--- a/backend/src/services/activity.ts
+++ b/backend/src/services/activity.ts
@@ -14,34 +14,121 @@ import { v4 as uuid } from 'uuid';
 import { dynamodb, TABLE_NAME } from '../utils/dynamodb.js';
 import { logger } from '../utils/logger.js';
 
-export type ActivityType =
-  | 'task.completed'
-  | 'task.snoozed'
-  | 'task.claimed'
-  | 'task.unclaimed'
-  | 'plant.created'
-  | 'plants.imported'
-  | 'plant.deleted'
-  | 'plant.died'
-  | 'plant.gave_away'
-  | 'plant.archived'
-  | 'plant.restored'
-  | 'plant.propagated'
-  | 'plant.shared_accepted'
-  | 'plant.health_checked'
-  | 'photo.uploaded'
-  | 'member.joined'
-  | 'member.left';
+export interface TaskCompletedActivityPayload {
+  taskId: string;
+  plantId: string;
+  plantName?: string;
+  taskType: string;
+  notes?: string | null;
+  viaSitter?: boolean;
+}
 
-export interface ActivityEvent<T = unknown> {
+export interface TaskSnoozedActivityPayload {
+  taskId: string;
+  plantId: string;
+  plantName: string;
+  taskType: string;
+  days: number;
+  reason: 'rain' | 'frost' | 'heat' | 'other' | null;
+  note: string | null;
+}
+
+export interface TaskAssignmentActivityPayload {
+  taskId: string;
+  plantId: string;
+  plantName: string;
+  taskType: string;
+}
+
+export interface PlantIdentityActivityPayload {
+  plantId: string;
+  plantName: string;
+}
+
+export interface PlantLifecycleActivityPayload extends PlantIdentityActivityPayload {
+  previousStatus?: 'active' | 'died' | 'gave_away' | 'archived';
+}
+
+/**
+ * Payload contract keyed by the durable event discriminator. Keeping this as
+ * an explicit map lets both the event envelope and producer input be derived
+ * as discriminated unions, so a type can no longer be paired with another
+ * event's payload by accident.
+ */
+export interface ActivityPayloadByType {
+  'task.completed': TaskCompletedActivityPayload;
+  'task.snoozed': TaskSnoozedActivityPayload;
+  'task.claimed': TaskAssignmentActivityPayload;
+  'task.unclaimed': TaskAssignmentActivityPayload;
+  'plant.created': PlantIdentityActivityPayload;
+  'plants.imported': { count: number };
+  'plant.deleted': PlantIdentityActivityPayload;
+  'plant.died': PlantLifecycleActivityPayload;
+  'plant.gave_away': PlantLifecycleActivityPayload;
+  'plant.archived': PlantLifecycleActivityPayload;
+  'plant.restored': PlantLifecycleActivityPayload;
+  'plant.propagated': PlantIdentityActivityPayload & {
+    parentPlantId: string;
+    parentPlantName: string;
+  };
+  'plant.shared_accepted': PlantIdentityActivityPayload & { fromHouseholdName: string };
+  'plant.health_checked': PlantIdentityActivityPayload & {
+    overall: 'healthy' | 'monitor' | 'concern';
+    demo: boolean;
+  };
+  'photo.uploaded': { plantId: string; photoId: string };
+  'member.joined': { role: 'admin' | 'member' };
+  'member.left': { role?: 'admin' | 'member' };
+}
+
+export type ActivityType = keyof ActivityPayloadByType;
+
+/** Runtime vocabulary used by parity tests and persistence-boundary guards. */
+export const ACTIVITY_TYPES = [
+  'task.completed',
+  'task.snoozed',
+  'task.claimed',
+  'task.unclaimed',
+  'plant.created',
+  'plants.imported',
+  'plant.deleted',
+  'plant.died',
+  'plant.gave_away',
+  'plant.archived',
+  'plant.restored',
+  'plant.propagated',
+  'plant.shared_accepted',
+  'plant.health_checked',
+  'photo.uploaded',
+  'member.joined',
+  'member.left',
+] as const satisfies readonly ActivityType[];
+
+type AssertNever<T extends never> = T;
+export type ActivityTypeListIsComplete = AssertNever<
+  Exclude<ActivityType, (typeof ACTIVITY_TYPES)[number]>
+>;
+
+interface ActivityEventEnvelope {
   id: string;
-  type: ActivityType;
   householdId: string;
   actorId: string;
   actorName: string;
   occurredAt: string;
-  payload: T;
 }
+
+export type ActivityEventByType<T extends ActivityType> = ActivityEventEnvelope & {
+  type: T;
+  payload: ActivityPayloadByType[T];
+};
+
+export type ActivityEvent = {
+  [T in ActivityType]: ActivityEventByType<T>;
+}[ActivityType];
+
+export type RecordActivityInput = {
+  [T in ActivityType]: Omit<ActivityEventByType<T>, 'id' | 'occurredAt'>;
+}[ActivityType];
 
 const MAX_LIMIT = 200;
 
@@ -52,13 +139,7 @@ const MAX_LIMIT = 200;
  * is missing one row," which is far better than a write that succeeded
  * partially.)
  */
-export async function recordActivity<T>(input: {
-  type: ActivityType;
-  householdId: string;
-  actorId: string;
-  actorName: string;
-  payload: T;
-}): Promise<void> {
+export async function recordActivity(input: RecordActivityInput): Promise<void> {
   const id = uuid();
   const now = new Date().toISOString();
   try {
@@ -113,6 +194,10 @@ export async function listActivity(householdId: string, limit = 50): Promise<Act
 
   return (result.Items ?? []).map((item) => {
     if (item.entityType === 'ActivityEvent') {
+      // DynamoDB is a persistence boundary: historical rows predate the
+      // compile-time payload map, so preserve them verbatim. Producers are
+      // checked by RecordActivityInput; the frontend keeps runtime fallbacks
+      // for older/newer rows.
       return {
         id: item.id as string,
         type: item.type as ActivityType,
@@ -121,7 +206,7 @@ export async function listActivity(householdId: string, limit = 50): Promise<Act
         actorName: item.actorName as string,
         occurredAt: item.occurredAt as string,
         payload: item.payload as unknown,
-      };
+      } as ActivityEvent;
     }
     // TaskCompletion legacy shape — fold into the envelope.
     return {

--- a/backend/src/services/chat/groundingGuard.ts
+++ b/backend/src/services/chat/groundingGuard.ts
@@ -7,12 +7,13 @@
  * the household-scoping tests elsewhere cover that it can't leak another
  * household's data).
  *
- * What it checks: numeric/quantitative care claims (a frequency, a
- * percentage, a temperature, a duration — the class of claim that produced
- * the real "missing-data-as-false-answer" bugs fixed in #170/#171) must be
- * traceable to a retrieved span's text. A claim with a number that appears
- * in NO retrieved span is flagged as ungrounded — the model asserted a
- * specific fact the corpus never gave it.
+ * What it checks: numeric/quantitative care claims (a frequency, percentage,
+ * temperature, duration, dose/dilution, or fertilizer ratio — the class of
+ * claim that produced the real "missing-data-as-false-answer" bugs fixed in
+ * #170/#171 and the dose blind spot fixed in #307) must be traceable to a
+ * retrieved span's text. A claim with a number that appears in NO retrieved
+ * span is flagged as ungrounded — the model asserted a specific fact the
+ * corpus never gave it.
  *
  * Deliberately NOT covered (starter-version limitation, see evals/README.md):
  * qualitative claims ("bright indirect light is best for pothos") aren't
@@ -42,20 +43,97 @@ export interface GroundingResult {
   claimsChecked: string[];
 }
 
-// Matches a number followed by a care-relevant unit, OR a bare "every N
-// day(s)/week(s)/month(s)" frequency phrase — the two claim shapes the actual
-// corpus makes ("50%+", "every 2-4 weeks", "70-90%", "below ~40%").
+// Matches a number followed by a care-relevant unit, a bare "every N"
+// frequency phrase, or a numeric mixing/fertilizer ratio. These are claim
+// shapes the actual corpus makes ("50%+", "every 2-4 weeks", "1 tsp per
+// gallon", "3-4 times the pot's volume", and "10-10-10" NPK).
 // No trailing `\b` after the unit alternation: `%` and `°` are already
 // non-word characters, so `\b` never matches right after them (there's no
 // word/non-word transition between "%" and a following space) — that gap
 // silently dropped every percentage claim in earlier testing.
-const CLAIM_PATTERN =
-  /\d+(\.\d+)?\s*(%|percent|degrees?|°[fc]?|days?|weeks?|months?|years?|hours?|minutes?|inches?|in\.|cm|ft|plants?|tasks?|reminders?)(?![a-z])|every\s+\d+/i;
+//
+// Ratio handling is deliberately narrower than "any hyphenated numbers":
+// colon forms accept two or three components, while a hyphen/en-dash
+// form requires three NPK-shaped components. That catches 1:4 and 20-20-20
+// without treating slash-formatted dates or an ISO date such as 2026-08-09
+// as fertilizer claims.
+const NUMBER = String.raw`\d+(?:\.\d+)?`;
+const RATIO_NUMBER = String.raw`\d{1,3}(?:\.\d+)?`;
+const MEASUREMENT_UNIT = String.raw`(?:ml|milliliters?|millilitres?|liters?|litres?|l|fl\.?\s*oz|oz|ounces?|tsp|teaspoons?|tbsp|tablespoons?|cups?|gallons?|quarts?|gal|grams?|mg|g|lbs?|pounds?)`;
+const SENSITIVE_UNIT = String.raw`(?:${MEASUREMENT_UNIT}|times?|parts?)`;
+const CARE_UNIT = String.raw`(?:%|percent|degrees?|°[fc]?|days?|weeks?|months?|years?|hours?|minutes?|inches?|in\.|cm|ft|${SENSITIVE_UNIT}|plants?|tasks?|reminders?)`;
+const COLON_RATIO = String.raw`${RATIO_NUMBER}\s*:\s*${RATIO_NUMBER}(?:\s*:\s*${RATIO_NUMBER})?`;
+const NPK_RATIO = String.raw`${RATIO_NUMBER}\s*[-–]\s*${RATIO_NUMBER}\s*[-–]\s*${RATIO_NUMBER}(?:\s*NPK)?`;
+const CLAIM_PATTERN = new RegExp(
+  String.raw`(?:(?<!\d)(?:${NPK_RATIO}|${COLON_RATIO})(?!\d)|${NUMBER}\s*${CARE_UNIT}(?![a-z])|every\s+${NUMBER})`,
+  'i'
+);
+
+/**
+ * Dose/dilution evidence needs a little more specificity than the legacy
+ * number-anywhere heuristic. `3 tsp` must not be "supported" merely because
+ * the same article separately says `3-4 times`; likewise an NPK ratio must
+ * occur as that ratio, not as three unrelated numbers. Unit aliases and dose
+ * denominators are canonicalized so `1 tsp per gallon` and `1 teaspoon per
+ * gal` remain equivalent, while `1 tsp per cup` does not borrow their support.
+ */
+function canonicalSensitiveUnit(unit: string): string {
+  const compact = unit.toLowerCase().replace(/[.\s]/g, '');
+  if (/^millilit(?:er|re)s?$/.test(compact) || compact === 'ml') return 'ml';
+  if (/^lit(?:er|re)s?$/.test(compact) || compact === 'l') return 'l';
+  if (compact === 'floz' || compact === 'oz' || /^ounces?$/.test(compact)) return 'oz';
+  if (compact === 'tsp' || /^teaspoons?$/.test(compact)) return 'tsp';
+  if (compact === 'tbsp' || /^tablespoons?$/.test(compact)) return 'tbsp';
+  if (/^cups?$/.test(compact)) return 'cup';
+  if (/^gallons?$/.test(compact) || compact === 'gal') return 'gallon';
+  if (/^quarts?$/.test(compact)) return 'quart';
+  if (compact === 'g' || /^grams?$/.test(compact)) return 'g';
+  if (compact === 'mg') return 'mg';
+  if (/^lbs?$/.test(compact) || /^pounds?$/.test(compact)) return 'lb';
+  if (/^times?$/.test(compact)) return 'times';
+  if (/^parts?$/.test(compact)) return 'parts';
+  return compact;
+}
+
+function extractSensitiveEvidence(text: string): Set<string> {
+  const evidence = new Set<string>();
+  const quantityPattern = new RegExp(
+    String.raw`(${NUMBER})\s*(${SENSITIVE_UNIT})(?![a-z])(?:\s*(?:per\b|/)\s*(?:(${NUMBER})\s*)?(${MEASUREMENT_UNIT})(?![a-z]))?`,
+    'gi'
+  );
+  for (const match of text.matchAll(quantityPattern)) {
+    let token = `quantity:${match[1]}:${canonicalSensitiveUnit(match[2])}`;
+    if (match[4]) {
+      const denominatorAmount = match[3];
+      const canonicalDenominator = canonicalSensitiveUnit(match[4]);
+      token +=
+        denominatorAmount && Number(denominatorAmount) !== 1
+          ? `:per:${denominatorAmount}:${canonicalDenominator}`
+          : `:per:${canonicalDenominator}`;
+    }
+    evidence.add(token);
+  }
+
+  const ratioPattern = new RegExp(String.raw`(?<!\d)(?:${NPK_RATIO}|${COLON_RATIO})(?!\d)`, 'gi');
+  for (const match of text.matchAll(ratioPattern)) {
+    evidence.add(`ratio:${extractNumbers(match[0]).join(':')}`);
+  }
+  return evidence;
+}
 
 function splitSentences(text: string): string[] {
-  return text
+  // Keep the period inside the care-unit abbreviation `fl. oz`; the generic
+  // punctuation splitter would otherwise turn `7 fl. oz` into two fragments
+  // and leave both without a recognizable quantitative claim. Restore the
+  // exact user-facing punctuation after splitting so results/logging retain
+  // the original sentence text. Ordinary sentence-ending periods still split.
+  const abbreviationPeriod = '\uE000';
+  const protectedText = text.replace(/\bfl\.(?=\s*oz(?![a-z]))/gi, (match) =>
+    match.replace('.', abbreviationPeriod)
+  );
+  return protectedText
     .split(/(?<=[.!?])\s+/)
-    .map((s) => s.trim())
+    .map((s) => s.replaceAll(abbreviationPeriod, '.').trim())
     .filter(Boolean);
 }
 
@@ -79,6 +157,7 @@ export function checkGrounding(
   const claimSentences = sentences.filter((s) => CLAIM_PATTERN.test(s));
   const corpusText = retrievedSpans.map((s) => s.text).join('\n');
   const corpusNumbers = new Set(extractNumbers(corpusText));
+  const corpusSensitiveEvidence = extractSensitiveEvidence(corpusText);
 
   const ungroundedClaims: string[] = [];
   for (const claim of claimSentences) {
@@ -88,7 +167,13 @@ export function checkGrounding(
     // same sentence (for example, "50% normally, but 92% today"). Numbers that
     // appear in context for an unrelated reason remain an accepted heuristic
     // false-negative risk documented in evals/README.md.
-    const hasSupport = claimNumbers.length === 0 || claimNumbers.every((n) => corpusNumbers.has(n));
+    const sensitiveEvidence = extractSensitiveEvidence(claim);
+    const hasNumberSupport =
+      claimNumbers.length === 0 || claimNumbers.every((n) => corpusNumbers.has(n));
+    const hasSensitiveSupport = [...sensitiveEvidence].every((token) =>
+      corpusSensitiveEvidence.has(token)
+    );
+    const hasSupport = hasNumberSupport && hasSensitiveSupport;
     if (!hasSupport) ungroundedClaims.push(claim);
   }
 

--- a/backend/src/services/chat/index.ts
+++ b/backend/src/services/chat/index.ts
@@ -704,6 +704,7 @@ async function* turnEvents(
 
       if (response.stopReason !== 'tool_use' && retrievedSpans.length > 0) {
         const grounding = checkGrounding(extractAssistantText(response.content), retrievedSpans);
+        const sourceCount = new Set(retrievedSpans.map((span) => span.source)).size;
         if (!grounding.grounded) {
           // Never log the claim text: chat content can itself contain PII.
           logger.warn(
@@ -711,7 +712,7 @@ async function* turnEvents(
               conversationId,
               claimsChecked: grounding.claimsChecked.length,
               ungroundedClaimCount: grounding.ungroundedClaims.length,
-              sourceCount: new Set(retrievedSpans.map((span) => span.source)).size,
+              sourceCount,
             },
             'chat_grounding_blocked'
           );
@@ -719,6 +720,18 @@ async function* turnEvents(
             ...response,
             content: [{ type: 'text', text: GROUNDING_BLOCK_MESSAGE }],
           };
+        } else {
+          // A clean pass and a vacuous pass (zero recognized claims) must be
+          // distinguishable in production. Counts only: never log answer or
+          // source text, which can contain user-provided/PII-bearing content.
+          logger.info(
+            {
+              conversationId,
+              claimsChecked: grounding.claimsChecked.length,
+              sourceCount,
+            },
+            'chat_grounding_checked'
+          );
         }
       }
 

--- a/backend/src/services/householdUsage.ts
+++ b/backend/src/services/householdUsage.ts
@@ -7,20 +7,22 @@
  * Used by GET /billing/me to surface "n of max" usage so the UI can show
  * meters and an over-limit banner after a downgrade. Deliberately tolerant:
  * legacy households predate the counters and the backfill is lazy, so a
- * missing attribute (or even a failed read) reports 0 rather than erroring —
- * billing/me must never 500 because a counter hasn't been seeded yet.
+ * missing attribute (or even a failed read) reports null rather than erroring
+ * or inventing a zero — billing/me must never 500 because a counter hasn't
+ * been seeded yet, but callers must still be able to distinguish "none" from
+ * "not known".
  */
 import { GetCommand } from '@aws-sdk/lib-dynamodb';
 import { dynamodb, TABLE_NAME } from '../utils/dynamodb.js';
 import { logger } from '../utils/logger.js';
 
 export interface HouseholdCounters {
-  plantCount: number;
-  memberCount: number;
+  plantCount: number | null;
+  memberCount: number | null;
 }
 
-function asCount(value: unknown): number {
-  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : 0;
+function asCount(value: unknown): number | null {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0 ? value : null;
 }
 
 export async function getHouseholdCounters(householdId: string): Promise<HouseholdCounters> {
@@ -31,12 +33,19 @@ export async function getHouseholdCounters(householdId: string): Promise<Househo
         Key: { PK: `HOUSEHOLD#${householdId}`, SK: 'METADATA' },
       })
     );
-    return {
+    const counters: HouseholdCounters = {
       plantCount: asCount(result.Item?.plantCount),
       memberCount: asCount(result.Item?.memberCount),
     };
+    const unavailableCounters = (['plantCount', 'memberCount'] as const).filter(
+      (counter) => counters[counter] === null
+    );
+    if (unavailableCounters.length > 0) {
+      logger.warn({ householdId, unavailableCounters }, 'household_counters_unseeded');
+    }
+    return counters;
   } catch (err) {
     logger.warn({ err: (err as Error).message, householdId }, 'household_counters_read_failed');
-    return { plantCount: 0, memberCount: 0 };
+    return { plantCount: null, memberCount: null };
   }
 }

--- a/backend/tests/integration/local-server.test.ts
+++ b/backend/tests/integration/local-server.test.ts
@@ -929,6 +929,37 @@ describe('GET /households/:id/activity', () => {
   });
 });
 
+describe('POST /plants/:id/health-check activity', () => {
+  it('labels the local canned result as demo data in the durable activity payload', async () => {
+    const token = await loginAsSeed();
+    const check = await request(app)
+      .post(`/plants/${seedPlantId}/health-check`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ imageBase64: 'A'.repeat(64) });
+
+    expect(check.status).toBe(200);
+    expect(check.body).toMatchObject({ demo: true, overall: 'monitor' });
+
+    const activity = await request(app)
+      .get(`/households/${seedHouseholdId}/activity`)
+      .set('Authorization', `Bearer ${token}`);
+    const event = activity.body.find(
+      (candidate: { type: string }) => candidate.type === 'plant.health_checked'
+    );
+    expect(event).toMatchObject({
+      type: 'plant.health_checked',
+      householdId: seedHouseholdId,
+      actorId: seedUserId,
+      payload: {
+        plantId: seedPlantId,
+        plantName: 'Monstera',
+        overall: 'monitor',
+        demo: true,
+      },
+    });
+  });
+});
+
 describe('DELETE /me', () => {
   it('refuses when caller is sole admin of a multi-member household', async () => {
     db.users.set('member-x', {
@@ -1965,6 +1996,13 @@ describe('billing', () => {
     const res = await request(app).get('/billing/me').set('Authorization', `Bearer ${token}`);
     expect(res.status).toBe(200);
     expect(res.body.planId).toBe('seedling');
+    expect(res.body.usageDetail).toEqual(res.body.usage);
+    expect(res.body.usage).toMatchObject({
+      plantCount: expect.any(Number),
+      memberCount: expect.any(Number),
+      maxPlants: expect.any(Number),
+      maxMembers: expect.any(Number),
+    });
   });
 
   it('admin checkout fails closed without changing the plan', async () => {

--- a/backend/tests/unit/handlers/billing.test.ts
+++ b/backend/tests/unit/handlers/billing.test.ts
@@ -131,7 +131,7 @@ describe('billing handler', () => {
       expect(billing.getHouseholdSubscription).toHaveBeenCalledWith('hh-1');
     });
 
-    it('includes usage (counters + plan caps) so the UI can render meters', async () => {
+    it('includes matching legacy usage and nullable-capable detail when both counters are known', async () => {
       const billing = await import('../../../src/services/billing.js');
       const { getCurrentSubscription } = await import('../../../src/handlers/billing/handler.js');
       vi.mocked(billing.getHouseholdSubscription).mockResolvedValueOnce({ planId: 'garden' });
@@ -144,12 +144,15 @@ describe('billing handler', () => {
       )) as APIGatewayProxyResult;
 
       expect(res.statusCode).toBe(200);
-      expect(JSON.parse(res.body).usage).toEqual({
+      const body = JSON.parse(res.body);
+      const expectedUsage = {
         plantCount: 42,
         maxPlants: 500,
         memberCount: 3,
         maxMembers: 6,
-      });
+      };
+      expect(body.usage).toEqual(expectedUsage);
+      expect(body.usageDetail).toEqual(expectedUsage);
       expect(getHouseholdCounters).toHaveBeenCalledWith('hh-1');
     });
 
@@ -166,17 +169,22 @@ describe('billing handler', () => {
         () => {}
       )) as APIGatewayProxyResult;
 
-      const usage = JSON.parse(res.body).usage;
+      const body = JSON.parse(res.body);
+      const usage = body.usage;
       expect(usage).toEqual({ plantCount: 25, maxPlants: 10, memberCount: 8, maxMembers: 6 });
+      expect(body.usageDetail).toEqual(usage);
       expect(usage.plantCount).toBeGreaterThan(usage.maxPlants);
       expect(usage.memberCount).toBeGreaterThan(usage.maxMembers);
     });
 
-    it('tolerates missing counters (legacy households) as zero usage', async () => {
+    it('omits legacy usage and preserves partial knowledge in usageDetail', async () => {
       const billing = await import('../../../src/services/billing.js');
       const { getCurrentSubscription } = await import('../../../src/handlers/billing/handler.js');
-      vi.mocked(billing.getHouseholdSubscription).mockResolvedValueOnce({ planId: 'greenhouse' });
-      // Default beforeEach mock: { plantCount: 0, memberCount: 0 }.
+      vi.mocked(billing.getHouseholdSubscription).mockResolvedValueOnce({ planId: 'seedling' });
+      vi.mocked(getHouseholdCounters).mockResolvedValueOnce({
+        plantCount: 25,
+        memberCount: null,
+      });
 
       const res = (await getCurrentSubscription(
         buildEvent({ httpMethod: 'GET' }),
@@ -184,11 +192,14 @@ describe('billing handler', () => {
         () => {}
       )) as APIGatewayProxyResult;
 
-      expect(JSON.parse(res.body).usage).toEqual({
-        plantCount: 0,
-        maxPlants: 5000,
-        memberCount: 0,
-        maxMembers: 50,
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(body).not.toHaveProperty('usage');
+      expect(body.usageDetail).toEqual({
+        plantCount: 25,
+        maxPlants: 10,
+        memberCount: null,
+        maxMembers: 6,
       });
     });
 

--- a/backend/tests/unit/handlers/plantHealthCheck.test.ts
+++ b/backend/tests/unit/handlers/plantHealthCheck.test.ts
@@ -95,7 +95,12 @@ describe('plants health-check handler', () => {
         householdId: 'hh-1',
         actorId: 'user-1',
         actorName: 'Chelsea',
-        payload: { plantId: 'plant-1', plantName: 'Fernie', overall: 'monitor' },
+        payload: {
+          plantId: 'plant-1',
+          plantName: 'Fernie',
+          overall: 'monitor',
+          demo: false,
+        },
       })
     );
     // A real (non-demo) assessment was reserved before Bedrock ran.
@@ -138,6 +143,16 @@ describe('plants health-check handler', () => {
     expect(res.statusCode).toBe(200);
     expect(leafHealthBudget.releaseUsage).toHaveBeenCalledWith('hh-1');
     expect(leafHealthBudget.incrementUsage).not.toHaveBeenCalled();
+    expect(activity.recordActivity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'plant.health_checked',
+        payload: expect.objectContaining({
+          plantId: 'plant-1',
+          overall: 'monitor',
+          demo: true,
+        }),
+      })
+    );
   });
 
   it('fails closed before Bedrock when the atomic reservation is unavailable', async () => {

--- a/backend/tests/unit/services/activity.test.ts
+++ b/backend/tests/unit/services/activity.test.ts
@@ -26,7 +26,7 @@ describe('activity service', () => {
       householdId: 'hh',
       actorId: 'u1',
       actorName: 'A',
-      payload: { plantId: 'p1' },
+      payload: { plantId: 'p1', plantName: 'Fernie' },
     });
 
     const cmd = vi.mocked(dynamodb.send).mock.calls[0][0] as unknown as {
@@ -50,7 +50,7 @@ describe('activity service', () => {
         householdId: 'hh',
         actorId: 'u1',
         actorName: 'A',
-        payload: {},
+        payload: { role: 'member' },
       })
     ).resolves.toBeUndefined();
   });

--- a/backend/tests/unit/services/activityContract.test.ts
+++ b/backend/tests/unit/services/activityContract.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const repositoryRoot = new URL('../../../../', import.meta.url);
+
+function activityTypes(relativePath: string): string[] {
+  const source = readFileSync(new URL(relativePath, repositoryRoot), 'utf8');
+  const marker = 'export const ACTIVITY_TYPES = [';
+  const start = source.indexOf(marker);
+  const end = source.indexOf('] as const', start);
+
+  if (start < 0 || end < 0) {
+    throw new Error(`Could not find ACTIVITY_TYPES in ${relativePath}`);
+  }
+
+  return [...source.slice(start, end).matchAll(/'([a-z]+(?:[._][a-z]+)+)'/gu)].map(
+    ([, type]) => type
+  );
+}
+
+describe('activity contract parity', () => {
+  it('keeps the frontend and backend discriminator vocabularies identical', () => {
+    const backendTypes = activityTypes('backend/src/services/activity.ts');
+    const frontendTypes = activityTypes('frontend/src/services/householdService.ts');
+
+    expect(backendTypes).not.toHaveLength(0);
+    expect(new Set(backendTypes).size).toBe(backendTypes.length);
+    expect(new Set(frontendTypes).size).toBe(frontendTypes.length);
+    expect(frontendTypes).toEqual(backendTypes);
+  });
+});

--- a/backend/tests/unit/services/chatGroundingGuard.test.ts
+++ b/backend/tests/unit/services/chatGroundingGuard.test.ts
@@ -11,6 +11,16 @@ const FERTILIZING_SPAN: RetrievedSpan = {
   text: 'Growing season (spring + summer): every 2-4 weeks at half the recommended strength.',
 };
 
+const DOSING_SPAN: RetrievedSpan = {
+  source: 'fertilizing.md',
+  text: [
+    'For liquid concentrate, dilute to about 1 tsp per gallon of water.',
+    'Use a balanced 10-10-10 or 20-20-20 fertilizer.',
+    "Flush with 3-4 times the pot's volume of water.",
+    'Mix one batch at a 1:4 concentrate-to-water ratio.',
+  ].join(' '),
+};
+
 describe('checkGrounding (AIEV-12 citation/grounding guard)', () => {
   it('is vacuously grounded when the answer makes no quantitative claim', () => {
     const result = checkGrounding('Bright indirect light is best for most tropical houseplants.', [
@@ -34,6 +44,126 @@ describe('checkGrounding (AIEV-12 citation/grounding guard)', () => {
       FERTILIZING_SPAN,
     ]);
     expect(result.grounded).toBe(true);
+  });
+
+  it.each([
+    ['Dilute your fertilizer to 3 tsp per gallon for best results.', /3 tsp/],
+    ['Use a 40-5-5 NPK fertilizer for flowering houseplants.', /40-5-5/],
+    ['Flush the pot with 9 times its volume of water.', /9 times/],
+    ['Mix 15 ml of neem oil into 1 liter of water and spray weekly.', /15 ml/],
+    ['Water your monstera 5 times a week.', /5 times/],
+  ])('flags the issue #307 fabricated dose/ratio example: %s', (answer, expectedClaim) => {
+    const result = checkGrounding(answer, [DOSING_SPAN]);
+
+    expect(result.grounded).toBe(false);
+    expect(result.claimsChecked).toHaveLength(1);
+    expect(result.ungroundedClaims).toHaveLength(1);
+    expect(result.ungroundedClaims[0]).toMatch(expectedClaim);
+  });
+
+  it.each([
+    'Dilute to 1 tsp per gallon of water.',
+    "Flush with 3-4 times the pot's volume of water.",
+    'Use a balanced 10-10-10 fertilizer.',
+    'Mix it at a 1:4 concentrate-to-water ratio.',
+  ])('accepts a supported dose or ratio claim: %s', (answer) => {
+    const result = checkGrounding(answer, [DOSING_SPAN]);
+
+    expect(result.grounded).toBe(true);
+    expect(result.claimsChecked).toHaveLength(1);
+    expect(result.ungroundedClaims).toHaveLength(0);
+  });
+
+  it.each([
+    ['Apply 1 teaspoon per gallon.', 'Use 1 tsp per 1 gal.'],
+    ['Apply 15 millilitres per litre.', 'Use 15 ml per liter.'],
+    ['Apply 2 ounces per pound.', 'Use 2 oz per lb.'],
+    ['Apply 1 tablespoon/cup.', 'Use 1 tbsp per cup.'],
+    ['Apply 7 ounces per gallon.', 'Use 7 fl. oz per gal.'],
+  ])('canonicalizes supported numerator and denominator aliases: %s', (source, answer) => {
+    const result = checkGrounding(answer, [{ source: 'dose.md', text: source }]);
+
+    expect(result.grounded).toBe(true);
+    expect(result.claimsChecked).toHaveLength(1);
+  });
+
+  it('does not let a supported numerator ground a substituted dose denominator', () => {
+    const result = checkGrounding('Dilute to 1 teaspoon per cup of water.', [DOSING_SPAN]);
+
+    expect(result.grounded).toBe(false);
+    expect(result.claimsChecked).toHaveLength(1);
+    expect(result.ungroundedClaims).toEqual(['Dilute to 1 teaspoon per cup of water.']);
+  });
+
+  it('distinguishes a multi-unit denominator from an implicit one-unit denominator', () => {
+    const result = checkGrounding('Dilute to 1 tsp per gallon.', [
+      { source: 'dose.md', text: 'Dilute to 1 teaspoon per 2 gallons.' },
+    ]);
+
+    expect(result.grounded).toBe(false);
+    expect(result.claimsChecked).toHaveLength(1);
+  });
+
+  it('keeps fl. oz together while splitting ordinary sentences', () => {
+    const result = checkGrounding(
+      'Mix gently. Apply 7 fl. oz per gallon. Stop if the leaves react.',
+      []
+    );
+
+    expect(result.grounded).toBe(false);
+    expect(result.claimsChecked).toEqual(['Apply 7 fl. oz per gallon.']);
+    expect(result.ungroundedClaims).toEqual(['Apply 7 fl. oz per gallon.']);
+  });
+
+  it.each([
+    '7 ml',
+    '7 milliliters',
+    '7 millilitres',
+    '7 l',
+    '7 liters',
+    '7 litres',
+    '7 oz',
+    '7 ounces',
+    '7 tsp',
+    '7 teaspoons',
+    '7 tbsp',
+    '7 tablespoons',
+    '7 cups',
+    '7 gallons',
+    '7 quarts',
+    '7 g',
+    '7 grams',
+    '7 mg',
+    '7 lb',
+    '7 lbs',
+    '7 pounds',
+    '7 parts',
+  ])('recognizes the added volume/mass/dilution unit %s', (quantity) => {
+    const result = checkGrounding(`Apply ${quantity} during feeding.`, []);
+
+    expect(result.grounded).toBe(false);
+    expect(result.claimsChecked).toHaveLength(1);
+  });
+
+  it('recognizes three-part NPK ratios with an en dash and generic colon ratios', () => {
+    const result = checkGrounding(
+      'Use 12–4–8 NPK for growth. Mix the concentrate at 1:6 before applying it.',
+      []
+    );
+
+    expect(result.grounded).toBe(false);
+    expect(result.claimsChecked).toHaveLength(2);
+    expect(result.ungroundedClaims).toHaveLength(2);
+  });
+
+  it('does not treat unit-name prefixes or ISO dates as quantitative care claims', () => {
+    const result = checkGrounding(
+      'The 7 gramophones arrived on 2026-08-09; the visit was 8/9, and 4 timeshares were discussed.',
+      []
+    );
+
+    expect(result.grounded).toBe(true);
+    expect(result.claimsChecked).toHaveLength(0);
   });
 
   it('flags a fabricated numeric claim with no support in any retrieved span', () => {

--- a/backend/tests/unit/services/chatTurn.test.ts
+++ b/backend/tests/unit/services/chatTurn.test.ts
@@ -98,6 +98,7 @@ import * as plantService from '../../../src/services/plantService.js';
 import * as climateService from '../../../src/services/climate.js';
 import * as householdService from '../../../src/services/householdService.js';
 import { searchCorpus } from '../../../src/services/chat/corpus.js';
+import { logger } from '../../../src/utils/logger.js';
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -390,6 +391,108 @@ describe('runChatTurn', () => {
     const persistedAnswer = vi.mocked(appendMessage).mock.calls.at(-1)?.[1];
     expect(persistedAnswer?.content).toEqual([{ type: 'text', text: GROUNDING_BLOCK_MESSAGE }]);
     expect(JSON.stringify(persistedAnswer)).not.toContain('92%');
+  });
+
+  it('logs a grounded pass with claim and source counts, including a zero-claim pass', async () => {
+    const infoSpy = vi.spyOn(logger, 'info');
+    vi.mocked(searchCorpus).mockResolvedValueOnce([
+      {
+        articleTitle: 'Lighting',
+        sectionTitle: 'Indirect light',
+        source: 'light-requirements.md',
+        text: 'Bright indirect light suits many tropical houseplants.',
+        score: 0.92,
+      },
+    ]);
+    vi.mocked(invokeChatModel)
+      .mockResolvedValueOnce({
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tu-rag-observability',
+            name: 'search_care_knowledge',
+            input: { query: 'tropical plant lighting' },
+          },
+        ],
+        stopReason: 'tool_use',
+        inputTokens: 100,
+        outputTokens: 10,
+        costUsd: 0.0003,
+      })
+      .mockResolvedValueOnce({
+        content: [{ type: 'text', text: 'Bright indirect light is a good starting point.' }],
+        stopReason: 'end_turn',
+        inputTokens: 120,
+        outputTokens: 15,
+        costUsd: 0.0004,
+      });
+
+    const result = await runChatTurn({
+      userId: 'u1',
+      householdId: 'hh-1',
+      message: 'What light should I provide?',
+    });
+
+    expect(result.assistantText).toBe('Bright indirect light is a good starting point.');
+    expect(infoSpy).toHaveBeenCalledWith(
+      {
+        conversationId: 'conv-1',
+        claimsChecked: 0,
+        sourceCount: 1,
+      },
+      'chat_grounding_checked'
+    );
+  });
+
+  it('logs a grounded quantitative pass with a nonzero checked-claim count', async () => {
+    const infoSpy = vi.spyOn(logger, 'info');
+    vi.mocked(searchCorpus).mockResolvedValueOnce([
+      {
+        articleTitle: 'Humidity',
+        sectionTitle: 'Tropicals',
+        source: 'humidity-tropicals.md',
+        text: 'Calatheas prefer at least 50% humidity.',
+        score: 0.92,
+      },
+    ]);
+    vi.mocked(invokeChatModel)
+      .mockResolvedValueOnce({
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tu-rag-quantitative-observability',
+            name: 'search_care_knowledge',
+            input: { query: 'calathea humidity' },
+          },
+        ],
+        stopReason: 'tool_use',
+        inputTokens: 100,
+        outputTokens: 10,
+        costUsd: 0.0003,
+      })
+      .mockResolvedValueOnce({
+        content: [{ type: 'text', text: 'Aim for at least 50% humidity.' }],
+        stopReason: 'end_turn',
+        inputTokens: 120,
+        outputTokens: 15,
+        costUsd: 0.0004,
+      });
+
+    const result = await runChatTurn({
+      userId: 'u1',
+      householdId: 'hh-1',
+      message: 'What humidity does a calathea need?',
+    });
+
+    expect(result.assistantText).toBe('Aim for at least 50% humidity.');
+    expect(infoSpy).toHaveBeenCalledWith(
+      {
+        conversationId: 'conv-1',
+        claimsChecked: 1,
+        sourceCount: 1,
+      },
+      'chat_grounding_checked'
+    );
   });
 
   it('accepts a current authoritative tool number when historical RAG keeps the guard active', async () => {

--- a/backend/tests/unit/services/householdUsage.test.ts
+++ b/backend/tests/unit/services/householdUsage.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+  GetCommand: vi.fn(function (input) {
+    return { input, kind: 'Get' };
+  }),
+}));
+
+vi.mock('../../../src/utils/dynamodb.js', () => ({
+  dynamodb: { send: vi.fn() },
+  TABLE_NAME: 'test-table',
+}));
+
+vi.mock('../../../src/utils/logger.js', () => ({
+  logger: { warn: vi.fn() },
+}));
+
+import { getHouseholdCounters } from '../../../src/services/householdUsage.js';
+import { dynamodb } from '../../../src/utils/dynamodb.js';
+import { logger } from '../../../src/utils/logger.js';
+
+describe('getHouseholdCounters', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('preserves genuine zero and positive counts', async () => {
+    vi.mocked(dynamodb.send).mockResolvedValueOnce({
+      Item: { plantCount: 0, memberCount: 3 },
+    } as never);
+
+    await expect(getHouseholdCounters('hh-1')).resolves.toEqual({
+      plantCount: 0,
+      memberCount: 3,
+    });
+    expect(logger.warn).not.toHaveBeenCalled();
+
+    const command = vi.mocked(dynamodb.send).mock.calls[0][0] as unknown as {
+      kind: string;
+      input: { TableName: string; Key: { PK: string; SK: string } };
+    };
+    expect(command).toMatchObject({
+      kind: 'Get',
+      input: {
+        TableName: 'test-table',
+        Key: { PK: 'HOUSEHOLD#hh-1', SK: 'METADATA' },
+      },
+    });
+  });
+
+  it('returns null for each missing counter and logs the unseeded state', async () => {
+    vi.mocked(dynamodb.send).mockResolvedValueOnce({
+      Item: { plantCount: 7 },
+    } as never);
+
+    await expect(getHouseholdCounters('legacy-hh')).resolves.toEqual({
+      plantCount: 7,
+      memberCount: null,
+    });
+    expect(logger.warn).toHaveBeenCalledWith(
+      { householdId: 'legacy-hh', unavailableCounters: ['memberCount'] },
+      'household_counters_unseeded'
+    );
+  });
+
+  it.each([
+    ['negative', -1],
+    ['fractional', 1.5],
+    ['infinite', Number.POSITIVE_INFINITY],
+    ['unsafe integer', Number.MAX_SAFE_INTEGER + 1],
+  ])('treats a %s stored counter as unavailable', async (_label, value) => {
+    vi.mocked(dynamodb.send).mockResolvedValueOnce({
+      Item: { plantCount: value, memberCount: 1 },
+    } as never);
+
+    await expect(getHouseholdCounters('invalid-hh')).resolves.toEqual({
+      plantCount: null,
+      memberCount: 1,
+    });
+    expect(logger.warn).toHaveBeenCalledWith(
+      { householdId: 'invalid-hh', unavailableCounters: ['plantCount'] },
+      'household_counters_unseeded'
+    );
+  });
+
+  it('returns unknown counters and a distinct log event when the read fails', async () => {
+    vi.mocked(dynamodb.send).mockRejectedValueOnce(new Error('DynamoDB unavailable') as never);
+
+    await expect(getHouseholdCounters('hh-2')).resolves.toEqual({
+      plantCount: null,
+      memberCount: null,
+    });
+    expect(logger.warn).toHaveBeenCalledWith(
+      { err: 'DynamoDB unavailable', householdId: 'hh-2' },
+      'household_counters_read_failed'
+    );
+    expect(logger.warn).not.toHaveBeenCalledWith(expect.anything(), 'household_counters_unseeded');
+  });
+});

--- a/docs/RESPONSIBLE-TECH-AUDITS.md
+++ b/docs/RESPONSIBLE-TECH-AUDITS.md
@@ -1,6 +1,8 @@
 # Responsible-Tech Audits — family-greenhouse
 
-Instantiates `STANDARDS/RESPONSIBLE-TECH-FRAMEWORK.md`. Last regenerated: 2026-07-13 (baseline created 2026-07-05; controls re-verified and documented gaps drained 2026-07-13).
+Instantiates `STANDARDS/RESPONSIBLE-TECH-FRAMEWORK.md`. Last regenerated:
+2026-08-09 (baseline created 2026-07-05; quantitative grounding scope and
+observability re-verified 2026-08-09).
 
 This is the detail layer behind the README's `## Standards conformance` table. Where a control needs a number or a mechanical gate, it's owned by the sibling standard and only referenced here (per the framework's "reference, don't repeat" rule).
 
@@ -53,7 +55,7 @@ This is the detail layer behind the README's `## Standards conformance` table. W
 **Findings:** Every chat answer is attributable to either a tool call (the user's own data — inherently sourced) or the RAG corpus (`search_care_knowledge` → `backend/src/data/plant-care-corpus/`). Model card: [`model-card.md`](../model-card.md).
 
 - **Commitment:** model card exists with intended/out-of-scope use, known failure modes, and eval-baseline reference. The persistent chat composer footer says "AI-generated — verify before acting," remains visible throughout the conversation, and is asserted in the authenticated responsive Playwright flow (`responsive-ux.spec.ts`).
-- **Gate:** AUTO-GATE — the citation/grounding guard is unit-tested and wired into the live `turnEvents` RAG path. It checks every quantitative token in the completed answer against retrieved spans before persistence or delivery; a failed answer is replaced by a safe verification message. RAG streaming text is held until the same guard passes, with sync and streaming regression tests. The deterministic starter benchmark still checks retrieval recall only; the full live-model scoring waiver below remains in force.
+- **Gate:** AUTO-GATE — the citation/grounding guard is unit-tested and wired into the live `turnEvents` RAG path. It checks recognized care-relevant quantitative claims (frequency, percentage, temperature, duration, length, volume, mass, dose/dilution, repetition, and fertilizer ratios) against retrieved spans before persistence or delivery; a failed answer is replaced by a safe verification message. RAG streaming text is held until the same guard passes, with sync and streaming regression tests. Content-free pass telemetry distinguishes substantive checks from zero-recognized-claim passes; the guard remains a selective heuristic rather than semantic entailment. The deterministic starter benchmark still checks retrieval recall only; the full live-model scoring waiver below remains in force. See [ADR 0008](adr/0008-unit-aware-rag-grounding.md).
 
 ## E. Accessibility audit
 
@@ -89,7 +91,7 @@ AI-Evaluation-Standard: APPLIES (tiers: tool-use + RAG, citation/grounding guard
 >
 > The following AI-EVALUATION-STANDARD gates are **not yet fully wired** and are explicitly waived, not silently skipped, until the expiry date above:
 >
-> - **§1 full RAGAS/DeepEval three-layer metric suite** (faithfulness ≥0.80, context recall/precision, answer relevancy, citation accuracy, hallucination rate, refusal correctness, per-segment breakdown, TruthfulQA drift). This standard's reference tooling is Python (`uv run pytest`); this is a Node/TypeScript monorepo. **What exists instead:** a starter benchmark (`evals/benchmark.jsonl`, 22 questions across all 11 corpus articles — the standard's target is 100–500) and a live citation/grounding guard (`backend/src/services/chat/groundingGuard.ts` + sync/stream tests) that checks retrieved context and blocks unsupported numeric care claims before delivery. This is a real, CI-gated starter, **not** the full RAGAS metric suite — no faithfulness/hallucination/refusal scoring against live model output exists yet, because that requires calling live Bedrock, which is out of scope for an offline CI gate without a dedicated eval-run budget and is not something this remediation pass executes against real AWS infrastructure.
+> - **§1 full RAGAS/DeepEval three-layer metric suite** (faithfulness ≥0.80, context recall/precision, answer relevancy, citation accuracy, hallucination rate, refusal correctness, per-segment breakdown, TruthfulQA drift). This standard's reference tooling is Python (`uv run pytest`); this is a Node/TypeScript monorepo. **What exists instead:** a 134-item starter benchmark (`evals/benchmark.jsonl`) across the 11 corpus articles and labeled adversarial classes, plus a live citation/grounding guard (`backend/src/services/chat/groundingGuard.ts` + sync/stream tests) that checks retrieved context and blocks unsupported recognized quantitative care claims before delivery. This is a real, CI-gated starter, **not** the full RAGAS metric suite — no faithfulness/hallucination/refusal scoring against live model output exists yet, because that requires calling live Bedrock, which is out of scope for an offline CI gate without a dedicated eval-run budget and is not something this remediation pass executes against real AWS infrastructure.
 > - **§2 red-team / Promptfoo OWASP-LLM scan + Garak baseline.** Partially addressed 2026-07-17. What now exists: a **structured, mapped, CI-gated injection-corpus exercise** — `evals/redteam/injection-corpus.json` (9 payloads tagged OWASP LLM01/02/06) run through the real tool executors + model-boundary sanitizer by `backend/tests/unit/services/chatRedteamInjection.test.ts`, asserting household-scope, PII-redaction, and write-gate invariants hold under injection; dated report in `docs/audits/red-team-2026-07-17.md`. What is **still not built** (this waiver bullet remains in force for these): live-model refusal/no-fabrication scoring against real Bedrock output, a Promptfoo OWASP LLM01–10 config against the mock chat path, and a Garak baseline. The offline exercise proves the _data layer_ can't be made to leak PII or cross household boundaries; it does not and cannot prove the _model's_ response behavior, which needs the ⛔USER-triggered live eval job.
 > - **§3 judge calibration.** N/A — no LLM-as-judge is in use (no automated grading of chat output by a second model).
 > - **§6 governance:** `docs/audits/ai-risk-register.md` and `docs/audits/eu-ai-act-classification.md` **are** committed as of this pass (see below). `docs/audits/iso42001-soa.md` and a feature-level `docs/audits/ai-impact-assessment-chat.md` are **not** — tracked as follow-on gaps, same expiry.
@@ -117,4 +119,6 @@ See `evals/eval-baseline.json` and `evals/README.md` for the full method and hon
 
 ---
 
-Last verified: 2026-07-13 · Recheck cadence: quarterly, and immediately on any Bedrock model swap, system-prompt rewrite, or new tool added to the chat tool registry.
+Last verified: 2026-08-09 · Recheck cadence: quarterly, and immediately on any
+Bedrock model swap, system-prompt rewrite, grounding-guard change, or new tool
+added to the chat tool registry.

--- a/docs/adr/0008-unit-aware-rag-grounding.md
+++ b/docs/adr/0008-unit-aware-rag-grounding.md
@@ -1,0 +1,53 @@
+# 0008 — Unit-aware quantitative grounding for RAG answers
+
+**Status:** Accepted
+
+**Date:** 2026-08-09
+
+**Deciders:** Chelsea Kelly-Reif
+
+## Context
+
+The chat grounding guard originally recognized frequencies, percentages,
+temperatures, durations, and lengths, then checked whether each recognized
+number appeared somewhere in the retrieved care corpus. That left the guard
+blind to dosing and dilution claims such as `1 tsp per gallon`, fertilizer
+ratios such as `10-10-10`, and repetitions such as `3-4 times the pot's
+volume`. It also meant a dose could borrow an unrelated occurrence of the same
+number from another sentence. A successful check with zero recognized claims
+produced no telemetry, so operators could not distinguish a substantive pass
+from a vacuous one.
+
+This is a hard AI guardrail: unsupported recognized quantitative claims are
+replaced before persistence or delivery, including on the buffered streaming
+path. Changing its scope therefore requires an explicit decision record.
+
+## Decision
+
+- Recognize care-relevant volume, mass, dose, dilution, `times`/`parts`, colon
+  ratios, slash-form dose denominators, and three-part NPK ratios in addition
+  to the existing quantitative forms.
+- Match safety-sensitive evidence as canonical number-and-unit tokens. For
+  doses written with `per` or `/`, include the denominator amount and unit so
+  `1 tsp per gallon` cannot support `1 tsp per cup`.
+- Continue to fail closed: if any recognized quantitative token lacks matching
+  retrieved evidence, replace the completed answer with the existing safe
+  verification message before it is stored or shown.
+- Emit `chat_grounding_checked` for successful RAG checks with only
+  `claimsChecked` and `sourceCount`. A zero-claim pass is allowed but is now
+  explicitly observable. Claim text and source text remain excluded from logs.
+- Keep the guard's scope precise: it is a deterministic quantitative heuristic
+  for RAG answers, not a semantic factuality or qualitative-entailment check.
+
+## Consequences
+
+- Fabricated dosing, dilution, repetition, and fertilizer-ratio claims are no
+  longer silently treated as having no claims to check.
+- Unit-aware matching may block some valid paraphrases that use an unsupported
+  alias. The safe replacement is preferable to delivering an unsupported dose;
+  aliases must be added with positive and negative regression tests.
+- Operators can measure how often the guard performs a substantive check versus
+  a zero-claim pass without logging user or corpus content.
+- Qualitative claims and unrecognized quantitative phrasing remain outside this
+  mechanical control. Live faithfulness, hallucination, and refusal scoring
+  remain covered by the dated AI-evaluation waiver.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -23,5 +23,6 @@ One file per decision: `NNNN-short-title.md`, numbered sequentially. Each has: *
 | [0005](0005-npm-workspaces-monorepo.md)              | npm-workspaces monorepo layout             | Accepted |
 | [0006](0006-standards-applicability-declarations.md) | Standards applicability declarations       | Accepted |
 | [0007](0007-i18n-json-catalogs-native-format.md)     | i18n: JSON catalogs, i18next-native format | Accepted |
+| [0008](0008-unit-aware-rag-grounding.md)             | Unit-aware quantitative RAG grounding      | Accepted |
 
 > Several earlier decisions (Cognito for auth, React+Vite+TanStack Query, gated external integrations) are documented inline in `docs/architecture.md` / `docs/strategy-review.md` and could be backfilled as ADRs when next touched.

--- a/docs/api-spec.yaml
+++ b/docs/api-spec.yaml
@@ -904,9 +904,17 @@ paths:
   /billing/me:
     get:
       summary: Current household subscription state
+      description: >-
+        `usageDetail` reports nullable per-field counters. The legacy numeric-only `usage` object is
+        included only when both counters are known, preserving rolling-deploy and cached-client safety.
       tags: [Billing]
       responses:
-        '200': { $ref: '#/components/responses/Ok' }
+        '200':
+          description: Subscription, plan caps, and best-known household usage
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BillingSubscriptionState'
   /billing/checkout:
     post:
       summary: 'Start an idempotent Stripe checkout session (body: planId, optional interval month|year|lifetime, optional checkoutAttemptId UUID)'
@@ -1348,6 +1356,52 @@ components:
             $ref: '#/components/schemas/Error'
 
   schemas:
+    BillingUsage:
+      type: object
+      additionalProperties: false
+      description: >-
+        Legacy numeric-only usage. This object is omitted from /billing/me unless both counters are
+        known.
+      required: [plantCount, maxPlants, memberCount, maxMembers]
+      properties:
+        plantCount: { type: integer, minimum: 0 }
+        maxPlants: { type: integer, minimum: 0 }
+        memberCount: { type: integer, minimum: 0 }
+        maxMembers: { type: integer, minimum: 0 }
+
+    BillingUsageDetail:
+      type: object
+      additionalProperties: false
+      description: >-
+        Best-known usage. A null counter means its value is unavailable; it never means zero. Plan
+        caps remain known and non-null.
+      required: [plantCount, maxPlants, memberCount, maxMembers]
+      properties:
+        plantCount: { type: integer, minimum: 0, nullable: true }
+        maxPlants: { type: integer, minimum: 0 }
+        memberCount: { type: integer, minimum: 0, nullable: true }
+        maxMembers: { type: integer, minimum: 0 }
+
+    BillingSubscriptionState:
+      type: object
+      additionalProperties: false
+      required: [planId, usageDetail]
+      properties:
+        planId: { type: string, enum: [seedling, garden, greenhouse] }
+        stripeCustomerId: { type: string }
+        stripeSubscriptionId: { type: string }
+        status:
+          type: string
+          description: Current Stripe subscription or retained entitlement status, when present.
+        currentPeriodEnd: { type: string, format: date-time }
+        usage:
+          allOf:
+            - $ref: '#/components/schemas/BillingUsage'
+          description: >-
+            Compatibility field for numeric-only clients; omitted whenever either counter is unknown.
+        usageDetail:
+          $ref: '#/components/schemas/BillingUsageDetail'
+
     FrontendTelemetryEvent:
       oneOf:
         - type: object

--- a/docs/audits/ai-risk-register.md
+++ b/docs/audits/ai-risk-register.md
@@ -2,7 +2,7 @@
 
 Per `STANDARDS/RESPONSIBLE-TECH-FRAMEWORK.md` "Governance scaffolding for AI systems" (NIST AI RMF **MAP** function). Seeded from `docs/chat-rag-design.md`'s non-goals and open-risks sections plus the tool-guard threat notes already in the codebase — this is a consolidation of existing, real design decisions into the register format the standard requires, not new analysis invented for this document.
 
-**Owner:** Chelsea Kelly-Reif. **Reviewed:** 2026-07-13 (first version 2026-07-05; live guard/privacy/disclosure controls re-verified 2026-07-13). **Recheck cadence:** quarterly, and immediately on any new tool added to `TOOL_REGISTRY`, a system-prompt rewrite, or a model swap.
+**Owner:** Chelsea Kelly-Reif. **Reviewed:** 2026-08-09 (first version 2026-07-05; quantitative grounding scope and observability re-verified 2026-08-09). **Recheck cadence:** quarterly, and immediately on any new tool added to `TOOL_REGISTRY`, a system-prompt rewrite, a grounding-guard change, or a model swap.
 
 ---
 
@@ -38,7 +38,8 @@ Per `STANDARDS/RESPONSIBLE-TECH-FRAMEWORK.md` "Governance scaffolding for AI sys
 
 - Tool-use architecture: for anything about the user's _own_ plants, the model must call a tool rather than guess — the tool result, not the model's prior, is the source of truth.
 - System-prompt rule 5: "If a tool returns no data... say so plainly" (explicit instruction against the missing-data-as-false-answer pattern).
-- `groundingGuard.ts`: a numeric-claim grounding heuristic wired into both sync and streaming RAG turns. Every numeric token in a completed answer must occur in the retrieved spans; otherwise the answer is replaced before it is persisted or shown. Streaming RAG output is buffered until the same check passes.
+- `groundingGuard.ts`: a quantitative-claim grounding heuristic wired into both sync and streaming RAG turns. It recognizes care-relevant frequencies, percentages, temperatures, durations, lengths, volumes, masses, doses, dilution/repetition forms, and fertilizer ratios. Recognized evidence is matched by number and, for safety-sensitive doses, canonical units and denominators expressed with `per` or `/`; unsupported claims are replaced before persistence or display. Streaming RAG output is buffered until the same check passes.
+- Successful checks emit content-free `chat_grounding_checked` telemetry with `claimsChecked` and `sourceCount`. This makes a zero-claim pass observable without logging answer or source text; it does not turn that pass into evidence that every sentence was verified. See [ADR 0008](../adr/0008-unit-aware-rag-grounding.md).
 
 **Gap:** no live faithfulness/hallucination-rate measurement against real model output exists (`evals/README.md` limitation). **Tracked, dated waiver:** `docs/RESPONSIBLE-TECH-AUDITS.md`.
 
@@ -64,7 +65,11 @@ Per `STANDARDS/RESPONSIBLE-TECH-FRAMEWORK.md` "Governance scaffolding for AI sys
 
 **Mitigations:** fixed, server-defined tool catalog (the model can't invent new tools); hallucinated-plant-ID rejection (server re-validates by name, never trusts the model's raw ID); per-turn tool-call cap (5); the RAG corpus is first-party authored content (not user- or web-sourced), so classic "indirect injection via untrusted retrieved content" has a much smaller attack surface than a general web-RAG system.
 
-**Gap:** no structured red-team exercise (Promptfoo OWASP-LLM scan, Garak baseline) has ever been run — tracked, dated waiver in `docs/RESPONSIBLE-TECH-AUDITS.md`.
+**Residual gap:** the committed red-team exercise covers the offline tool/data
+layer with mapped prompt-injection fixtures, but no live-model
+refusal/no-fabrication run, Promptfoo OWASP-LLM scan, or Garak baseline exists.
+The remaining generation-layer work is tracked by the dated waiver in
+`docs/RESPONSIBLE-TECH-AUDITS.md`.
 
 ### Value-chain / component integration
 

--- a/docs/billing.md
+++ b/docs/billing.md
@@ -70,6 +70,47 @@ The "Upgrade to X" button on `BillingSettings` does:
 
 The portal flow ("Manage subscription") is the same shape — `POST /billing/portal` returns a Stripe Customer Portal URL, frontend redirects there. Cancel + payment-method updates happen in Stripe's UI.
 
+## Usage response contract
+
+`GET /billing/me` returns the household's subscription state and two usage
+representations during the compatibility window:
+
+| Field         | Presence                          | Counter types    | Client contract                                                                |
+| ------------- | --------------------------------- | ---------------- | ------------------------------------------------------------------------------ |
+| `usageDetail` | Always                            | `number \| null` | Source of truth for current clients; `null` means unavailable, never zero      |
+| `usage`       | Only when both counters are known | `number`         | Legacy shape for cached/older clients that do not understand nullable counters |
+
+Both objects carry `plantCount`, `maxPlants`, `memberCount`, and `maxMembers`.
+The plan caps are always known. A genuine zero remains `0`; a missing, invalid,
+or unreadable metadata counter becomes `null` in `usageDetail`. If either
+counter is unknown, the server omits `usage` entirely so a numeric-only client
+does not coerce unknown data into a zero-value meter.
+
+When both counters are known, the two representations are identical:
+
+```json
+{
+  "planId": "seedling",
+  "usage": { "plantCount": 4, "maxPlants": 10, "memberCount": 2, "maxMembers": 6 },
+  "usageDetail": { "plantCount": 4, "maxPlants": 10, "memberCount": 2, "maxMembers": 6 }
+}
+```
+
+Partial knowledge is preserved per field, while the legacy object is omitted:
+
+```json
+{
+  "planId": "seedling",
+  "usageDetail": { "plantCount": 10, "maxPlants": 10, "memberCount": null, "maxMembers": 6 }
+}
+```
+
+New clients prefer `usageDetail` and fall back to `usage` when talking to an
+older backend. They evaluate each known counter independently, so an unknown
+member count neither creates an over-limit warning nor hides a known plant
+overage. The machine-readable contract is in
+[`api-spec.yaml`](api-spec.yaml).
+
 ## Backend implementation
 
 `backend/src/services/billing.ts` is the single billing service. Key surfaces:
@@ -165,6 +206,14 @@ second activation path. Retained Stripe mechanics are covered with isolated
 unit mocks; do not point development UI at an external billing environment
 while the hold remains active.
 
+For `GET /billing/me`, the local server computes plant and member totals from
+its in-memory records. Those reads have no unseeded or unavailable state, so
+local responses include both `usage` and `usageDetail` with the same numeric
+values. This is an intentional parity limit, not a claim that production
+counters are always available. The nullable and partial-counter paths are
+covered by the household-usage service, billing-handler, and frontend billing
+tests instead of a synthetic local-server failure switch.
+
 ## Plan caps and downgrades
 
 If a household downgrades from Greenhouse → Seedling and they have 200 plants,
@@ -187,7 +236,9 @@ Invoice access goes through the Stripe Customer Portal. We don't ingest invoice 
 ## Testing
 
 - `tests/unit/services/billing.test.ts` — pure tests of `deltaForStripeEvent` for every event type, plus `getHouseholdSubscription` defaults
-- `tests/integration/local-server.test.ts` — `describe('billing')` and `describe('plan limits')` blocks exercise checkout, plan-flip, plant-cap-402 against the real handlers via supertest
+- `tests/unit/services/householdUsage.test.ts` and `tests/unit/handlers/billing.test.ts` — genuine-zero, partial/invalid counter, read-failure, and compatibility response shapes
+- `frontend/tests/unit/features/BillingSettings.test.tsx` — nullable meters, legacy fallback, and independent over-limit evaluation
+- `tests/integration/local-server.test.ts` — `describe('billing')` and `describe('plan limits')` blocks exercise checkout, local `usage`/`usageDetail` parity, plan-flip, and plant-cap-402 via supertest
 
 The webhook signature verification is _not_ unit-tested here because mocking `stripe.webhooks.constructEvent` would just be testing our mock. We rely on Stripe's official typings + the `deltaForStripeEvent` test coverage.
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -91,6 +91,23 @@ responses are operationally different from 5xx.
 
 Useful Logs Insights queries:
 
+To separate substantive RAG grounding passes from answers where the
+deterministic guard recognized no quantitative claim, query the chat Lambda log
+group:
+
+```text
+fields @timestamp, claimsChecked, sourceCount, conversationId
+| filter msg = "chat_grounding_checked"
+| stats count(*) as passes by claimsChecked
+| sort claimsChecked asc
+```
+
+The `claimsChecked = 0` row is an observability signal, not a failure by itself:
+qualitative answers may legitimately contain nothing this guard is designed to
+inspect. Investigate a sustained shift alongside request mix and manual review;
+the current offline evaluation suite cannot explain it, and answer or source
+text must never be added to this log.
+
 ```text
 fields @timestamp, routeKey, status, responseLatency, requestId
 | filter routeKey != "GET /health" and status >= 500

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "Family Greenhouse web app — React + TypeScript + Vite PWA for collaborative household plant care.",
   "license": "Elastic-2.0",
   "type": "module",

--- a/frontend/src/features/dashboard/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/DashboardPage.tsx
@@ -2,12 +2,16 @@ import { useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Link } from 'react-router';
 import { useTranslation } from 'react-i18next';
-import { CheckIcon } from '@heroicons/react/24/outline';
+import {
+  CheckIcon,
+  ExclamationTriangleIcon,
+  InformationCircleIcon,
+} from '@heroicons/react/24/outline';
 import { useAuthStore } from '@/store/authStore';
 import { taskService, SnoozeReason, TaskWithCoverage } from '@/services/taskService';
 import { plantService } from '@/services/plantService';
 import { climateService } from '@/services/climateService';
-import { householdService } from '@/services/householdService';
+import { householdService, type ActivityEvent } from '@/services/householdService';
 import { deriveClimateSignals, climateSkipSuggestion } from '@/features/tasks/climateSignals';
 import {
   ClaimControls,
@@ -44,8 +48,7 @@ import clsx from 'clsx';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { taskTypeLabels, taskTypeStyles } from '@/utils/taskTypeConfig';
 import { formatDueDate, isOverdue } from '@/utils/date';
-
-type ActivityFilter = 'all' | 'tasks' | 'plants' | 'people';
+import { filterActivity, type ActivityFilter } from './activityFeed';
 
 const filterLabels: Record<ActivityFilter, string> = {
   all: 'All',
@@ -53,25 +56,6 @@ const filterLabels: Record<ActivityFilter, string> = {
   plants: 'Plants',
   people: 'People',
 };
-
-function filterActivity(
-  events: import('@/services/householdService').ActivityEvent[],
-  filter: ActivityFilter
-) {
-  if (filter === 'all') return events;
-  return events.filter((e) => {
-    if (filter === 'tasks')
-      return (
-        e.type === 'task.completed' ||
-        e.type === 'task.snoozed' ||
-        e.type === 'task.claimed' ||
-        e.type === 'task.unclaimed'
-      );
-    if (filter === 'plants') return e.type.startsWith('plant.') || e.type === 'photo.uploaded';
-    if (filter === 'people') return e.type === 'member.joined' || e.type === 'member.left';
-    return true;
-  });
-}
 
 export function DashboardPage() {
   useDocumentTitle('Dashboard');
@@ -400,28 +384,29 @@ function Metric({ label, value, emphasis }: MetricProps) {
 }
 
 interface ActivityRowProps {
-  event: import('@/services/householdService').ActivityEvent;
+  event: ActivityEvent;
 }
 
 function ActivityRow({ event }: ActivityRowProps) {
-  const { type, actorName, occurredAt, payload } = event;
-  const icon = <CheckIcon className="h-4 w-4 text-primary-700" aria-hidden="true" />;
+  const { t } = useTranslation();
+  const { actorName, occurredAt } = event;
+  let icon = <CheckIcon className="h-4 w-4 text-primary-700" aria-hidden="true" />;
+  let iconTone = 'bg-primary-100 ring-primary-200/60';
   let body: React.ReactNode;
-  switch (type) {
+
+  switch (event.type) {
     case 'task.completed':
       body = (
         <>
           <span className="font-medium">{actorName}</span> completed{' '}
-          <span className="font-medium">
-            {(payload as { taskType?: string }).taskType ?? 'a task'}
-          </span>
+          <span className="font-medium">{event.payload.taskType ?? 'a task'}</span>
         </>
       );
       break;
     case 'task.snoozed': {
       // "snoozed water for Monstera (rain expected)" — the climate skip
       // reasons read as why the cycle was skipped.
-      const p = payload as { taskType?: string; plantName?: string; reason?: string | null };
+      const p = event.payload;
       const reasonLabel =
         p.reason === 'rain'
           ? 'rain expected'
@@ -442,11 +427,11 @@ function ActivityRow({ event }: ActivityRowProps) {
     }
     case 'task.claimed':
     case 'task.unclaimed': {
-      const p = payload as { taskType?: string; plantName?: string };
+      const p = event.payload;
       body = (
         <>
           <span className="font-medium">{actorName}</span>{' '}
-          {type === 'task.claimed' ? 'claimed' : 'released'}{' '}
+          {event.type === 'task.claimed' ? 'claimed' : 'released'}{' '}
           <span className="font-medium">{p.taskType ?? 'a task'}</span>
           {p.plantName && <> for {p.plantName}</>}
         </>
@@ -457,23 +442,80 @@ function ActivityRow({ event }: ActivityRowProps) {
       body = (
         <>
           <span className="font-medium">{actorName}</span> added{' '}
-          <span className="font-medium">
-            {(payload as { plantName?: string }).plantName ?? 'a plant'}
-          </span>
+          <span className="font-medium">{event.payload.plantName ?? 'a plant'}</span>
         </>
       );
       break;
+    case 'plants.imported': {
+      const p = event.payload;
+      const count =
+        typeof p.count === 'number' && Number.isInteger(p.count) && p.count > 0 ? p.count : null;
+      body =
+        count === null
+          ? t('activity.importedUnknown', { actor: actorName })
+          : t('activity.imported', { actor: actorName, count });
+      break;
+    }
+    case 'plant.propagated': {
+      const p = event.payload;
+      body = t('activity.propagated', {
+        actor: actorName,
+        plant: p.plantName ?? t('activity.aPlant'),
+        parent: p.parentPlantName ?? t('activity.anotherPlant'),
+      });
+      break;
+    }
+    case 'plant.shared_accepted': {
+      const p = event.payload;
+      body = t('activity.sharedAccepted', {
+        actor: actorName,
+        plant: p.plantName ?? t('activity.aPlant'),
+        household: p.fromHouseholdName ?? t('activity.anotherHousehold'),
+      });
+      break;
+    }
+    case 'plant.health_checked': {
+      const p = event.payload;
+      const overall =
+        p.overall === 'healthy' || p.overall === 'monitor' || p.overall === 'concern'
+          ? p.overall
+          : null;
+      const plant = p.plantName ?? t('activity.aPlant');
+      if (p.demo) {
+        icon = <InformationCircleIcon className="h-4 w-4 text-amber-700" aria-hidden="true" />;
+        iconTone = 'bg-amber-50 ring-amber-200';
+        body = t('activity.healthDemo', { actor: actorName, plant });
+      } else if (p.demo === false && overall) {
+        if (overall === 'monitor') {
+          icon = <InformationCircleIcon className="h-4 w-4 text-amber-700" aria-hidden="true" />;
+          iconTone = 'bg-amber-50 ring-amber-200';
+        } else if (overall === 'concern') {
+          icon = <ExclamationTriangleIcon className="h-4 w-4 text-red-700" aria-hidden="true" />;
+          iconTone = 'bg-red-50 ring-red-200';
+        }
+        body = t('activity.healthChecked', {
+          actor: actorName,
+          plant,
+          overall: t(`plants.leafHealth.overall.${overall}`),
+        });
+      } else {
+        icon = <InformationCircleIcon className="h-4 w-4 text-gray-600" aria-hidden="true" />;
+        iconTone = 'bg-gray-100 ring-gray-200';
+        body = t('activity.healthCheckedUnknown', { actor: actorName, plant });
+      }
+      break;
+    }
     case 'plant.archived':
     case 'plant.restored':
     case 'plant.died':
     case 'plant.gave_away': {
-      const p = payload as { plantName?: string };
+      const p = event.payload;
       const verb = {
         'plant.archived': 'archived',
         'plant.restored': 'restored',
         'plant.died': 'recorded the loss of',
         'plant.gave_away': 'recorded giving away',
-      }[type];
+      }[event.type];
       body = (
         <>
           <span className="font-medium">{actorName}</span> {verb}{' '}
@@ -510,12 +552,19 @@ function ActivityRow({ event }: ActivityRowProps) {
         </>
       );
       break;
-    default:
-      body = <span className="font-medium">{actorName}</span>;
+    default: {
+      const _exhaustive: never = event;
+      void _exhaustive;
+      body = t('activity.generic', { actor: actorName });
+      break;
+    }
   }
+
   return (
     <li className="flex items-center gap-4 px-6 py-3 text-sm">
-      <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-primary-100 ring-1 ring-primary-200/60">
+      <span
+        className={`inline-flex h-8 w-8 items-center justify-center rounded-full ring-1 ${iconTone}`}
+      >
         {icon}
       </span>
       <div className="flex-1">

--- a/frontend/src/features/dashboard/activityFeed.ts
+++ b/frontend/src/features/dashboard/activityFeed.ts
@@ -1,0 +1,34 @@
+import type { ActivityEvent, ActivityType } from '@/services/householdService';
+
+export type ActivityFilter = 'all' | 'tasks' | 'plants' | 'people';
+
+type ActivityCategory = Exclude<ActivityFilter, 'all'>;
+
+// Keep this map explicit instead of relying on discriminator prefixes. The
+// import event is intentionally named `plants.imported`, and a prefix check
+// silently dropped it from the Plants filter. `Record` also makes a new event
+// fail type-checking until its filter category is chosen deliberately.
+const ACTIVITY_CATEGORIES: Record<ActivityType, ActivityCategory> = {
+  'task.completed': 'tasks',
+  'task.snoozed': 'tasks',
+  'task.claimed': 'tasks',
+  'task.unclaimed': 'tasks',
+  'plant.created': 'plants',
+  'plants.imported': 'plants',
+  'plant.deleted': 'plants',
+  'plant.died': 'plants',
+  'plant.gave_away': 'plants',
+  'plant.archived': 'plants',
+  'plant.restored': 'plants',
+  'plant.propagated': 'plants',
+  'plant.shared_accepted': 'plants',
+  'plant.health_checked': 'plants',
+  'photo.uploaded': 'plants',
+  'member.joined': 'people',
+  'member.left': 'people',
+};
+
+export function filterActivity(events: ActivityEvent[], filter: ActivityFilter): ActivityEvent[] {
+  if (filter === 'all') return events;
+  return events.filter((event) => ACTIVITY_CATEGORIES[event.type] === filter);
+}

--- a/frontend/src/features/settings/BillingSettings.tsx
+++ b/frontend/src/features/settings/BillingSettings.tsx
@@ -1,7 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { SparklesIcon } from '@heroicons/react/24/outline';
-import { billingService, isOverPlanLimit, PlanUsage } from '@/services/billingService';
+import {
+  billingService,
+  isOverPlanLimit,
+  resolvePlanUsage,
+  type PlanUsageDetail,
+} from '@/services/billingService';
 import { useActiveHouseholdId } from '@/hooks/useActiveHouseholdId';
 import { Card, CardHeader } from '@/components/Card';
 import { Alert } from '@/components/Alert';
@@ -39,7 +44,7 @@ export function BillingSettings() {
   // Fail closed if an old or malformed API response omits the status field.
   const paymentsAvailable = plansQuery.data?.paymentsAvailable === true;
   const currentPlanId = subQuery.data?.planId ?? 'seedling';
-  const usage = subQuery.data?.usage;
+  const usage = resolvePlanUsage(subQuery.data);
   // Genuinely over the plan caps — only possible after a downgrade. Reads,
   // edits, and deletes all keep working; only adding is blocked server-side.
   const overLimit = isOverPlanLimit(usage);
@@ -90,44 +95,69 @@ export function BillingSettings() {
 /**
  * Ambient "n of max" meters for the household's plan caps. Bars turn red when
  * over the cap (post-downgrade) — purely informational, the server enforces.
+ * Unknown counters get explicit text and no bar, so unavailable data cannot
+ * look like a genuine zero.
  */
-function UsageMeters({ usage }: { usage: PlanUsage }) {
+function UsageMeters({ usage }: { usage: PlanUsageDetail }) {
   const { t } = useTranslation();
   const meters = [
     {
-      label: t('settings.billing.plantsUsage', { n: usage.plantCount, max: usage.maxPlants }),
+      key: 'plants',
+      label:
+        usage.plantCount === null
+          ? t('settings.billing.plantsUsageUnavailable', { max: usage.maxPlants })
+          : t('settings.billing.plantsUsage', {
+              n: usage.plantCount,
+              max: usage.maxPlants,
+            }),
       count: usage.plantCount,
       max: usage.maxPlants,
     },
     {
-      label: t('settings.billing.membersUsage', { n: usage.memberCount, max: usage.maxMembers }),
+      key: 'members',
+      label:
+        usage.memberCount === null
+          ? t('settings.billing.membersUsageUnavailable', { max: usage.maxMembers })
+          : t('settings.billing.membersUsage', {
+              n: usage.memberCount,
+              max: usage.maxMembers,
+            }),
       count: usage.memberCount,
       max: usage.maxMembers,
     },
   ];
   return (
-    <div className="mt-4 space-y-3" data-testid="usage-meters">
-      <p className="text-sm font-medium text-gray-700">{t('settings.billing.usageTitle')}</p>
-      {meters.map((m) => {
-        const over = m.count > m.max;
-        const pct = m.max > 0 ? Math.min(100, Math.round((m.count / m.max) * 100)) : 0;
-        return (
-          <div key={m.label}>
-            <p className={clsx('text-xs', over ? 'text-red-600 font-medium' : 'text-gray-600')}>
-              {m.label}
-            </p>
-            <div
-              className="mt-1 h-1.5 w-full max-w-xs rounded-full bg-primary-100/60"
-              role="presentation"
-            >
-              <div
-                className={clsx('h-1.5 rounded-full', over ? 'bg-red-500' : 'bg-primary-500')}
-                style={{ width: `${pct}%` }}
-              />
+    <div className="mt-4" data-testid="usage-meters">
+      <p id="billing-usage-title" className="text-sm font-medium text-gray-700">
+        {t('settings.billing.usageTitle')}
+      </p>
+      <div className="mt-3 space-y-3" role="list" aria-labelledby="billing-usage-title">
+        {meters.map((m) => {
+          const available = m.count !== null;
+          const over = m.count !== null && m.count > m.max;
+          const pct =
+            m.count !== null && m.max > 0 ? Math.min(100, Math.round((m.count / m.max) * 100)) : 0;
+          return (
+            <div key={m.key} role="listitem" data-testid={`usage-meter-${m.key}`}>
+              <p className={clsx('text-xs', over ? 'text-red-600 font-medium' : 'text-gray-600')}>
+                {m.label}
+              </p>
+              {available && (
+                <div
+                  className="mt-1 h-1.5 w-full max-w-xs rounded-full bg-primary-100/60"
+                  role="presentation"
+                  data-testid={`usage-meter-${m.key}-bar`}
+                >
+                  <div
+                    className={clsx('h-1.5 rounded-full', over ? 'bg-red-500' : 'bg-primary-500')}
+                    style={{ width: `${pct}%` }}
+                  />
+                </div>
+              )}
             </div>
-          </div>
-        );
-      })}
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -18,6 +18,20 @@
     "daysAgo_one": "{{count}} day ago",
     "daysAgo_other": "{{count}} days ago"
   },
+  "activity": {
+    "aPlant": "a plant",
+    "anotherPlant": "another plant",
+    "anotherHousehold": "another household",
+    "generic": "{{actor}} made an update",
+    "imported_one": "{{actor}} imported {{count}} plant",
+    "imported_other": "{{actor}} imported {{count}} plants",
+    "importedUnknown": "{{actor}} imported plants",
+    "propagated": "{{actor}} propagated {{plant}} from {{parent}}",
+    "sharedAccepted": "{{actor}} accepted {{plant}} from {{household}}",
+    "healthChecked": "{{actor}} ran a leaf-health check on {{plant}} — {{overall}}",
+    "healthCheckedUnknown": "{{actor}} ran a leaf-health check on {{plant}}",
+    "healthDemo": "{{actor}} viewed a demo leaf-health result for {{plant}} — no image analysis was performed"
+  },
   "spaces": {
     "all": "All spaces",
     "inside": "Inside",
@@ -520,7 +534,9 @@
     "billing": {
       "usageTitle": "Usage",
       "plantsUsage": "{{n}} of {{max}} plants",
+      "plantsUsageUnavailable": "— of {{max}} plants — usage unavailable",
       "membersUsage": "{{n}} of {{max}} members",
+      "membersUsageUnavailable": "— of {{max}} members — usage unavailable",
       "nativeUnavailable": "Plan changes aren't available in the app.",
       "overLimitTitle": "Over your plan limit",
       "overLimitBody": "Your household has more plants or members than your current plan includes. Everything you have keeps working — you can still view, edit, and remove — but adding new plants or members is paused until you are back under the limit."

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -19,6 +19,21 @@
     "daysAgo_other": "hace {{count}} días",
     "daysAgo_many": "{{count}} days ago"
   },
+  "activity": {
+    "aPlant": "una planta",
+    "anotherPlant": "otra planta",
+    "anotherHousehold": "otro hogar",
+    "generic": "{{actor}} realizó una actualización",
+    "imported_one": "{{actor}} importó {{count}} planta",
+    "imported_many": "{{actor}} importó {{count}} plantas",
+    "imported_other": "{{actor}} importó {{count}} plantas",
+    "importedUnknown": "{{actor}} importó plantas",
+    "propagated": "{{actor}} propagó {{plant}} a partir de {{parent}}",
+    "sharedAccepted": "{{actor}} aceptó {{plant}} de {{household}}",
+    "healthChecked": "{{actor}} revisó la salud de las hojas de {{plant}} — {{overall}}",
+    "healthCheckedUnknown": "{{actor}} revisó la salud de las hojas de {{plant}}",
+    "healthDemo": "{{actor}} vio un resultado de demostración de salud foliar para {{plant}} — no se realizó ningún análisis de imagen"
+  },
   "spaces": {
     "all": "Todos los espacios",
     "inside": "Interior",
@@ -533,7 +548,9 @@
     "billing": {
       "usageTitle": "Uso",
       "plantsUsage": "{{n}} de {{max}} plantas",
+      "plantsUsageUnavailable": "— de {{max}} plantas — uso no disponible",
       "membersUsage": "{{n}} de {{max}} miembros",
+      "membersUsageUnavailable": "— de {{max}} miembros — uso no disponible",
       "nativeUnavailable": "Los cambios de plan no están disponibles en la aplicación.",
       "overLimitTitle": "Por encima del límite de tu plan",
       "overLimitBody": "Tu hogar tiene más plantas o miembros de los que incluye tu plan actual. Todo lo que tienes sigue funcionando — puedes ver, editar y eliminar — pero añadir nuevas plantas o miembros queda en pausa hasta que vuelvas a estar dentro del límite."

--- a/frontend/src/services/billingService.ts
+++ b/frontend/src/services/billingService.ts
@@ -20,11 +20,19 @@ export interface PlanCatalog {
   plans: Plan[];
 }
 
-/** Current usage vs. the active plan's caps, from GET /billing/me. */
+/** Legacy numeric-only usage shape from GET /billing/me. */
 export interface PlanUsage {
   plantCount: number;
   maxPlants: number;
   memberCount: number;
+  maxMembers: number;
+}
+
+/** Nullable usage shape for counters that may be unseeded or unavailable. */
+export interface PlanUsageDetail {
+  plantCount: number | null;
+  maxPlants: number;
+  memberCount: number | null;
   maxMembers: number;
 }
 
@@ -34,8 +42,17 @@ export interface SubscriptionState {
   stripeSubscriptionId?: string;
   status?: string;
   currentPeriodEnd?: string;
-  /** Optional: older backends don't send it; treat absence as "unknown". */
+  /** Legacy shape: present only when both counters are known. */
   usage?: PlanUsage;
+  /** Additive nullable shape. Older backends do not send it. */
+  usageDetail?: PlanUsageDetail;
+}
+
+/** Prefer the nullable contract, with rolling-deploy fallback to legacy usage. */
+export function resolvePlanUsage(
+  subscription?: SubscriptionState | null
+): PlanUsageDetail | undefined {
+  return subscription?.usageDetail ?? subscription?.usage;
 }
 
 /**
@@ -43,9 +60,13 @@ export interface SubscriptionState {
  * allows — only possible after a downgrade (or an admin-side plan change).
  * Existing data stays readable/editable; only adding is blocked server-side.
  */
-export function isOverPlanLimit(usage?: PlanUsage | null): boolean {
+export function isOverPlanLimit(usage?: PlanUsageDetail | null): boolean {
   if (!usage) return false;
-  return usage.plantCount > usage.maxPlants || usage.memberCount > usage.maxMembers;
+  // Evaluate each dimension independently: an unknown member count must not
+  // manufacture a warning, but it also must not hide a known plant overage.
+  const plantsOver = typeof usage.plantCount === 'number' && usage.plantCount > usage.maxPlants;
+  const membersOver = typeof usage.memberCount === 'number' && usage.memberCount > usage.maxMembers;
+  return plantsOver || membersOver;
 }
 
 export const billingService = {

--- a/frontend/src/services/householdService.ts
+++ b/frontend/src/services/householdService.ts
@@ -159,32 +159,116 @@ export interface DailyAnalytics {
   series: Array<{ date: string; count: number }>;
 }
 
+export interface TaskCompletedActivityPayload {
+  taskId: string;
+  plantId: string;
+  plantName?: string;
+  taskType: string;
+  notes?: string | null;
+  viaSitter?: boolean;
+}
+
+export interface TaskSnoozedActivityPayload {
+  taskId: string;
+  plantId: string;
+  plantName: string;
+  taskType: string;
+  days: number;
+  reason: 'rain' | 'frost' | 'heat' | 'other' | null;
+  note: string | null;
+}
+
+export interface TaskAssignmentActivityPayload {
+  taskId: string;
+  plantId: string;
+  plantName: string;
+  taskType: string;
+}
+
+export interface PlantIdentityActivityPayload {
+  plantId: string;
+  plantName: string;
+}
+
+export interface PlantLifecycleActivityPayload extends PlantIdentityActivityPayload {
+  previousStatus?: 'active' | 'died' | 'gave_away' | 'archived';
+}
+
 /**
- * Unified activity envelope. The `type` discriminator drives which fields
- * are present in `payload`; the renderer pattern-matches on it.
+ * Payload contract keyed by the durable event discriminator. The API client
+ * and dashboard renderer both consume the discriminated union derived from
+ * this map, while their runtime fallbacks still tolerate older or newer rows.
  */
-export interface ActivityEvent {
+export interface ActivityPayloadByType {
+  'task.completed': TaskCompletedActivityPayload;
+  'task.snoozed': TaskSnoozedActivityPayload;
+  'task.claimed': TaskAssignmentActivityPayload;
+  'task.unclaimed': TaskAssignmentActivityPayload;
+  'plant.created': PlantIdentityActivityPayload;
+  'plants.imported': { count: number };
+  'plant.deleted': PlantIdentityActivityPayload;
+  'plant.died': PlantLifecycleActivityPayload;
+  'plant.gave_away': PlantLifecycleActivityPayload;
+  'plant.archived': PlantLifecycleActivityPayload;
+  'plant.restored': PlantLifecycleActivityPayload;
+  'plant.propagated': PlantIdentityActivityPayload & {
+    parentPlantId: string;
+    parentPlantName: string;
+  };
+  'plant.shared_accepted': PlantIdentityActivityPayload & { fromHouseholdName: string };
+  'plant.health_checked': PlantIdentityActivityPayload & {
+    overall: 'healthy' | 'monitor' | 'concern';
+    demo: boolean;
+  };
+  'photo.uploaded': { plantId: string; photoId: string };
+  'member.joined': { role: 'admin' | 'member' };
+  'member.left': { role?: 'admin' | 'member' };
+}
+
+export type ActivityType = keyof ActivityPayloadByType;
+
+/** Runtime vocabulary kept in mechanical parity with the backend list. */
+export const ACTIVITY_TYPES = [
+  'task.completed',
+  'task.snoozed',
+  'task.claimed',
+  'task.unclaimed',
+  'plant.created',
+  'plants.imported',
+  'plant.deleted',
+  'plant.died',
+  'plant.gave_away',
+  'plant.archived',
+  'plant.restored',
+  'plant.propagated',
+  'plant.shared_accepted',
+  'plant.health_checked',
+  'photo.uploaded',
+  'member.joined',
+  'member.left',
+] as const satisfies readonly ActivityType[];
+
+type AssertNever<T extends never> = T;
+export type ActivityTypeListIsComplete = AssertNever<
+  Exclude<ActivityType, (typeof ACTIVITY_TYPES)[number]>
+>;
+
+interface ActivityEventEnvelope {
   id: string;
-  type:
-    | 'task.completed'
-    | 'task.snoozed'
-    | 'task.claimed'
-    | 'task.unclaimed'
-    | 'plant.created'
-    | 'plant.deleted'
-    | 'plant.died'
-    | 'plant.gave_away'
-    | 'plant.archived'
-    | 'plant.restored'
-    | 'photo.uploaded'
-    | 'member.joined'
-    | 'member.left';
   householdId: string;
   actorId: string;
   actorName: string;
   occurredAt: string;
-  payload: Record<string, unknown>;
 }
+
+export type ActivityEventByType<T extends ActivityType> = ActivityEventEnvelope & {
+  type: T;
+  payload: ActivityPayloadByType[T];
+};
+
+export type ActivityEvent = {
+  [T in ActivityType]: ActivityEventByType<T>;
+}[ActivityType];
 
 export interface Membership {
   householdId: string;

--- a/frontend/tests/unit/features/BillingSettings.test.tsx
+++ b/frontend/tests/unit/features/BillingSettings.test.tsx
@@ -5,8 +5,10 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BillingSettings } from '@/features/settings/BillingSettings';
 import {
   isOverPlanLimit,
+  resolvePlanUsage,
   type Plan,
   type PlanUsage,
+  type PlanUsageDetail,
   type SubscriptionState,
 } from '@/services/billingService';
 import { useAuthStore } from '@/store/authStore';
@@ -54,7 +56,11 @@ const PLANS: Plan[] = [
   },
 ];
 
-function usage(over: Partial<PlanUsage> = {}): PlanUsage {
+function usage(over: Partial<PlanUsageDetail> = {}): PlanUsageDetail {
+  return { plantCount: 4, maxPlants: 10, memberCount: 1, maxMembers: 1, ...over };
+}
+
+function legacyUsage(over: Partial<PlanUsage> = {}): PlanUsage {
   return { plantCount: 4, maxPlants: 10, memberCount: 1, maxMembers: 1, ...over };
 }
 
@@ -105,6 +111,33 @@ describe('isOverPlanLimit (over-limit calc)', () => {
     expect(isOverPlanLimit(usage({ plantCount: 11 }))).toBe(true);
     expect(isOverPlanLimit(usage({ memberCount: 2 }))).toBe(true);
   });
+
+  it('does not treat unknown counts as zero but still warns for a known over-limit count', () => {
+    expect(isOverPlanLimit(usage({ plantCount: null, memberCount: null }))).toBe(false);
+    expect(isOverPlanLimit(usage({ plantCount: null, memberCount: 1 }))).toBe(false);
+    expect(isOverPlanLimit(usage({ plantCount: 11, memberCount: null }))).toBe(true);
+    expect(isOverPlanLimit(usage({ plantCount: null, memberCount: 2 }))).toBe(true);
+  });
+});
+
+describe('resolvePlanUsage (rolling-deploy compatibility)', () => {
+  it('prefers nullable usageDetail over the legacy numeric shape', () => {
+    const detail = usage({ plantCount: null, memberCount: 2 });
+    expect(
+      resolvePlanUsage({
+        planId: 'seedling',
+        usage: legacyUsage({ plantCount: 0, memberCount: 1 }),
+        usageDetail: detail,
+      })
+    ).toBe(detail);
+  });
+
+  it('falls back to legacy usage and tolerates responses with neither shape', () => {
+    const legacy = legacyUsage();
+    expect(resolvePlanUsage({ planId: 'seedling', usage: legacy })).toBe(legacy);
+    expect(resolvePlanUsage({ planId: 'seedling' })).toBeUndefined();
+    expect(resolvePlanUsage(undefined)).toBeUndefined();
+  });
 });
 
 describe('BillingSettings', () => {
@@ -113,7 +146,7 @@ describe('BillingSettings', () => {
   });
 
   it('shows ambient usage meters whenever usage data is present', async () => {
-    await renderBilling({ planId: 'seedling', usage: usage() });
+    await renderBilling({ planId: 'seedling', usage: legacyUsage() });
     expect(screen.getByTestId('usage-meters')).toBeInTheDocument();
     expect(screen.getByText('4 of 10 plants')).toBeInTheDocument();
     expect(screen.getByText('1 of 1 members')).toBeInTheDocument();
@@ -121,10 +154,47 @@ describe('BillingSettings', () => {
     expect(screen.queryByText('Over your plan limit')).not.toBeInTheDocument();
   });
 
+  it('renders a genuine zero as zero rather than unavailable', async () => {
+    await renderBilling({ planId: 'seedling', usage: legacyUsage({ plantCount: 0 }) });
+
+    expect(screen.getByText('0 of 10 plants')).toBeInTheDocument();
+    expect(screen.getByTestId('usage-meter-plants-bar')).toBeInTheDocument();
+    expect(screen.queryByText(/plants.*usage unavailable/i)).not.toBeInTheDocument();
+  });
+
   it('renders no meters (and no banner) when the backend omits usage', async () => {
     await renderBilling({ planId: 'seedling' });
     expect(screen.queryByTestId('usage-meters')).not.toBeInTheDocument();
     expect(screen.queryByText('Over your plan limit')).not.toBeInTheDocument();
+  });
+
+  it('renders explicit accessible unavailable states instead of zero-value meters', async () => {
+    await renderBilling({
+      planId: 'seedling',
+      usageDetail: { plantCount: null, maxPlants: 10, memberCount: null, maxMembers: 1 },
+    });
+
+    expect(screen.getByRole('list', { name: 'Usage' })).toBeInTheDocument();
+    expect(screen.getByText('— of 10 plants — usage unavailable')).toBeInTheDocument();
+    expect(screen.getByText('— of 1 members — usage unavailable')).toBeInTheDocument();
+    expect(screen.queryByTestId('usage-meter-plants-bar')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('usage-meter-members-bar')).not.toBeInTheDocument();
+    expect(screen.queryByText('0 of 10 plants')).not.toBeInTheDocument();
+    expect(screen.queryByText('Over your plan limit')).not.toBeInTheDocument();
+  });
+
+  it('keeps the warning when one counter is unknown but the known counter is over its cap', async () => {
+    await renderBilling({
+      planId: 'seedling',
+      // A stale/cached legacy value must not win over the detail supplied by
+      // the current backend.
+      usage: legacyUsage({ plantCount: 0, memberCount: 1 }),
+      usageDetail: { plantCount: 25, maxPlants: 10, memberCount: null, maxMembers: 1 },
+    });
+
+    expect(screen.getByText('Over your plan limit')).toBeInTheDocument();
+    expect(screen.getByText('25 of 10 plants')).toBeInTheDocument();
+    expect(screen.getByText('— of 1 members — usage unavailable')).toBeInTheDocument();
   });
 
   it('shows the over-limit banner after a downgrade leaves the household over its caps', async () => {
@@ -182,7 +252,7 @@ describe('BillingSettings', () => {
       await renderBilling({
         planId: 'garden',
         stripeCustomerId: 'cus_1',
-        usage: usage(),
+        usage: legacyUsage(),
       });
       // No checkout cards (Greenhouse is the non-current plan here), no
       // cadence toggle, no Stripe portal button.

--- a/frontend/tests/unit/features/DashboardActivity.test.tsx
+++ b/frontend/tests/unit/features/DashboardActivity.test.tsx
@@ -1,0 +1,278 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router';
+import { http, HttpResponse } from 'msw';
+import i18n from '@/i18n';
+import { DashboardPage } from '@/features/dashboard/DashboardPage';
+import { filterActivity } from '@/features/dashboard/activityFeed';
+import type {
+  ActivityEvent,
+  ActivityEventByType,
+  ActivityPayloadByType,
+  ActivityType,
+} from '@/services/householdService';
+import { useAuthStore } from '@/store/authStore';
+import { server } from '../../msw/server';
+
+const API = 'http://localhost:4000';
+
+function event<T extends ActivityType>(
+  type: T,
+  payload: ActivityPayloadByType[T],
+  id = type
+): ActivityEventByType<T> {
+  return {
+    id: `event-${id}`,
+    type,
+    householdId: 'hh-1',
+    actorId: 'user-1',
+    actorName: 'Chelsea',
+    occurredAt: '2026-08-06T12:00:00.000Z',
+    payload,
+  };
+}
+
+/** Simulates unvalidated network/history data that intentionally violates this build's contract. */
+function runtimeEvent(type: string, payload: Record<string, unknown>): ActivityEvent {
+  return {
+    id: `event-${type}`,
+    type,
+    householdId: 'hh-1',
+    actorId: 'user-1',
+    actorName: 'Chelsea',
+    occurredAt: '2026-08-06T12:00:00.000Z',
+    payload,
+  } as unknown as ActivityEvent;
+}
+
+function renderDashboardActivity(activity: ActivityEvent[]) {
+  server.use(
+    http.get(`${API}/tasks/upcoming`, () => HttpResponse.json([])),
+    http.get(`${API}/tasks`, () => HttpResponse.json([])),
+    http.get(`${API}/plants`, () => HttpResponse.json([])),
+    http.get(`${API}/spaces`, () => HttpResponse.json([])),
+    http.get(`${API}/households/hh-1`, () =>
+      HttpResponse.json({
+        id: 'hh-1',
+        name: 'Home',
+        createdAt: '',
+        createdBy: 'user-1',
+        members: [{ userId: 'user-1', name: 'Chelsea', role: 'admin', joinedAt: '' }],
+      })
+    ),
+    http.get(`${API}/households/hh-1/activity`, () => HttpResponse.json(activity)),
+    http.get(`${API}/households/hh-1/climate`, () => HttpResponse.json({ status: 'no_location' })),
+    http.get(`${API}/households/hh-1/year-in-review`, () =>
+      HttpResponse.json({
+        year: 2026,
+        totalCompletions: 0,
+        byMember: [],
+        byTaskType: [],
+        topPlants: [],
+      })
+    )
+  );
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/dashboard']}>
+        <DashboardPage />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+beforeEach(async () => {
+  await i18n.changeLanguage('en');
+  useAuthStore.setState({
+    user: {
+      id: 'user-1',
+      email: 'chelsea@example.com',
+      name: 'Chelsea',
+      householdId: 'hh-1',
+      householdRole: 'admin',
+    },
+    isAuthenticated: true,
+    isLoading: false,
+  } as never);
+});
+
+describe('dashboard activity rows', () => {
+  it('renders all four production event types with their event details', async () => {
+    renderDashboardActivity([
+      event('plants.imported', { count: 12 }),
+      event('plant.propagated', {
+        plantId: 'plant-baby',
+        plantName: 'Baby Monstera',
+        parentPlantId: 'plant-mother',
+        parentPlantName: 'Mother Monstera',
+      }),
+      event('plant.shared_accepted', {
+        plantId: 'plant-pothos',
+        plantName: 'Pothos',
+        fromHouseholdName: 'Kelly household',
+      }),
+      event('plant.health_checked', {
+        plantId: 'plant-fernie',
+        plantName: 'Fernie',
+        overall: 'monitor',
+        demo: false,
+      }),
+    ]);
+
+    expect(await screen.findByText('Chelsea imported 12 plants')).toBeInTheDocument();
+    expect(
+      screen.getByText('Chelsea propagated Baby Monstera from Mother Monstera')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Chelsea accepted Pothos from Kelly household')).toBeInTheDocument();
+    expect(
+      screen.getByText('Chelsea ran a leaf-health check on Fernie — Worth monitoring')
+    ).toBeInTheDocument();
+  });
+
+  it('labels a demo leaf-health result as canned instead of a real check', async () => {
+    renderDashboardActivity([
+      event('plant.health_checked', {
+        plantId: 'plant-fernie',
+        plantName: 'Fernie',
+        overall: 'monitor',
+        demo: true,
+      }),
+    ]);
+
+    expect(
+      await screen.findByText(
+        'Chelsea viewed a demo leaf-health result for Fernie — no image analysis was performed'
+      )
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/ran a leaf-health check/i)).not.toBeInTheDocument();
+  });
+
+  it('uses neutral copy when a legacy payload lacks a count or known health verdict', async () => {
+    renderDashboardActivity([
+      runtimeEvent('plants.imported', {}),
+      runtimeEvent('plant.health_checked', { plantName: 'Fernie', overall: 'unexpected' }),
+    ]);
+
+    expect(await screen.findByText('Chelsea imported plants')).toBeInTheDocument();
+    expect(screen.getByText('Chelsea ran a leaf-health check on Fernie')).toBeInTheDocument();
+    expect(screen.queryByText(/imported 0 plants/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/worth monitoring/i)).not.toBeInTheDocument();
+  });
+
+  it('does not present a legacy health verdict as confirmed when demo provenance is missing', async () => {
+    renderDashboardActivity([
+      runtimeEvent('plant.health_checked', { plantName: 'Fernie', overall: 'healthy' }),
+    ]);
+
+    expect(
+      await screen.findByText('Chelsea ran a leaf-health check on Fernie')
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/looking healthy/i)).not.toBeInTheDocument();
+  });
+
+  it('uses status-specific visual tones while keeping the verdict in text', async () => {
+    renderDashboardActivity([
+      event(
+        'plant.health_checked',
+        {
+          plantId: 'plant-healthy',
+          plantName: 'Fernie',
+          overall: 'healthy',
+          demo: false,
+        },
+        'healthy'
+      ),
+      event(
+        'plant.health_checked',
+        {
+          plantId: 'plant-monitor',
+          plantName: 'Ivy',
+          overall: 'monitor',
+          demo: false,
+        },
+        'monitor'
+      ),
+      event(
+        'plant.health_checked',
+        {
+          plantId: 'plant-concern',
+          plantName: 'Rose',
+          overall: 'concern',
+          demo: false,
+        },
+        'concern'
+      ),
+    ]);
+
+    const healthyRow = (
+      await screen.findByText('Chelsea ran a leaf-health check on Fernie — Looking healthy')
+    ).closest('li');
+    const monitorRow = screen
+      .getByText('Chelsea ran a leaf-health check on Ivy — Worth monitoring')
+      .closest('li');
+    const concernRow = screen
+      .getByText('Chelsea ran a leaf-health check on Rose — Needs attention')
+      .closest('li');
+
+    expect(healthyRow?.querySelector('svg')).toHaveClass('text-primary-700');
+    expect(healthyRow?.firstElementChild).toHaveClass('bg-primary-100');
+    expect(monitorRow?.querySelector('svg')).toHaveClass('text-amber-700');
+    expect(monitorRow?.firstElementChild).toHaveClass('bg-amber-50');
+    expect(concernRow?.querySelector('svg')).toHaveClass('text-red-700');
+    expect(concernRow?.firstElementChild).toHaveClass('bg-red-50');
+  });
+
+  it('keeps rendering when a newer backend sends an activity type this build does not know', async () => {
+    renderDashboardActivity([runtimeEvent('plant.future_event', {})]);
+
+    expect(await screen.findByText('Chelsea made an update')).toBeInTheDocument();
+  });
+});
+
+describe('dashboard activity filters', () => {
+  it('includes every plant event, including the plural plants.imported type', () => {
+    const plantEvents: ActivityEvent[] = [
+      event('plant.created', { plantId: 'p1', plantName: 'Plant 1' }),
+      event('plants.imported', { count: 2 }),
+      event('plant.deleted', { plantId: 'p2', plantName: 'Plant 2' }),
+      event('plant.died', { plantId: 'p3', plantName: 'Plant 3' }),
+      event('plant.gave_away', { plantId: 'p4', plantName: 'Plant 4' }),
+      event('plant.archived', { plantId: 'p5', plantName: 'Plant 5' }),
+      event('plant.restored', { plantId: 'p6', plantName: 'Plant 6' }),
+      event('plant.propagated', {
+        plantId: 'p7',
+        plantName: 'Plant 7',
+        parentPlantId: 'p6',
+        parentPlantName: 'Plant 6',
+      }),
+      event('plant.shared_accepted', {
+        plantId: 'p8',
+        plantName: 'Plant 8',
+        fromHouseholdName: 'Neighbors',
+      }),
+      event('plant.health_checked', {
+        plantId: 'p9',
+        plantName: 'Plant 9',
+        overall: 'healthy',
+        demo: false,
+      }),
+      event('photo.uploaded', { plantId: 'p10', photoId: 'photo-1' }),
+    ];
+    const plantTypes = plantEvents.map(({ type }) => type);
+    const events = [
+      ...plantEvents,
+      event('task.completed', {
+        taskId: 'task-1',
+        plantId: 'p1',
+        taskType: 'water',
+      }),
+      event('member.joined', { role: 'member' }),
+    ];
+
+    expect(filterActivity(events, 'plants').map(({ type }) => type)).toEqual(plantTypes);
+  });
+});

--- a/frontend/tests/unit/features/SharedCarePulse.test.tsx
+++ b/frontend/tests/unit/features/SharedCarePulse.test.tsx
@@ -23,7 +23,7 @@ function completion(actorId: string, occurredAt: string): ActivityEvent {
     actorId,
     actorName: actorId,
     occurredAt,
-    payload: {},
+    payload: { taskId: 'task-1', plantId: 'plant-1', taskType: 'water' },
   };
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "family-greenhouse",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "license": "Elastic-2.0",
   "private": true,
   "description": "A shared plant-care journal for the whole household — per-plant schedules, reminders that find the right person across browser/email/SMS, and a care log everyone can see. React + TypeScript on AWS Lambda + DynamoDB + Cognito.",


### PR DESCRIPTION
## Summary

- Make household activity exhaustive across backend producers and dashboard rendering, including truthful demo-health provenance.
- Make RAG grounding unit- and denominator-aware, with content-free pass telemetry and a decision record.
- Preserve real zero usage, represent unavailable household counters honestly, and keep legacy billing clients compatible.
- Cut the `0.23.1` patch release with API, i18n, audit, observability, and billing documentation updates.

## Why

The activity feed dropped several emitted events, numeric grounding claims could borrow a matching number from unrelated source text, and unavailable usage was rendered as a misleading zero.

## Validation

- `npm run verify` — 690 frontend tests and 1,457 backend tests; formatting, lint, types, coverage, i18n, observability, and production dependency audit
- `npm run build`
- `npm --workspace frontend run size`
- Chromium production-bundle smoke and responsive dashboard checks
